### PR TITLE
chore: add basic build, test, and release actions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,36 @@
+name: main
+
+concurrency:
+  group: main
+  cancel-in-progress: true
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  release-snapshot:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          cache: false
+          go-version: "1.21"
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v4
+        with:
+          distribution: goreleaser
+          version: v1.23.0
+          args: release --clean --snapshot
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_PROJECT_TOKEN: ${{ secrets.GH_PROJECT_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,33 @@
+name: release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release-tag:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          cache: false
+          go-version: "1.21"
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v4
+        with:
+          distribution: goreleaser
+          version: v1.23.0
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_PROJECT_TOKEN: ${{ secrets.GH_PROJECT_TOKEN }}
+          GORELEASER_CURRENT_TAG: ${{ github.ref_name }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,26 @@
+name: test
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+      - uses: actions/setup-go@v4
+        with:
+          cache: false
+          go-version: "1.21"
+      - name: Validate
+        run: make validate
+      - name: Build
+        run: make build
+      - name: Run Tests
+        run: make test

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,67 @@
+dist: releases
+snapshot:
+  name_template: '{{ trimprefix .Summary "v" }}'
+
+builds:
+  - id: default
+    binary: gptscript
+    env:
+      - CGO_ENABLED=0
+    goarch:
+      - amd64
+      - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
+    flags:
+      - -trimpath
+    ldflags:
+      - -s
+      - -w
+      - -X "github.com/gptscript-ai/gptscript/pkg/version.Tag=v{{ .Version }}"
+
+universal_binaries:
+  - id: mac
+    ids:
+      - default
+    replace: true
+
+archives:
+  - id: default
+    builds:
+      - default
+      - mac
+    name_template: '{{.Project}}-v{{ .Version }}-{{ if eq .Os "darwin" }}macOS-universal{{ else }}{{ .Os }}-{{ .Arch }}{{ .Arm }}{{ end }}'
+    format_overrides:
+      - goos: windows
+        format: zip
+
+checksum:
+  name_template: "checksums.txt"
+
+changelog:
+  use: github
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^Merge pull request"
+
+release:
+  github:
+    owner: gptscript-ai
+    name: gptscript
+  prerelease: auto
+
+brews:
+  - description: "GPTScript CLI"
+    install: |
+      bin.install "gptscript"
+    homepage: "https://github.com/gptscript-ai/gptscript"
+    skip_upload: false
+    folder: "Formula"
+    repository:
+      owner: gptscript-ai
+      name: homebrew-tap
+      token: "{{ .Env.GH_PROJECT_TOKEN }}"


### PR DESCRIPTION
Add basic github actions to build, test, and generate release artifacts
for `gptscript`. Includes goreleaser configuration to publish homebrew
Formulas to our [tap repository](https://github.com/gptscript-ai/homebrew-tap/).
