### PR TITLE
enhance: enable shell completions

### DIFF
--- a/pkg/cli/gptscript.go
+++ b/pkg/cli/gptscript.go
@@ -48,8 +48,23 @@ func New() *cobra.Command {
 }
 
 func (r *GPTScript) Customize(cmd *cobra.Command) {
-	cmd.Use = version.ProgramName + " [flags] PROGRAM_FILE [INPUT...]"
 	cmd.Flags().SetInterspersed(false)
+	cmd.Use = version.ProgramName + " [flags] PROGRAM_FILE [INPUT...]"
+	cmd.Version = version.Get().String()
+	cmd.CompletionOptions.HiddenDefaultCmd = true
+	cmd.TraverseChildren = true
+
+	// Enable shell completion for the gptscript command.
+	// Note: The gptscript command doesn't have any subcommands, but Cobra requires that at least one is defined before
+	// it will generate the completion command automatically. To work around this, define a hidden no-op subcommand.
+	cmd.AddCommand(&cobra.Command{Hidden: true})
+	cmd.SetHelpCommand(&cobra.Command{Hidden: true})
+
+	// Override arg completion to prevent the hidden subcommands from masking default completion for positional args.
+	// Note: This should be removed if the gptscript command supports subcommands in the future.
+	cmd.ValidArgsFunction = func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+		return nil, cobra.ShellCompDirectiveDefault
+	}
 }
 
 func (r *GPTScript) listTools(ctx context.Context) error {


### PR DESCRIPTION
Enable basic shell completions for `bash`, `zsh`, `fish`, and
`powershell` by exposing the `completion` command automatically
generated by Cobra. The command is hidden, so it doesn't show up
in the help text or completions.

```zsh
$ source <(gptscript completion zsh)
$ gptscript --[tab]
 -- completions --
--assemble            -- Assemble tool to a single artifact, saved to --output ($GPTSCRIPT_ASSEMBLE)
--cache               -- Disable caching ($GPTSCRIPT_CACHE)
--cache-dir           -- Directory to store cache (default: $XDG_CACHE_HOME/gptscript) ($GPTSCRIPT_CACHE_DIR)
--debug               -- Enable debug logging ($GPTSCRIPT_DEBUG)
--dump-state          -- Dump the internal execution state to a file ($GPTSCRIPT_DUMP_STATE)
--help                -- help for gptscript
--input               -- Read input from a file ("-" for stdin) ($GPTSCRIPT_INPUT)
--list-models         -- List the models available and exit ($GPTSCRIPT_LIST_MODELS)
--list-tools          -- List built-in tools and exit ($GPTSCRIPT_LIST_TOOLS)
--listen-address      -- Server listen address ($GPTSCRIPT_LISTEN_ADDRESS)
--openai-api-key      -- OpenAI API KEY ($OPENAI_API_KEY)
--openai-api-type     -- OpenAI API Type (valid: OPEN_AI, AZURE, AZURE_AD) ($OPENAI_API_TYPE)
--openai-api-version  -- OpenAI API Version (for Azure) ($OPENAI_API_VERSION)
--openai-base-url     -- OpenAI base URL ($OPENAI_BASE_URL)
--openai-org-id       -- OpenAI organization ID ($OPENAI_ORG_ID)
--output              -- Save output to a file, or - for stdout ($GPTSCRIPT_OUTPUT)
--quiet               -- No output logging ($GPTSCRIPT_QUIET)
--server              -- Start server ($GPTSCRIPT_SERVER)
--sub-tool            -- Use tool of this name, not the first tool in file ($GPTSCRIPT_SUB_TOOL)
--version             -- version for gptscript
```

This implementation produces file path completions for ALL positional and flag args.
Support for customizing completions for individual arguments will
require new features in `github.com/acorn-io/cmd` and should be
addressed in a followup.

