### PR TITLE
chore: go back to publishing only the latest version to brew

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -55,8 +55,7 @@ release:
   prerelease: auto
 
 brews:
-  - name: gptscript@{{ .Major }}.{{ .Minor }}.{{ .Patch }} 
-    description: "GPTScript CLI"
+  - description: "GPTScript CLI"
     install: |
       bin.install "gptscript"
     homepage: "https://github.com/gptscript-ai/gptscript"


### PR DESCRIPTION
This made the happy path brew install unwieldy.
