### PR TITLE
fix: ensure embedded ui fs is populated before ci builds

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ jobs:
         with:
           distribution: goreleaser
           version: v1.23.0
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_PROJECT_TOKEN: ${{ secrets.GH_PROJECT_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,6 +18,8 @@ jobs:
         with:
           cache: false
           go-version: "1.21"
+      - name: Build UI
+        run: make build-ui
       - name: Validate
         run: make validate
       - name: Build

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,6 +2,11 @@ dist: releases
 snapshot:
   name_template: '{{ trimprefix .Summary "v" }}'
 
+before:
+  hooks:
+    # Generate UI assets to embedded in binaries
+    - make build-ui
+
 builds:
   - id: default
     binary: gptscript


### PR DESCRIPTION
Tell goreleaser to build the UI before it builds the `gptscript`
binaries. This ensures that the go:embed FS used by `gptscript --serve` gets populated.

