### PR TITLE
fix: enable ui in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 FROM golang:1.22.0-alpine3.19 AS build
-RUN apk add -U --no-cache make git
-COPY / /src/gptscript
+RUN apk add -U --no-cache make git npm
+COPY . /src/gptscript
 WORKDIR /src/gptscript
-RUN make build
+
+RUN make all
 
 FROM alpine AS release
 COPY --from=build /src/gptscript/bin /usr/local/bin/


### PR DESCRIPTION
Update the Dockerfile so that the UI is built before the `gptscript` binary.
