### PR TITLE
Append sys.append builtin

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.22.0
 replace github.com/sashabaranov/go-openai => github.com/gptscript-ai/go-openai v0.0.0-20240206232711-45b6e096246a
 
 require (
+	github.com/BurntSushi/locker v0.0.0-20171006230638-a6e239ea1c69
 	github.com/acorn-io/broadcaster v0.0.0-20240105011354-bfadd4a7b45d
 	github.com/acorn-io/cmd v0.0.0-20240203032901-e9e631185ddb
 	github.com/adrg/xdg v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/BurntSushi/locker v0.0.0-20171006230638-a6e239ea1c69 h1:+tu3HOoMXB7RXEINRVIpxJCT+KdYiI7LAEAUrOw3dIU=
+github.com/BurntSushi/locker v0.0.0-20171006230638-a6e239ea1c69/go.mod h1:L1AbZdiDllfyYH5l5OkAaZtk7VkWe89bPJFmnDBNHxg=
 github.com/acorn-io/baaah v0.0.0-20240119160309-2a58ee757bbd h1:Zbau2J6sEPl1H4gqnEx4/TI55eZncQR5cjfPOcG2lxE=
 github.com/acorn-io/baaah v0.0.0-20240119160309-2a58ee757bbd/go.mod h1:13nTO3svO8zTD3j9E5c86tCtK5YrKsK5sxca4Lwkbc0=
 github.com/acorn-io/broadcaster v0.0.0-20240105011354-bfadd4a7b45d h1:hfpNQkJ4I2b8+DbMr8m97gG67ku0uPsMzUfskVu3cHU=

--- a/pkg/builtin/builtin.go
+++ b/pkg/builtin/builtin.go
@@ -270,8 +270,7 @@ func SysWrite(ctx context.Context, env []string, input string) (string, error) {
 	defer locker.Unlock(params.Filename)
 
 	data := []byte(params.Content)
-	msg := fmt.Sprintf("Wrote %d bytes to file %s", len(data), params.Filename)
-	log.Debugf(msg)
+	log.Debugf("Wrote %d bytes to file %s", len(data), params.Filename)
 
 	return "", os.WriteFile(params.Filename, data, 0644)
 }
@@ -301,10 +300,9 @@ func SysAppend(ctx context.Context, env []string, input string) (string, error) 
 		return "", err
 	}
 
-	msg := fmt.Sprintf("Appended %d bytes to file %s", n, params.Filename)
-	log.Debugf(msg)
+	log.Debugf("Appended %d bytes to file %s", n, params.Filename)
 
-	return "", err
+	return "", nil
 }
 
 func fixQueries(u string) (string, error) {


### PR DESCRIPTION
Add a new built-in tool called `sys.append` that appends content to a file instead of truncating it.

Resolves https://github.com/gptscript-ai/gptscript/issues/24

I think this could also be implemented in `sys.write` by adding an extra parameter to indicate that an append is desired. Interested to hear if folks think that's a better approach.