### PR TITLE
feat: refactor docs and add content around tools and authoring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,5 +39,8 @@ validate: tidy lint
 ci: build
 	./bin/gptscript ./scripts/ci.gpt
 
+gen-docs: build
+	./bin/gptscript ./scripts/gen-docs.gpt
+
 serve-docs:
-	(cd docs && npm start)
+	(cd docs && npm i && npm start)

--- a/README.md
+++ b/README.md
@@ -2,10 +2,13 @@
 
 ## Overview
 
-GPTScript is a new scripting language to automate your interaction with a Large Language Model (LLM), namely OpenAI. The ultimate goal is to create a fully natural language based programming experience. The syntax of GPTScript is largely natural language, making it very easy to learn and use.
+GPTScript is a new scripting language to automate your interaction with a Large Language Model (LLM), namely OpenAI. The ultimate goal is to create a natural language programming experience. The syntax of GPTScript is largely natural language, making it very easy to learn and use.
 Natural language prompts can be mixed with traditional scripts such as bash and python or even external HTTP service
-calls. With GPTScript you can do just about anything like [plan a vacation](./examples/travel-agent.gpt),
+calls. With GPTScript you can do just about anything, like [plan a vacation](./examples/travel-agent.gpt),
 [edit a file](./examples/add-go-mod-dep.gpt), [run some SQL](./examples/sqlite-download.gpt), or [build a mongodb/flask app](./examples/hacker-news-headlines.gpt).
+
+| :memo: | We are currently exploring options for interacting with local models using GPTScript. |
+|-|:-|
 
 ```yaml
 # example.gpt
@@ -59,8 +62,16 @@ Download and install the archive for your platform and architecture from the [re
 
 ### 2. Get an API key from [OpenAI](https://platform.openai.com/api-keys).
 
+#### macOS and Linux
+
 ```shell
 export OPENAI_API_KEY="your-api-key"
+```
+
+#### Windows
+
+```powershell
+$env:OPENAI = 'your-api-key'
 ```
 
 ### 3. Run Hello World
@@ -175,7 +186,7 @@ Description: Tool description
 # This tool can invoke tool1 or tool2 if needed
 Tools: tool1, tool2
 Args: arg1: The description of arg1
-      
+
 Tool instructions go here.
 ```
 #### Tool Parameters
@@ -228,7 +239,7 @@ description: A tool that echos the input
 args: input: The input
 
 #!/bin/bash
-        
+
 echo "${input}"
 ```
 
@@ -247,7 +258,7 @@ Join us on Discord: [![Discord](https://img.shields.io/discord/12045584209848648
 
 ## License
 
-Copyright (c) 2023 [Acorn Labs, Inc.](http://acorn.io)
+Copyright (c) 2024 [Acorn Labs, Inc.](http://acorn.io)
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/docs/docs/01-overview.md
+++ b/docs/docs/01-overview.md
@@ -1,0 +1,41 @@
+---
+title: Overview
+slug: /
+---
+
+GPTScript is a new scripting language to automate your interaction with a Large Language Model (LLM), namely OpenAI. The ultimate goal is to create a natural language programming experience. The syntax of GPTScript is largely natural language, making it very easy to learn and use. Natural language prompts can be mixed with traditional scripts such as bash and python or even external HTTP service calls. With GPTScript you can do just about anything, like [plan a vacation](https://github.com/gptscript-ai/gptscript/blob/main/examples/travel-agent.gpt), [edit a file](https://github.com/gptscript-ai/gptscript/blob/main/examples/add-go-mod-dep.gpt), [run some SQL](https://github.com/gptscript-ai/gptscript/blob/main/examples/sqlite-download.gpt), or [build a mongodb/flask app](https://github.com/gptscript-ai/gptscript/blob/main/examples/hacker-news-headlines.gpt).
+
+:::note
+We are currently exploring options for interacting with local models using GPTScript.
+:::
+
+```yaml
+# example.gpt
+
+Tools: sys.download, sys.exec, sys.remove
+
+Download https://www.sqlitetutorial.net/wp-content/uploads/2018/03/chinook.zip to a
+random file. Then expand the archive to a temporary location as there is a sqlite
+database in it.
+
+First inspect the schema of the database to understand the table structure.
+
+Form and run a SQL query to find the artist with the most number of albums and output
+the result of that.
+
+When done remove the database file and the downloaded content.
+```
+```
+$ gptscript ./example.gpt
+
+OUTPUT:
+
+The artist with the most number of albums in the database is Iron Maiden, with a total
+of 21 albums.
+```
+
+For more examples check out the [examples](https://github.com/gptscript-ai/gptscript/blob/main/examples) directory.
+
+## Community
+
+Join us on Discord: [![Discord](https://img.shields.io/discord/1204558420984864829?label=Discord)](https://discord.gg/9sSf4UyAMC)

--- a/docs/docs/02-getting-started.md
+++ b/docs/docs/02-getting-started.md
@@ -1,0 +1,61 @@
+# Getting Started
+
+### 1. Install the latest release
+
+#### Homebrew (macOS and Linux)
+
+```shell
+brew install gptscript-ai/tap/gptscript
+```
+
+#### Install Script (macOS and Linux):
+
+```shell
+curl https://get.gptscript.ai/install.sh | sh
+```
+
+#### WinGet (Windows)
+
+```shell
+winget install gptscript-ai.gptscript
+```
+
+#### Manually
+
+Download and install the archive for your platform and architecture from the [releases page](https://github.com/gptscript-ai/gptscript/releases).
+
+### 2. Get an API key from [OpenAI](https://platform.openai.com/api-keys).
+
+#### macOS and Linux
+
+```shell
+export OPENAI_API_KEY="your-api-key"
+```
+
+#### Windows
+
+```powershell
+$env:OPENAI = 'your-api-key'
+```
+
+### 3. Run Hello World
+
+```shell
+gptscript https://get.gptscript.ai/echo.gpt --input 'Hello, World!'
+
+OUTPUT:
+
+Hello, World!
+```
+The model used by default is `gpt-4-turbo-preview` and you must have access to that model in your OpenAI account.
+
+### 4. Extra Credit: Examples and Run Debugging UI
+
+Clone examples and run debugging UI
+```shell
+git clone https://github.com/gptscript-ai/gptscript
+cd gptscript/examples
+
+# Run the debugging UI
+gptscript --server
+```

--- a/docs/docs/100-tools/01-using.md
+++ b/docs/docs/100-tools/01-using.md
@@ -1,0 +1,53 @@
+# Using Tools
+In GPTScript, tools are used to extend the capabilities of a script. The idea behind them is that AI performs better when it has very specific instructions for a given task. Tools are a way to break-up the problem into smaller and more focused pieces where each tool is responsible for a specific task. A typical flow like this is to have a main script that imports a set of tools it can use to accomplish its goal.
+
+GPTScripts can utilize tools in one of three ways:
+1. Built-in system tools
+2. In-script tools
+3. External tools
+
+### System Tools
+All GPTScripts have access to system tools, like `sys.read` and `sys.write`, that can be used without any additional configuration.
+
+```yaml
+tools: sys.read, sys.write
+
+Read all of the files in my current directory, do not recurse over any subdirectories, and give me a description of this directory's contents.
+```
+
+System tools are a set of core tools that come packaged with GPTScript by default.
+
+### In-Script Tools
+Things get more interesting when you start to use custom tools.
+
+The most basic example of this is an in-script tool that is defined in the same file as the main script. This is useful for breaking up a large script into smaller, more manageable pieces.
+
+```yaml
+tools: random-number
+
+Select a number at random and, based on the results, write a poem about it.
+
+---
+name: random-number
+description: Generate a random number between 1 and 100.
+
+Select a number at random between 1 and 100 and return only the number.
+```
+
+### External Tools
+
+This is where the real power of GPTScript starts to become evident. For this example lets use the external [image-generation](https://github.com/gptscript-ai/image-generation) and [search](https://github.com/gptscript-ai/search) tools to generate an image and then search the web for similar images.
+
+:::note
+There will be better packaging and distribution for external tools in the future. For now, this assumes you have the tools cloned locally and are pointing to their repos directly.
+:::
+
+```yaml
+tools: ./image-generation/tool.gpt, ./vision/tool.gpt, sys.read
+
+Generate an image of a city skyline at night and write the resulting image to a file called city_skyline.png.
+
+Take this image and write a description of it in the style of pirate.
+```
+
+External tools are tools that are defined by a `tool.gpt` file in their root directory. They can be imported into a GPTScript by specifying the path to the tool's root directory.

--- a/docs/docs/100-tools/02-authoring.md
+++ b/docs/docs/100-tools/02-authoring.md
@@ -1,0 +1,112 @@
+# Authoring Tools
+
+You can author your own tools for your use or to share with others. The process for authoring a tool is as simple as creating a `tool.gpt` file in the root directory of your project. This file is itself a GPTScript that defines the tool's name, description, and what it should do.
+
+Here's an example of the `tool.gpt` file for the `image-generation` tool:
+
+```yaml
+description: I am a tool that can generate images based on arguments that are sent to me. I return a list of URLs to the generated images.
+args: prompt: (required) The text prompt based on which the GPT model will generate a response
+args: model: (optional) The model to use for image generation. Defaults to "dall-e-3".
+args: size: (optional) The size of the image to generate, format WxH (e.g. 1024x1024). Defaults to 1024x1024.
+args: quality: (optional) The quality of the generated image. Allowed values are "standard" or "hd". Default is "standard".
+args: number: (optional) The number of images to generate. Defaults to 1.
+
+#!/usr/bin/env python3 ./cli.py --prompt="${prompt}" --model="${model}" --size="${size}" --quality="${quality}" --number="${number}"
+```
+
+At the bottom you'll notice a shebang line that specifies the command to run when the tool is invoked. This is the exact command that will be executed when the tool is used in a GPTScript. Doing this with tools allows for a high degree of reliability that the tool would not otherwise have.
+
+:::tip
+Every arg becomes an environment variable when the tool is invoked.
+:::
+
+## Binary Tools
+GPTScript can call binaries and scripts located on your system or externally. This is done by defining a `tool.gpt` file in the same directory that the binary or script is located. In that `tool.gpt` file, you call it directly using the `#!` directive.
+
+For example:
+
+```yaml
+description: This is a tool that calls a binary.
+args: arg1: The first argument.
+
+#!/usr/bin/env ./path/to/binary --arg1="${arg1}"
+```
+
+## Shell
+You can call shell scripts directly using the `#!` directive. For example:
+
+```yaml
+description: This is a tool that calls a shell script.
+args: arg1: The first argument.
+
+#!/usr/bin/env sh
+echo "Hello, world!"
+./path/to/script.sh --arg1="${arg1}"
+```
+
+## Python
+You can call Python scripts directly, for example:
+
+```yaml
+description: This is a tool that calls a Python script.
+args: arg1: The first argument.
+
+#!/usr/bin/env python3 ./path/to/script.py --arg1="${arg1}"
+```
+
+If you need to bootstrap a Python environment, you can use a virtual environment. For example:
+
+```yaml
+description: This is a tool that calls a Python script in a virtual environment.
+args: arg1: The first argument.
+
+#!/usr/bin/env sh
+python3 -m venv .venv
+pip3 install -r requirements.txt
+python3 ./path/to/script.py --arg1="${arg1}"
+```
+
+## Node
+
+You can call Node.js scripts directly, for example:
+
+```yaml
+description: This is a tool that calls a Node.js script.
+args: arg1: The first argument.
+
+#!/usr/bin/env node ./path/to/script.js --arg1="${arg1}"
+```
+
+If you need to bootstrap a Node.js environment, you can use call npm in the `tool.gpt` file. For example:
+
+```yaml
+description: This is a tool that calls a Node.js script with a package manager.
+args: arg1: The first argument.
+
+#!/usr/bin/env sh
+npm install
+node ./path/to/script.js --arg1="${arg1}"
+```
+
+## Golang
+
+You can call Golang binaries directly, for example:
+
+```yaml
+description: This is a tool that calls a Golang binary.
+args: arg1: The first argument.
+
+#!/usr/bin/env ./path/to/binary --arg1="${arg1}"
+```
+
+If you need to bootstrap a Golang binary, you can the go CLI to build it before running it. For example:
+
+```yaml
+description: This is a tool that calls a Golang binary.
+args: arg1: The first argument.
+
+#!/usr/bin/env sh
+go build -o ./path/to/binary
+./path/to/binary --arg1="${arg1}"
+```

--- a/docs/docs/100-tools/03-offerings/01-image-generation.md
+++ b/docs/docs/100-tools/03-offerings/01-image-generation.md
@@ -1,23 +1,34 @@
 # Image Generation
 
-## Overview
-
 The `image-generation` tool leverages OpenAI's DALL-E model to convert textual descriptions into images. It offers a versatile approach to creating visual content, making it suitable for a wide range of applications, from content creation to design assistance.
 
 For more information, check out the tool [here](https://github.com/gptscript-ai/image-generation)
+
+## Installation
+We are working on an process where installation of tools will be as simple as
+referencing the tool's link in your GPTScript. For now, you can follow the steps below to install the image-generation tool.
+
+1. Clone the image-generation tool repository [from GitHub](https://github.com/gptscript-ai/image-generation).
+
+```shell
+git clone https://github.com/gptscript-ai/image-generation
+```
+
+2. Run `make bootstrap` to setup the python venv and install the required dependencies.
+
+```shell
+make bootstrap
+```
+
+3. Reference `<path-to-the-repo>/tool.gpt` in your GPTScript.
 
 ## Usage
 To use the Image Generation tool, you need to make sure that the OPENAI_API_KEY environment variable is set to your OpenAI API key. You can obtain an API key from the OpenAI platform if you don't already have one.
 
 With that setup, you can use it in any GPTScript like so:
 
-:::tip
-This script assumes you have the `image-generation` tool repo cloned locally and located at `./image-generation`. The ability to import tools from remote
-locations is coming soon.
-:::
-
 ```
-tools: ./image-generation, sys.write
+tools: ./image-generation/tool.gpt, sys.download, sys.write
 
 Generate an image of a city skyline at night with a resolution of 512x512 pixels.
 

--- a/docs/docs/100-tools/03-offerings/02-system.md
+++ b/docs/docs/100-tools/03-offerings/02-system.md
@@ -104,3 +104,12 @@ Writes content to a specified file.
 
 - `content`: The content to be written to the file.
 - `filename`: The filename where the content should be written.
+
+## sys.append
+
+Appends the contents to a file.
+
+#### Arguments
+
+- `content`: The content to append.
+- `filename`: The name of the file to append to.

--- a/docs/docs/100-tools/03-offerings/_category_.json
+++ b/docs/docs/100-tools/03-offerings/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Offerings",
+  "collapsible": true,
+  "link": {
+    "type": "generated-index",
+    "title": "Offerings"
+  }
+}

--- a/docs/docs/100-tools/100-tools.md
+++ b/docs/docs/100-tools/100-tools.md
@@ -1,97 +1,7 @@
----
-title: Overview
-slug: /
----
+# Tools
 
-GPTScript is a new scripting language to automate your interaction with a Large Language Model (LLM), namely OpenAI. The ultimate goal is to create a fully natural language based programming experience. The syntax of GPTScript is largely natural language, making it very easy to learn and use.
-Natural language prompts can be mixed with traditional scripts such as bash and python or even external HTTP service
-calls. With GPTScript you can do just about anything like [plan a vacation](https://github.com/gptscript-ai/gptscript/blob/main/examples/travel-agent.gpt),
-[edit a file](https://github.com/gptscript-ai/gptscript/blob/main/examples/add-go-mod-dep.gpt), [run some SQL](https://github.com/gptscript-ai/gptscript/blob/main/examples/sqlite-download.gpt), or [build a mongodb/flask app](https://github.com/gptscript-ai/gptscript/blob/main/examples/hacker-news-headlines.gpt).
-
-```yaml
-# example.gpt
-
-Tools: sys.download, sys.exec, sys.remove
-
-Download https://www.sqlitetutorial.net/wp-content/uploads/2018/03/chinook.zip to a
-random file. Then expand the archive to a temporary location as there is a sqlite
-database in it.
-
-First inspect the schema of the database to understand the table structure.
-
-Form and run a SQL query to find the artist with the most number of albums and output
-the result of that.
-
-When done remove the database file and the downloaded content.
-```
-```
-$ gptscript ./example.gpt
-
-OUTPUT:
-
-The artist with the most number of albums in the database is Iron Maiden, with a total
-of 21 albums.
-```
-## Quick Start
-
-### 1. Install the latest release
-
-#### Homebrew (macOS and Linux)
-
-```shell
-brew install gptscript-ai/tap/gptscript
-```
-
-#### Install Script (macOS and Linux):
-
-```shell
-curl https://get.gptscript.ai/install.sh | sh
-```
-
-#### WinGet (Windows)
-
-```shell
-winget install gptscript-ai.gptscript
-```
-
-#### Manually
-
-Download and install the archive for your platform and architecture from the [releases page](https://github.com/gptscript-ai/gptscript/releases).
-
-### 2. Get an API key from [OpenAI](https://platform.openai.com/api-keys).
-
-```shell
-export OPENAI_API_KEY="your-api-key"
-```
-
-### 3. Run Hello World
-
-```shell
-gptscript https://get.gptscript.ai/echo.gpt --input 'Hello, World!'
-
-OUTPUT:
-
-Hello, World!
-```
-The model used by default is `gpt-4-turbo-preview` and you must have access to that model in your OpenAI account.
-
-### 4. Extra Credit: Examples and Run Debugging UI
-
-Clone examples and run debugging UI
-```shell
-git clone https://github.com/gptscript-ai/gptscript
-cd gptscript/examples
-
-# Run the debugging UI
-gptscript --server
-```
-
-## How it works
-
-***GPTScript is composed of tools.*** Each tool performs a series of actions similar to a function. Tools have available
-to them other tools that can be invoked similar to a function call. While similar to a function, the tools are
-primarily implemented with a natural language prompt. ***The interaction of the tools is determined by the AI model***,
-the model determines if the tool needs to be invoked and what arguments to pass. Tools are intended to be implemented
+***GPTScript is composed of tools.*** Each tool performs a series of actions similar to a function. Tools have available to them other tools that can be invoked similar to a function call. While similar to a function, the tools are
+primarily implemented with a natural language prompt. ***The interaction of the tools is determined by the AI model***, the model determines if the tool needs to be invoked and what arguments to pass. Tools are intended to be implemented
 with a natural language prompt but can also be implemented with a command or HTTP call.
 
 ### Example
@@ -110,14 +20,17 @@ args: question: The question to ask Bob.
 
 When asked how I am doing, respond with "Thanks for asking "${question}", I'm doing great fellow friendly AI tool!"
 ```
+
+
 Put the above content in a file named `bob.gpt` and run the following command:
-```shell
+```sh
 $ gptscript bob.gpt
 
 OUTPUT:
 
 Bob said, "Thanks for asking 'How are you doing?', I'm doing great fellow friendly AI tool!"
 ```
+
 Tools can be implemented by invoking a program instead of a natural language prompt. The below
 example is the same as the previous example but implements Bob using python.
 
@@ -141,10 +54,6 @@ print(f"Thanks for asking {os.environ['question']}, I'm doing great fellow frien
 With these basic building blocks you can create complex scripts with AI interacting with AI, your local system, data,
 or external services.
 
-## GPT File Reference
-
-### Extension
-GPTScript files use the `.gpt` extension by convention.
 
 ### File Structure
 A GPTScript file has one or more tools in the file. Each tool is separated by three dashes `---` alone on a line.
@@ -232,32 +141,3 @@ args: input: The input
 
 echo "${input}"
 ```
-
-## Built in Tools
-
-There are several built in tools to do basic things like read/write files, download http content and execute commands.
-Run `gptscript --list-tools` to list all the built-in tools.
-
-## Examples
-
-For more examples check out the [examples](https://github.com/gptscript-ai/gptscript/blob/main/examples) directory.
-
-## Community
-
-Join us on Discord: [![Discord](https://img.shields.io/discord/1204558420984864829?label=Discord)](https://discord.gg/9sSf4UyAMC)
-
-## License
-
-Copyright (c) 2023 [Acorn Labs, Inc.](http://acorn.io)
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-[http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.

--- a/docs/docs/100-tools/_category_.json
+++ b/docs/docs/100-tools/_category_.json
@@ -1,0 +1,3 @@
+{
+  "label": "Tools"
+}

--- a/docs/docs/101-cookbook/_category_.json
+++ b/docs/docs/101-cookbook/_category_.json
@@ -1,0 +1,11 @@
+{
+  "label": "Cookbook",
+  "collapsible": true,
+  "link": {
+    "type": "generated-index",
+    "title": "Cookbook"
+  },
+  "customProps": {
+    "description": "Explore the various things you can do with GPTScript and how to do them."
+  }
+}

--- a/docs/docs/101-cookbook/image-generator.md
+++ b/docs/docs/101-cookbook/image-generator.md
@@ -1,0 +1,48 @@
+# Image Generator
+
+In this example, let's say that we want to create an image generator tool that will take a prompt from the user and generate an image based on that prompt but
+in a specific style that we tell the tool to use.
+
+1. Clone the image-generation tool repository from Github.
+
+    ```shell
+    git clone https://github.com/gptscript-ai/image-generation
+    ```
+
+2. Bootstrap the tool.
+
+    ```shell
+    make bootstrap
+    ```
+
+3. Create a file called `painter.gpt`.
+
+    ```yaml
+    tools: ./image-generation/tool.gpt, sys.download, sys.write
+    args: prompt: (required) The prompt to use for generating the image.
+
+    Generate the ${prompt} in the style of a 17th century impressionist oil painting.
+
+    Write the resulting image to a file named "painting.png".
+    ```
+
+4. Run the script.
+
+    ```shell
+    gptscript painter.gpt --prompt "a city skyline at night"
+    ```
+
+This will generate an image of a city skyline at night in the style of a 17th century impressionist oil painting and write the resulting image to a file named `painting.png`.
+
+## Recap
+In this example, we have created a GPTScript that leverages the `image-generation` tool to generate an image based on a prompt. We gave it some flexibility by specifiying an argument `prompt` that the user can provide when running the script. We also specified gave the script a specific style of the image that we want to generate, that being a 17th century impressionist oil painter.
+
+Notable things to point out:
+#### Tools
+The `tools` directive was used here to reference the `image-generation` tool and the `sys.download` and `sys.write` system tools. GPTScript will know the tools availble to it and will use them when it sees fit in the script.
+
+#### Args
+We used the `args` directive to specify the `prompt` argument that the user can provide when running the script. This is a required argument and the user must provide it when running the script.
+
+#### Interpolation
+The `${prompt}` syntax can we used to reference the `prompt` argument in the script. This is a made-up syntax and can be replaced with any other syntax that you prefer. The LLM should be able to understand the syntax and use the argument in the script.

--- a/docs/docs/tools/_category_.json
+++ b/docs/docs/tools/_category_.json
@@ -1,8 +1,0 @@
-{
-  "label": "Tools",
-  "position": 2,
-  "link": {
-    "type": "generated-index",
-    "description": "Explore the various tools on offer for gptscripts"
-  }
-}

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -60,6 +60,11 @@ const config = {
             label: "GitHub",
             position: "right",
           },
+          {
+            href: "https://discord.gg/9sSf4UyAMC",
+            label: "Discord",
+            position: "right",
+          },
         ],
       },
       footer: {
@@ -68,6 +73,10 @@ const config = {
           {
             label: "GitHub",
             to: "https://github.com/gptscript-ai/gptscript",
+          },
+          {
+            label: "Discord",
+            to: "https://discord.gg/9sSf4UyAMC",
           },
         ],
         copyright: `Copyright © ${new Date().getFullYear()} Acorn Labs, Inc`,

--- a/docs/package.json
+++ b/docs/package.json
@@ -27,11 +27,7 @@
     "@docusaurus/types": "3.1.1"
   },
   "browserslist": {
-    "production": [
-      ">0.5%",
-      "not dead",
-      "not op_mini all"
-    ],
+    "production": [">0.5%", "not dead", "not op_mini all"],
     "development": [
       "last 3 chrome version",
       "last 3 firefox version",

--- a/scripts/gen-docs.gpt
+++ b/scripts/gen-docs.gpt
@@ -1,0 +1,14 @@
+tools: system-tools-state, sys.read, sys.write
+
+Do the following in order:
+1. Get the current state of system tools
+2. Update the ./docs/docs/100-tools/03-offerings/02-system.md file to
+   reflect the latest changes. The file should not change structure and
+   should add any new content at the end of the file in the same format.
+
+---
+name: system-tools-state
+tools: sys.exec
+description: Get the current state of system tools
+
+#!/usr/bin/env go run main.go --list-tools


### PR DESCRIPTION
First pass at some documentation around what tools are, how they work, and how you can make them. This also include some restructuring to make content flow more naturally.

To test this out, run `make serve-docs`.

At the time of creating this PR, the packaging format for external tools (as we want it to look) has not been implemented. This PR reflects the current state of things.