### PR TITLE
test: adding first pass at an integration suite for some of our basic examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,14 @@ build:
 tidy:
 	go mod tidy
 
-test:
+test: unit
+
+unit:
 	go test -v ./...
+
+int:
+	@docker build -t int -f integration/Dockerfile .
+	@docker run -e OPENAI_API_KEY=${OPENAI_API_KEY} int
 
 GOLANGCI_LINT_VERSION ?= v1.56.1
 lint:
@@ -39,8 +45,11 @@ validate: tidy lint
 ci: build
 	./bin/gptscript ./scripts/ci.gpt
 
-gen-docs: build
-	./bin/gptscript ./scripts/gen-docs.gpt
-
 serve-docs:
 	(cd docs && npm i && npm start)
+
+gen-docs: build
+	./bin/gptscript --cache=false ./scripts/gen-docs.gpt
+
+gen-test-cases:
+	./bin/gptscript --cache=false ./scripts/gen-test-cases.gpt

--- a/integration/Dockerfile
+++ b/integration/Dockerfile
@@ -1,0 +1,8 @@
+FROM golang:1.22
+
+WORKDIR /gptscript
+COPY . .
+
+RUN make build
+
+CMD ["./bin/gptscript", "--cache=false", "integration/integration.gpt"]

--- a/integration/integration.gpt
+++ b/integration/integration.gpt
@@ -1,0 +1,43 @@
+tools: gptscript, sys.read, sys.find, sys.abort
+description: Test the GPTScript tool against a series of example files and assert if the tool's output for given test cases meets the expected result.
+temperature: 0.5
+
+Objective: Test the GPTScript tool against a series of example files and assert if the tool's output for given test
+           cases meets the expected result.
+
+Test Files:
+- examples/bob.gpt
+- examples/bob-as-shell.gpt
+- examples/echo.gpt
+- examples/time.gpt
+- examples/helloworld.gpt
+
+Procedure:
+1. For each `.gpt` script file, locate its corresponding `.test.txt` file at the `integration/tests/*.test.txt` path.
+   The test file shares the same name as the script, minus the `.gpt` extension.
+2. Parse the test file to extract individual test cases. Each test case contains an input and an expected output.
+3. Sequentially execute the following steps for each test case:
+    1. Invoke the `gptscript` tool with the provided input from the test case.
+    2. Capture the actual output and compare it with the expected output from the test case.
+    3. Create a unique test case name derived from the input and expected output for easy identification.
+    4. Determine if the actual output is correct. Criteria for correctness include an exact match or an acceptable similarity
+       to the expected output, as well as any changes made to system state as described in the test case.
+       - If correct, output a success message: `PASSED: <test case name>`.
+       - If incorrect or an error occurs, output an error message: `FAILED: <test case name>: <error description or output difference>`.
+    5. Continue with the next test case regardless of the outcome of the current one.
+4. After completing all test cases for all files, compile and display a summary of the results. The summary should include:
+   - A bullet-point list of the files that were tested.
+   - The count of passed tests compared to the total number of tests.
+   - A listing and description of any failed tests (only if failures occurred).
+   - Analyze the results and determine if any ammendments need to be made to the test summary.
+5. Finally, if any tests failed, abort the script with a non-zero exit code. Otherwise, exit with a zero exit code.
+
+---
+name: gptscript
+description: Run a file
+arg: file: The file to be run
+arg: input: The input to be used
+
+#!/bin/bash
+
+go run main.go ${file} ${input}

--- a/integration/tests/bob-as-shell.test.txt
+++ b/integration/tests/bob-as-shell.test.txt
@@ -1,0 +1,4 @@
+# Test Cases for bob.gpt
+
+## Test Case 1: Standard Execution
+- Expected Output: Bob said, "Thanks for asking 'How are you doing?', I'm doing great fellow friendly AI tool!"

--- a/integration/tests/bob.test.txt
+++ b/integration/tests/bob.test.txt
@@ -1,0 +1,4 @@
+# Test Cases for bob.gpt
+
+## Test Case 1: Standard Execution
+- Expected Output: Bob said, "Thanks for asking 'How are you doing?', I'm doing great fellow friendly AI tool!"

--- a/integration/tests/echo.test.txt
+++ b/integration/tests/echo.test.txt
@@ -1,0 +1,13 @@
+# Test Cases for echo.gpt
+
+## Test Case 1: Simple String
+- Input: "Hello, World!"
+- Expected Output: "Hello, World!"
+
+## Test Case 2: Empty String
+- Input: ""
+- Expected Output: ""
+
+## Test Case 3: String with Special Characters
+- Input: "Hello, World! @$%^&*()"
+- Expected Output: "Hello, World! @$%^&*()"

--- a/integration/tests/helloworld.test.txt
+++ b/integration/tests/helloworld.test.txt
@@ -1,0 +1,4 @@
+# Test Cases for helloworld.gpt
+
+## Test Case 1: Standard Execution
+- Expected Output: "Hello, World!"

--- a/integration/tests/time.test.txt
+++ b/integration/tests/time.test.txt
@@ -1,0 +1,13 @@
+# Test Cases for time.gpt
+
+## Test Case 1: Timezone Available
+- Input: "America/New_York"
+- Expected Output: Current date and time in America/New_York timezone
+
+## Test Case 2: Invalid Timezone
+- Input: "Invalid/Timezone"
+- Expected Output: Error or notice indicating invalid timezone
+
+## Test Case 3: No Timezone Provided
+- Input: ""
+- Expected Output: Current date and time in default timezone

--- a/scripts/gen-test-cases.gpt
+++ b/scripts/gen-test-cases.gpt
@@ -1,0 +1,11 @@
+tools: sys.read, sys.find, sys.write
+
+For each of the examples .gpt files in the examples directory,
+please read them and determine logical test cases. Be sure to include
+input and expected output for each test case. Think about potential
+edge cases and how the program should handle them. Update their associated
+.test.txt files in the integration/tests directory with the tests cases
+you have determined.
+
+Do not remove the existing test cases and ensure they follow the same
+format as the existing tests.


### PR DESCRIPTION
This is a first pass at what an integration suite **could look like** for this repo entirely written in `gptscript`. I doubt this will be the final iteration of this but its more of a "this works kinda well" thing. I'm completely open to the idea of us tossing this if we don't like the approach.

That being said, I added three things here:
1. `make int` which runs the integration suite in a container
2. `make gen-test-cases` which generates test cases to run in the integration suite
3. A new `integration` directory which contains a:
    - Dockerfile for running safely locally
    - Collection of test case files
    - `integration.gpt` script