### PR TITLE
Ignore common node and python files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 /bin
 /.idea
 /static/ui
+**/node_modules/
+**/package-lock.json
+**/__pycache__


### PR DESCRIPTION
These are going to start showing up in the examples. If you run the
recipegenerator example, you would see these as changes.

Signed-off-by: Craig Jellick <craig@acorn.io>
