### PR TITLE
chore: add releases to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 **/package-lock.json
 **/__pycache__
 /docs/yarn.lock
+/releases
+/checksums.txt


### PR DESCRIPTION
Add the releases directory to the .gitignore to prevent runtime/debug
from detecting a modified source tree when built via goreleaser. Before
this change, binaries built from tagged releases would return incorrect
version info with a '-dirty' suffix.
