### PR TITLE
Check if response has a choice before debug logging to prevent null r…

### DIFF
--- a/pkg/openai/client.go
+++ b/pkg/openai/client.go
@@ -422,7 +422,9 @@ func (c *Client) call(ctx context.Context, request openai.ChatCompletionRequest,
 		} else if err != nil {
 			return nil, err
 		}
-		slog.Debug("stream", "content", response.Choices[0].Delta.Content)
+		if response.Choices != nil && len(response.Choices) > 0 {
+			slog.Debug("stream", "content", response.Choices[0].Delta.Content)
+		}
 		if partial != nil {
 			partialMessage = appendMessage(partialMessage, response)
 			partial <- types.CompletionStatus{

--- a/pkg/openai/client.go
+++ b/pkg/openai/client.go
@@ -422,7 +422,7 @@ func (c *Client) call(ctx context.Context, request openai.ChatCompletionRequest,
 		} else if err != nil {
 			return nil, err
 		}
-		if response.Choices != nil && len(response.Choices) > 0 {
+		if len(response.Choices) > 0 {
 			slog.Debug("stream", "content", response.Choices[0].Delta.Content)
 		}
 		if partial != nil {


### PR DESCRIPTION
The debug logging will cause an exception when the response contains no choice. Adding check logic before using response.Choices[0] can prevent errors.