### PR TITLE
Fix: use milliseconds to record state file

### DIFF
--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -245,6 +245,6 @@ func recordStateMessage(state *engine.State) error {
 		return err
 	}
 
-	filename := filepath.Join(tmpdir, fmt.Sprintf("gptscript-state-%v-%v", hostname, time.Now().Unix()))
+	filename := filepath.Join(tmpdir, fmt.Sprintf("gptscript-state-%v-%v", hostname, time.Now().UnixMilli()))
 	return os.WriteFile(filename, data, 0444)
 }


### PR DESCRIPTION
A previous attempt that uses time.Unix() as state file could cause conflicts, because there could be multiple calls happening at the same second when tools are invoked. Changing this to MilliSeconds should work.