### PR TITLE
Fix: Use subPath as root dir when invoking runtime

### DIFF
--- a/pkg/repos/get.go
+++ b/pkg/repos/get.go
@@ -78,7 +78,7 @@ func (m *Manager) setup(ctx context.Context, runtime Runtime, tool types.Tool, e
 		return "", nil, err
 	}
 
-	newEnv, err := runtime.Setup(ctx, m.runtimeDir, target, env)
+	newEnv, err := runtime.Setup(ctx, m.runtimeDir, targetFinal, env)
 	if err != nil {
 		return "", nil, err
 	}

--- a/pkg/repos/runtimes/golang/golang.go
+++ b/pkg/repos/runtimes/golang/golang.go
@@ -77,7 +77,7 @@ func stripGo(env []string) (result []string) {
 
 func (r *Runtime) runBuild(ctx context.Context, toolSource, binDir string, env []string) error {
 	log.Infof("Running go build in %s", toolSource)
-	cmd := debugcmd.New(ctx, filepath.Join(binDir, "go"), "build", "-o", "bin/gptscript-go-tool")
+	cmd := debugcmd.New(ctx, filepath.Join(binDir, "go"), "build", "-buildvcs=false", "-o", "bin/gptscript-go-tool")
 	cmd.Env = stripGo(env)
 	cmd.Dir = toolSource
 	return cmd.Run()


### PR DESCRIPTION
When reference a tool in a subDir, for example

```
tools: github.com/gptscript-ai/search/duckduckgo, sys.http.html2text?

summarize nba standings for last season. Search using DuckDuckGo. Feel free to get the contents
of the returned URLs in order to get more information. Provide as much detail as you can.
```

The runtime is being called at the root level, not the subPath. Normally the file(main.go) will live in the same directory as tool.gpt, so runtime will fail. It probably makes more sense to assume all the files are living in the same directory within the subDir that it is referencing to.

Also, in go runtime, building in subDir will fail because of missing git VCS info. Adding `-buildvcs=false` should fix that.