### PR TITLE
fix: create done file in the right place

### DIFF
--- a/pkg/repos/get.go
+++ b/pkg/repos/get.go
@@ -58,7 +58,7 @@ func (m *Manager) setup(ctx context.Context, runtime Runtime, tool types.Tool, e
 
 	target := filepath.Join(m.storageDir, tool.Source.Repo.Revision, runtime.ID())
 	targetFinal := filepath.Join(target, tool.Source.Repo.Path)
-	doneFile := target + ".done"
+	doneFile := targetFinal + ".done"
 	envData, err := os.ReadFile(doneFile)
 	if err == nil {
 		var savedEnv []string


### PR DESCRIPTION
This was causing a bug where the first time you run a tool that comes from a multi-tool repo (such as gptscript-ai/search), it would work, but if you ever try to run any other tools from the same repo, they would not work. This is because the "done file" was being created in the wrong location (at the root of the repo, instead of at the location of the tool itself). This fixes that.