### PR TITLE
Fix: just use parsed url.String() for http.get

### DIFF
--- a/pkg/loader/url.go
+++ b/pkg/loader/url.go
@@ -64,7 +64,6 @@ func loadURL(ctx context.Context, base *source, name string) (*source, bool, err
 	pathURL.Path = path.Dir(parsed.Path)
 	pathString := pathURL.String()
 	name = path.Base(parsed.Path)
-	url = pathString + "/" + name
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {


### PR DESCRIPTION
We are just joining url and path with `/` and that would cause extra `/` get appended.

We should just remove the url reassignment. 

Related error:
```
gptscript https://get.gptscript.ai/echo.gpt --input 'Hello, World!'
2024/03/14 16:49:21 error loading https://get.gptscript.ai//echo.gpt: 404 Not Found
```