### PR TITLE
feat: add more synonyms for json response

### DIFF
--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -113,6 +113,14 @@ func isParam(line string, tool *types.Tool) (_ bool, err error) {
 			return false, err
 		}
 		tool.Parameters.Cache = &b
+	case "jsonmode":
+		fallthrough
+	case "json":
+		fallthrough
+	case "jsonoutput":
+		fallthrough
+	case "jsonformat":
+		fallthrough
 	case "jsonresponse":
 		tool.Parameters.JSONResponse, err = toBool(value)
 		if err != nil {


### PR DESCRIPTION
I often forget what is the right parameter for json response so just
add more synonyms, json, json output, and json format.
