### PR TITLE
fix: detect built-in tools when loading from assemble output

### DIFF
--- a/pkg/loader/loader.go
+++ b/pkg/loader/loader.go
@@ -87,7 +87,12 @@ func loadProgram(data []byte, into *types.Program, targetToolName string) (types
 		return types.Tool{}, err
 	}
 
+	into.ToolSet = make(map[string]types.Tool, len(ext.ToolSet))
 	for k, v := range ext.ToolSet {
+		if builtinTool, ok := builtin.Builtin(k); ok {
+			v = builtinTool
+		}
+
 		for tk, tv := range v.ToolMapping {
 			v.ToolMapping[tk] = tv + id
 		}


### PR DESCRIPTION
Using the --assemble flag will output the contents that can be read again by gptscript to construct a tool without going through all the steps again. This doesn't detect built-in tools, and will, instead, try to run the built-in tools like they are commands.

This change will detect the built-in tools to ensure they are run correctly.