### PR TITLE
fix: opt in to `import.meta.*` properties

### DIFF
--- a/ui/stores/context.ts
+++ b/ui/stores/context.ts
@@ -11,7 +11,7 @@ export const useContext = defineStore('context', {
     baseUrl: () => {
       let base = ''
 
-      if ( process.server ) {
+      if ( import.meta.server ) {
         const headers = useRequestHeaders()
 
         base = `http://${ headers.host }`

--- a/ui/utils/string.ts
+++ b/ui/utils/string.ts
@@ -234,7 +234,7 @@ export function random32s(count: number): number[] {
   const out = []
   let i: number
 
-  if ( process.server || typeof window === 'undefined' ) {
+  if ( import.meta.server || typeof window === 'undefined' ) {
     for ( i = 0; i < count; i++ ) {
       out[i] = crypto.randomBytes(4).readUInt32BE(0)
     }


### PR DESCRIPTION
This is a very early PR to make this app compatible with [changes we expect to release in Nuxt v5](https://github.com/nuxt/nuxt/issues/25323).

In [Nuxt v3.7.0](https://github.com/nuxt/nuxt/releases/tag/v3.7.0) we added support for `import.meta.*` (see [original PR](https://github.com/nuxt/nuxt/pull/22428)) and we've been gradually updating docs and moving across from the old `process.*` patterned variables.

As I'm sure you're aware, these variables are replaced at build-time and enable tree-shaking in bundled code.
This change affects _runtime_ code (that is, that is processed by the Nuxt bundler, like vite or webpack) rather than code running in Node. So it really doesn't matter what the string is, but it makes more sense in an ESM-world to use `import.meta` rather than `process`.
