### PR TITLE
feat: Add gptscript --list-models [PROVIDER]

### DIFF
--- a/pkg/cli/gptscript.go
+++ b/pkg/cli/gptscript.go
@@ -146,7 +146,7 @@ func (r *GPTScript) Run(cmd *cobra.Command, args []string) error {
 	defer gptScript.Close()
 
 	if r.ListModels {
-		models, err := gptScript.ListModels(cmd.Context())
+		models, err := gptScript.ListModels(cmd.Context(), args...)
 		if err != nil {
 			return err
 		}

--- a/pkg/gptscript/gptscript.go
+++ b/pkg/gptscript/gptscript.go
@@ -103,6 +103,6 @@ func (g *GPTScript) GetModel() engine.Model {
 	return g.Registry
 }
 
-func (g *GPTScript) ListModels(ctx context.Context) ([]string, error) {
-	return g.Registry.ListModels(ctx)
+func (g *GPTScript) ListModels(ctx context.Context, providers ...string) ([]string, error) {
+	return g.Registry.ListModels(ctx, providers...)
 }

--- a/pkg/llm/registry.go
+++ b/pkg/llm/registry.go
@@ -11,7 +11,7 @@ import (
 
 type Client interface {
 	Call(ctx context.Context, messageRequest types.CompletionRequest, status chan<- types.CompletionStatus) (*types.CompletionMessage, error)
-	ListModels(ctx context.Context) (result []string, _ error)
+	ListModels(ctx context.Context, providers ...string) (result []string, _ error)
 	Supports(ctx context.Context, modelName string) (bool, error)
 }
 
@@ -28,9 +28,9 @@ func (r *Registry) AddClient(client Client) error {
 	return nil
 }
 
-func (r *Registry) ListModels(ctx context.Context) (result []string, _ error) {
+func (r *Registry) ListModels(ctx context.Context, providers ...string) (result []string, _ error) {
 	for _, v := range r.clients {
-		models, err := v.ListModels(ctx)
+		models, err := v.ListModels(ctx, providers...)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/openai/client.go
+++ b/pkg/openai/client.go
@@ -127,7 +127,12 @@ func (c *Client) Supports(ctx context.Context, modelName string) (bool, error) {
 	return slices.Contains(models, modelName), nil
 }
 
-func (c *Client) ListModels(ctx context.Context) (result []string, _ error) {
+func (c *Client) ListModels(ctx context.Context, providers ...string) (result []string, _ error) {
+	// Only serve if providers is empty or "" is in the list
+	if len(providers) != 0 && !slices.Contains(providers, "") {
+		return nil, nil
+	}
+
 	models, err := c.c.ListModels(ctx)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
You can now list models for a specific model provider by passing the
model provider name as an argument to --list-models
