### PR TITLE
fix: trim leading whitespace from arg descriptions

### DIFF
--- a/pkg/loader/loader_test.go
+++ b/pkg/loader/loader_test.go
@@ -77,7 +77,7 @@ func TestHelloWorld(t *testing.T) {
       "arguments": {
         "properties": {
           "input": {
-            "description": " Any string",
+            "description": "Any string",
             "type": "string"
           }
         },

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -60,7 +60,7 @@ func addArg(line string, tool *types.Tool) error {
 
 	tool.Parameters.Arguments.Properties[key] = &openapi3.SchemaRef{
 		Value: &openapi3.Schema{
-			Description: value,
+			Description: strings.TrimSpace(value),
 			Type:        "string",
 		},
 	}


### PR DESCRIPTION
Trim the optional leading whitespace from descriptions when parsing
arguments to prevent them from showing up in the chat completion function
definitions produced by gptscript.
