### PR TITLE
fix: openapi: description length and default bearer auth

### DIFF
--- a/pkg/engine/openapi.go
+++ b/pkg/engine/openapi.go
@@ -84,9 +84,11 @@ func (e *Engine) runOpenAPI(tool types.Tool, input string) (*Return, error) {
 	}
 
 	// Check for authentication (only if using HTTPS)
-	if u.Scheme == "https" && len(instructions.SecurityInfos) > 0 {
-		if err := handleAuths(req, envMap, instructions.SecurityInfos); err != nil {
-			return nil, fmt.Errorf("error setting up authentication: %w", err)
+	if u.Scheme == "https" {
+		if len(instructions.SecurityInfos) > 0 {
+			if err := handleAuths(req, envMap, instructions.SecurityInfos); err != nil {
+				return nil, fmt.Errorf("error setting up authentication: %w", err)
+			}
 		}
 
 		// If there is a bearer token set for the whole server, and no Authorization header has been defined, use it.

--- a/pkg/loader/openapi.go
+++ b/pkg/loader/openapi.go
@@ -84,6 +84,10 @@ func getOpenAPITools(t *openapi3.T, defaultHost string) ([]types.Tool, error) {
 				toolDesc = operation.Summary
 			}
 
+			if len(toolDesc) > 1024 {
+				toolDesc = toolDesc[:1024]
+			}
+
 			var (
 				// auths are represented as a list of maps, where each map contains the names of the required security schemes.
 				// Items within the same map are a logical AND. The maps themselves are a logical OR. For example:


### PR DESCRIPTION
Two small fixes that I would like to get in before the next release:
1. Cap the tool description at 1024 characters so that OpenAI doesn't get mad.
2. Check for the bearer token for the server even if no security schemes are defined.