### PR TITLE
docs: add Algolia search

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -91,6 +91,11 @@ const config = {
         darkTheme: prismThemes.dracula,
         additionalLanguages: ["cue", "docker"],
       },
+      algolia: {
+        apiKey: "e89df119e1db0b9e0c99ad397b8f4469",
+        appId: "CLLI98NP9G",
+        indexName: "gptscript",
+      },
     }),
 };
 


### PR DESCRIPTION
The API key included here is a public value that is supposed to be committed to the repo. It is not a secret.