### PR TITLE
fix: credentials: set server address on auth if it isn't set

### DIFF
--- a/pkg/credentials/store.go
+++ b/pkg/credentials/store.go
@@ -35,6 +35,10 @@ func (s *Store) Get(toolName string) (*Credential, bool, error) {
 		return nil, false, nil
 	}
 
+	if auth.ServerAddress == "" {
+		auth.ServerAddress = toolNameWithCtx(toolName, s.credCtx) // Not sure why we have to do this, but we do.
+	}
+
 	cred, err := credentialFromDockerAuthConfig(auth)
 	if err != nil {
 		return nil, false, err


### PR DESCRIPTION
for #237

For some reason, when you get the auth back from the file credsStore, it doesn't have the server address set on it. We already know the server address, since it is basically the "key" which we use to look it up. So now we just set it if it's unset.