### PR TITLE
fix: credentials: block output while running credential tools

### DIFF
--- a/pkg/builtin/builtin.go
+++ b/pkg/builtin/builtin.go
@@ -21,7 +21,6 @@ import (
 	"github.com/BurntSushi/locker"
 	"github.com/google/shlex"
 	"github.com/gptscript-ai/gptscript/pkg/confirm"
-	"github.com/gptscript-ai/gptscript/pkg/runner"
 	"github.com/gptscript-ai/gptscript/pkg/types"
 	"github.com/jaytaylor/html2text"
 )
@@ -647,15 +646,7 @@ func SysDownload(ctx context.Context, env []string, input string) (_ string, err
 	return params.Location, nil
 }
 
-func SysPrompt(ctx context.Context, _ []string, input string) (_ string, err error) {
-	monitor := ctx.Value(runner.MonitorKey{})
-	if monitor == nil {
-		return "", errors.New("no monitor in context")
-	}
-
-	unpause := monitor.(runner.Monitor).Pause()
-	defer unpause()
-
+func SysPrompt(_ context.Context, _ []string, input string) (_ string, err error) {
 	var params struct {
 		Message   string `json:"message,omitempty"`
 		Fields    string `json:"fields,omitempty"`

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -1,0 +1,19 @@
+package context
+
+import (
+	"context"
+)
+
+type pauseKey struct{}
+
+func AddPauseFuncToCtx(ctx context.Context, pauseF func() func()) context.Context {
+	return context.WithValue(ctx, pauseKey{}, pauseF)
+}
+
+func GetPauseFuncFromCtx(ctx context.Context) func() func() {
+	pauseF, ok := ctx.Value(pauseKey{}).(func() func())
+	if !ok {
+		return func() func() { return func() {} }
+	}
+	return pauseF
+}

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -137,7 +137,7 @@ func (c *Context) WrappedContext() context.Context {
 	return context.WithValue(c.Ctx, engineContext{}, c)
 }
 
-func (e *Engine) Start(ctx Context, input string) (*Return, error) {
+func (e *Engine) Start(ctx Context, input string, pauseF func() func()) (*Return, error) {
 	tool := ctx.Tool
 
 	if tool.IsCommand() {
@@ -148,7 +148,7 @@ func (e *Engine) Start(ctx Context, input string) (*Return, error) {
 		} else if tool.IsOpenAPI() {
 			return e.runOpenAPI(tool, input)
 		}
-		s, err := e.runCommand(ctx.WrappedContext(), tool, input)
+		s, err := e.runCommand(ctx.WrappedContext(), tool, input, pauseF)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -137,7 +137,7 @@ func (c *Context) WrappedContext() context.Context {
 	return context.WithValue(c.Ctx, engineContext{}, c)
 }
 
-func (e *Engine) Start(ctx Context, input string, pauseF func() func()) (*Return, error) {
+func (e *Engine) Start(ctx Context, input string) (*Return, error) {
 	tool := ctx.Tool
 
 	if tool.IsCommand() {
@@ -148,7 +148,7 @@ func (e *Engine) Start(ctx Context, input string, pauseF func() func()) (*Return
 		} else if tool.IsOpenAPI() {
 			return e.runOpenAPI(tool, input)
 		}
-		s, err := e.runCommand(ctx.WrappedContext(), tool, input, pauseF)
+		s, err := e.runCommand(ctx.WrappedContext(), tool, input, ctx.IsCredential)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -178,12 +178,13 @@ func (r *Runner) call(callCtx engine.Context, monitor Monitor, env []string, inp
 		Content:     input,
 	})
 
-	// The sys.prompt tool is a special case where we need to pass the monitor to the builtin function.
-	if callCtx.Tool.BuiltinFunc != nil && callCtx.Tool.ID == "sys.prompt" {
-		callCtx.Ctx = context.WithValue(callCtx.Ctx, MonitorKey{}, monitor)
+	var result *engine.Return
+	if callCtx.IsCredential {
+		result, err = e.Start(callCtx, input, monitor.Pause)
+	} else {
+		result, err = e.Start(callCtx, input, nil)
 	}
 
-	result, err := e.Start(callCtx, input)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
for #256

One of the goals of the credentials framework was to block output to the terminal while running `sys.prompt`, since it prompts the user directly in the terminal. I originally implemented this by storing the Monitor into the Context and then pulling it out of the Context and running its `Pause` function in the implementation of `sys.prompt`. However, this does not work, as credential tools pretty much always have to call `sys.prompt` with a new gptscript subprocess.

This new implementation instead stores the Pause function inside of the context and calls it within the Engine code prior to running a credential tool. This way, the Monitor is paused in the correct process.