### PR TITLE
chore: include gptscript-credential-helpers in packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@
 **/__pycache__
 /docs/yarn.lock
 /releases
+/binaries
 /checksums.txt
 /.env*

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -67,7 +67,7 @@ brews:
       bin.install "gptscript"
       {{ if eq .Os "darwin" }}bin.install "gptscript-credential-osxkeychain"{{ end }}
     homepage: "https://github.com/gptscript-ai/gptscript"
-    skip_upload: true
+    skip_upload: false
     folder: "Formula"
     repository:
       owner: gptscript-ai

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,6 +6,7 @@ before:
   hooks:
     # Generate UI assets to embedded in binaries
     - make build-ui
+    - ./scripts/download-cred-helpers.sh
 
 builds:
   - id: default
@@ -21,12 +22,16 @@ builds:
       - -s
       - -w
       - -X "github.com/gptscript-ai/gptscript/pkg/version.Tag=v{{ .Version }}"
+    hooks:
+      post: ./scripts/copy-cred-helper.sh {{ .Os }} {{ .Arch }}
 
 universal_binaries:
   - id: mac
     ids:
       - default
     replace: true
+    hooks:
+      post: cp binaries/gptscript-credential-osxkeychain releases/mac_darwin_all
 
 archives:
   - id: default
@@ -60,8 +65,9 @@ brews:
   - description: "GPTScript CLI"
     install: |
       bin.install "gptscript"
+      {{ if eq .Os "darwin" }}bin.install "gptscript-credential-osxkeychain"{{ end }}
     homepage: "https://github.com/gptscript-ai/gptscript"
-    skip_upload: false
+    skip_upload: true
     folder: "Formula"
     repository:
       owner: gptscript-ai

--- a/scripts/copy-cred-helper.sh
+++ b/scripts/copy-cred-helper.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+OS="$1"
+ARCH="$2"
+
+case "$OS" in
+	"darwin")
+		case "$ARCH" in
+			"amd64")
+				cp binaries/gptscript-credential-osxkeychain releases/default_darwin_amd64_v1
+				;;
+			"arm64")
+				cp binaries/gptscript-credential-osxkeychain releases/default_darwin_arm64
+				;;
+		esac
+		;;
+	"windows")
+		case "$ARCH" in
+			"amd64")
+				cp binaries/gptscript-credential-wincred.exe releases/default_windows_amd64_v1
+				;;
+		esac
+		;;
+esac

--- a/scripts/copy-cred-helper.sh
+++ b/scripts/copy-cred-helper.sh
@@ -19,7 +19,10 @@ case "$OS" in
 	"windows")
 		case "$ARCH" in
 			"amd64")
-				cp binaries/gptscript-credential-wincred.exe releases/default_windows_amd64_v1
+				cp binaries/gptscript-credential-wincred-amd64.exe releases/default_windows_amd64_v1/gptscript-credential-wincred.exe
+				;;
+			"arm64")
+				cp binaries/gptscript-credential-wincred-arm64.exe releases/default_windows_arm64/gptscript-credential-wincred.exe
 				;;
 		esac
 		;;

--- a/scripts/download-cred-helpers.sh
+++ b/scripts/download-cred-helpers.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# This script downloads the gptscript-credential-helpers. (For use in CI.)
+
+GPTSCRIPT_CRED_HELPERS_VERSION="v0.1.0"
+BINARY_DIR="binaries"
+
+mkdir -p "$BINARY_DIR"
+cd "$BINARY_DIR"
+
+wget -O gptscript-credential-osxkeychain "https://github.com/gptscript-ai/gptscript-credential-helpers/releases/download/${GPTSCRIPT_CRED_HELPERS_VERSION}/gptscript-credential-osxkeychain"
+chmod +x gptscript-credential-osxkeychain
+
+wget -O gptscript-credential-wincred.exe "https://github.com/gptscript-ai/gptscript-credential-helpers/releases/download/${GPTSCRIPT_CRED_HELPERS_VERSION}/gptscript-credential-wincred-${GPTSCRIPT_CRED_HELPERS_VERSION}.windows-amd64.exe"
+chmod +x gptscript-credential-wincred.exe

--- a/scripts/download-cred-helpers.sh
+++ b/scripts/download-cred-helpers.sh
@@ -13,5 +13,8 @@ cd "$BINARY_DIR"
 wget -O gptscript-credential-osxkeychain "https://github.com/gptscript-ai/gptscript-credential-helpers/releases/download/${GPTSCRIPT_CRED_HELPERS_VERSION}/gptscript-credential-osxkeychain"
 chmod +x gptscript-credential-osxkeychain
 
-wget -O gptscript-credential-wincred.exe "https://github.com/gptscript-ai/gptscript-credential-helpers/releases/download/${GPTSCRIPT_CRED_HELPERS_VERSION}/gptscript-credential-wincred-${GPTSCRIPT_CRED_HELPERS_VERSION}.windows-amd64.exe"
-chmod +x gptscript-credential-wincred.exe
+wget -O gptscript-credential-wincred-amd64.exe "https://github.com/gptscript-ai/gptscript-credential-helpers/releases/download/${GPTSCRIPT_CRED_HELPERS_VERSION}/gptscript-credential-wincred-${GPTSCRIPT_CRED_HELPERS_VERSION}.windows-amd64.exe"
+chmod +x gptscript-credential-wincred-amd64.exe
+
+wget -O gptscript-credential-wincred-arm64.exe "https://github.com/gptscript-ai/gptscript-credential-helpers/releases/download/${GPTSCRIPT_CRED_HELPERS_VERSION}/gptscript-credential-wincred-${GPTSCRIPT_CRED_HELPERS_VERSION}.windows-arm64.exe"
+chmod +x gptscript-credential-wincred-arm64.exe


### PR DESCRIPTION
This should be the last step for packaging the GPTScript credential helpers, which are small CLI programs (forked from the docker-credential-helpers repo) that gptscript uses to interact with OS keystores. The source for this is at github.com/gptscript-ai/gptscript-credential-helpers

I recently revamped and cleaned up the credential helper repo and created its first GitHub release, v0.1.0. I also combined the amd64 and arm64 darwin binaries into a single universal binary using github.com/g-linville/makefat, my fork of the tool github.com/randall77/makefat. (We can move this fork to gptscript-ai if we want. I basically just added CI and a goreleaser config for it, and set up reproducible builds.)

These changes add hooks to the goreleaser file to download the compiled binaries for gptscript-credential-osxkeychain and gptscript-credential-wincred.exe from the v0.1.0 release in the credential helpers repo. Then, the programs get copied into the correct release folder for their corresponding OS+arch.

The trouble with this is that I can't fully test to make sure that the changes are picked up and working in Homebrew and Winget until this is in. Since Winget is just uploading the archive that contains the binaries, I think it should work. And I added another command to the Homebrew formula that should cause it to install the osxkeychain helper alongside gptscript itself.