### PR TITLE
Fix time.gpt example to add more guidance to arg description and nodejs-imagegen example to use the dalle-image-generation repo.

### DIFF
--- a/examples/nodejs-imagegen/server.js
+++ b/examples/nodejs-imagegen/server.js
@@ -51,7 +51,7 @@ app.post('/generate-logo', async (req, res) => {
     }
 `;
     const tool = new gptscript.Tool({
-        tools: ['github.com/gptscript-ai/image-generation'],
+        tools: ['github.com/gptscript-ai/dalle-image-generation'],
         jsonResponse: true,
         instructions: instructions,
     })

--- a/examples/time.gpt
+++ b/examples/time.gpt
@@ -5,7 +5,7 @@ Ask time to get you the time in different timezones.
 ---
 name: time
 description: Can tell current time in any timezone,
-args: timezone: The timezone you want time in.
+args: timezone: The timezone you want time in e.g. 'Pacific/Honolulu'
 
 #!/bin/bash
 echo "Your current date and time is "


### PR DESCRIPTION
Fix time.gpt example to add more guidance to timezone arg's description to make it work more reliably with other provider models.
Fix nodejs-imagegen example to use the dalle-image-generation repo.