### PR TITLE
Revert "bug: expand interpreter args to multiple arguments"

### DIFF
--- a/pkg/engine/cmd.go
+++ b/pkg/engine/cmd.go
@@ -211,12 +211,6 @@ func (e *Engine) newCommand(ctx context.Context, extraEnv []string, tool types.T
 		cmdArgs = append(cmdArgs, f.Name())
 	}
 
-	// This is a bit hacky, but we want ARGS="x y" to expand to "x" and "y" not "x y" if used as arguments
-	cmdArgs, err = shlex.Split(strings.Join(cmdArgs, " "))
-	if err != nil {
-		return nil, nil, err
-	}
-
 	// This is a workaround for Windows, where the command interpreter is constructed with unix style paths
 	// It converts unix style paths to windows style paths
 	if runtime.GOOS == "windows" {

--- a/pkg/tests/runner_test.go
+++ b/pkg/tests/runner_test.go
@@ -572,19 +572,3 @@ func TestExport(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "TEST RESULT CALL: 3", x)
 }
-
-func TestShlex(t *testing.T) {
-	runner := tester.NewRunner(t)
-
-	runner.RespondWith(tester.Result{
-		Func: types.CompletionFunctionCall{
-			Name: "transient",
-		},
-	})
-	x, err := runner.Run("", `{
-"args":" x y  z  "
-}`)
-	require.NoError(t, err)
-	// The fact the white space is all perfect means that the string didn't get passed as one arg but multiple
-	assert.Equal(t, "x y z\n", x)
-}

--- a/pkg/tests/testdata/TestShlex/test.gpt
+++ b/pkg/tests/testdata/TestShlex/test.gpt
@@ -1,2 +1,0 @@
-
-#!/usr/bin/env echo ${ARGS}


### PR DESCRIPTION
This reverts commit b5e053ca9253f95dc083bdcc128e37b0d25c9f47.
