### PR TITLE
enhance: update credentials framework for OAuth support

### DIFF
--- a/pkg/cli/credential.go
+++ b/pkg/cli/credential.go
@@ -93,7 +93,7 @@ func (c *Credential) Run(_ *cobra.Command, _ []string) error {
 		expires := "never"
 		if cred.ExpiresAt != nil {
 			if !cred.IsExpired() {
-				expires = cred.ExpiresAt.Sub(time.Now()).Truncate(time.Second).String()
+				expires = time.Until(*cred.ExpiresAt).Truncate(time.Second).String()
 			} else {
 				expires = "expired"
 			}

--- a/pkg/cli/credential.go
+++ b/pkg/cli/credential.go
@@ -15,6 +15,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	expiresNever   = "never"
+	expiresExpired = "expired"
+)
+
 type Credential struct {
 	root        *GPTScript
 	AllContexts bool `usage:"List credentials for all contexts" local:"true"`
@@ -90,12 +95,11 @@ func (c *Credential) Run(_ *cobra.Command, _ []string) error {
 	}
 
 	for _, cred := range creds {
-		expires := "never"
+		expires := expiresNever
 		if cred.ExpiresAt != nil {
+			expires = expiresExpired
 			if !cred.IsExpired() {
 				expires = time.Until(*cred.ExpiresAt).Truncate(time.Second).String()
-			} else {
-				expires = "expired"
 			}
 		}
 

--- a/pkg/credentials/credential.go
+++ b/pkg/credentials/credential.go
@@ -49,7 +49,7 @@ func (c Credential) toDockerAuthConfig() (types.AuthConfig, error) {
 
 func credentialFromDockerAuthConfig(authCfg types.AuthConfig) (Credential, error) {
 	var cred Credential
-	if err := json.Unmarshal([]byte(authCfg.Password), &cred); err != nil {
+	if err := json.Unmarshal([]byte(authCfg.Password), &cred); err != nil || len(cred.Env) == 0 {
 		// Legacy: try unmarshalling into just an env map
 		var env map[string]string
 		if err := json.Unmarshal([]byte(authCfg.Password), &env); err != nil {

--- a/pkg/credentials/credential.go
+++ b/pkg/credentials/credential.go
@@ -4,43 +4,58 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/docker/cli/cli/config/types"
 )
 
-const ctxSeparator = "///"
-
 type CredentialType string
 
 const (
+	ctxSeparator                               = "///"
 	CredentialTypeTool          CredentialType = "tool"
 	CredentialTypeModelProvider CredentialType = "modelProvider"
+	ExistingCredential                         = "GPTSCRIPT_EXISTING_CREDENTIAL"
 )
 
 type Credential struct {
-	Context  string            `json:"context"`
-	ToolName string            `json:"toolName"`
-	Type     CredentialType    `json:"type"`
-	Env      map[string]string `json:"env"`
+	Context      string            `json:"context"`
+	ToolName     string            `json:"toolName"`
+	Type         CredentialType    `json:"type"`
+	Env          map[string]string `json:"env"`
+	ExpiresAt    *time.Time        `json:"expiresAt"`
+	RefreshToken string            `json:"refreshToken"`
+}
+
+func (c Credential) IsExpired() bool {
+	if c.ExpiresAt == nil {
+		return false
+	}
+	return time.Now().After(*c.ExpiresAt)
 }
 
 func (c Credential) toDockerAuthConfig() (types.AuthConfig, error) {
-	env, err := json.Marshal(c.Env)
+	cred, err := json.Marshal(c)
 	if err != nil {
 		return types.AuthConfig{}, err
 	}
 
 	return types.AuthConfig{
-		Username:      string(c.Type),
-		Password:      string(env),
+		Username:      string(c.Type), // Username is required, but not used
+		Password:      string(cred),
 		ServerAddress: toolNameWithCtx(c.ToolName, c.Context),
 	}, nil
 }
 
 func credentialFromDockerAuthConfig(authCfg types.AuthConfig) (Credential, error) {
-	var env map[string]string
-	if err := json.Unmarshal([]byte(authCfg.Password), &env); err != nil {
-		return Credential{}, err
+	var cred Credential
+	if err := json.Unmarshal([]byte(authCfg.Password), &cred); err != nil {
+		// Legacy: try unmarshalling into just an env map
+		var env map[string]string
+		if err := json.Unmarshal([]byte(authCfg.Password), &env); err != nil {
+			return Credential{}, err
+		}
+		cred.Env = env
 	}
 
 	// We used to hardcode the username as "gptscript" before CredentialType was introduced, so
@@ -62,10 +77,12 @@ func credentialFromDockerAuthConfig(authCfg types.AuthConfig) (Credential, error
 	}
 
 	return Credential{
-		Context:  ctx,
-		ToolName: tool,
-		Type:     CredentialType(credType),
-		Env:      env,
+		Context:      ctx,
+		ToolName:     tool,
+		Type:         CredentialType(credType),
+		Env:          cred.Env,
+		ExpiresAt:    cred.ExpiresAt,
+		RefreshToken: cred.RefreshToken,
 	}, nil
 }
 

--- a/pkg/credentials/credential.go
+++ b/pkg/credentials/credential.go
@@ -41,7 +41,7 @@ func (c Credential) toDockerAuthConfig() (types.AuthConfig, error) {
 	}
 
 	return types.AuthConfig{
-		Username:      string(c.Type), // Username is required, but not used
+		Username:      string(c.Type),
 		Password:      string(cred),
 		ServerAddress: toolNameWithCtx(c.ToolName, c.Context),
 	}, nil

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -904,11 +904,11 @@ func (r *Runner) handleCredentials(callCtx engine.Context, monitor Monitor, env 
 
 			// If the existing credential is expired, we need to provide it to the cred tool through the environment.
 			if exists && c.IsExpired() {
-				credJson, err := json.Marshal(c)
+				credJSON, err := json.Marshal(c)
 				if err != nil {
 					return nil, fmt.Errorf("failed to marshal credential: %w", err)
 				}
-				env = append(env, fmt.Sprintf("%s=%s", credentials.ExistingCredential, string(credJson)))
+				env = append(env, fmt.Sprintf("%s=%s", credentials.ExistingCredential, string(credJSON)))
 			}
 
 			// Get the input for the credential tool, if there is any.

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -934,6 +934,7 @@ func (r *Runner) handleCredentials(callCtx engine.Context, monitor Monitor, env 
 				return nil, fmt.Errorf("failed to unmarshal credential tool %s response: %w", credToolName, err)
 			}
 			c.ToolName = credName
+			c.Type = credentials.CredentialTypeTool
 
 			isEmpty := true
 			for _, v := range c.Env {


### PR DESCRIPTION
This adds support for expiration and refresh tokens to the credential framework. All of these changes are backwards compatible with existing credentials, though new credentials will be stored in a slightly different format.

Notable changes:
- An expiration time for the credential will be saved if the cred tool provides that field. Once the credential is expired, the next time it is requested, the credential tool will be run again.
- A refresh token for the credential will be saved if the cred tool provides that field. This is useful in certain OAuth situations for requesting a new token without user interaction.
- `gptscript cred` output looks a little nicer and displays more information.