### PR TITLE
chore: update default model to gpt-4-turbo

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ OUTPUT:
 Hello, World!
 ```
 
-The model used by default is `gpt-4-turbo-preview` and you must have access to that model in your OpenAI account.
+The model used by default is `gpt-4-turbo` and you must have access to that model in your OpenAI account.
 
 If using Azure OpenAI, make sure you configure the model to be one of the supported versions with the `--default-model` argument.
 
@@ -244,7 +244,7 @@ Tool parameters are key-value pairs defined at the beginning of a tool block, be
 | Key            | Description                                                                                                                             |
 |------------------|-----------------------------------------------------------------------------------------------------------------------------------------|
 | `Name`           | The name of the tool.                                                                                                                   |
-| `Model Name`     | The OpenAI model to use, by default it uses "gpt-4-turbo-preview"                                                                         |
+| `Model Name`     | The OpenAI model to use, by default it uses "gpt-4-turbo"                                                                         |
 | `Description`    | The description of the tool. It is important that this properly describes the tool's purpose as the description is used by the LLM.     |
 | `Internal Prompt`| Setting this to `false` will disable the built-in system prompt for this tool.                                                          |
 | `Tools`          | A comma-separated list of tools that are available to be called by this tool.                                                            |

--- a/docs/docs/02-getting-started.md
+++ b/docs/docs/02-getting-started.md
@@ -59,7 +59,7 @@ OUTPUT:
 Hello, World!
 ```
 
-The model used by default is `gpt-4-turbo-preview` and you must have access to that model in your OpenAI account.
+The model used by default is `gpt-4-turbo` and you must have access to that model in your OpenAI account.
 
 If using Azure OpenAI, make sure you configure the model to be one of the supported versions with the `--default-model` argument.
 

--- a/docs/docs/07-gpt-file-reference.md
+++ b/docs/docs/07-gpt-file-reference.md
@@ -46,7 +46,7 @@ Tool parameters are key-value pairs defined at the beginning of a tool block, be
 | Key               | Description                                                                                                                                   |
 |-------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|
 | `Name`            | The name of the tool.                                                                                                                         |
-| `Model Name`      | The OpenAI model to use, by default it uses "gpt-4-turbo-preview"                                                                             |
+| `Model Name`      | The OpenAI model to use, by default it uses "gpt-4-turbo"                                                                             |
 | `Description`     | The description of the tool. It is important that this properly describes the tool's purpose as the description is used by the LLM.           |
 | `Internal Prompt` | Setting this to `false` will disable the built-in system prompt for this tool.                                                                |
 | `Tools`           | A comma-separated list of tools that are available to be called by this tool.                                                                 |

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/fatih/color v1.16.0
 	github.com/getkin/kin-openapi v0.123.0
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
-	github.com/gptscript-ai/chat-completion-client v0.0.0-20240404013040-49eb8f6affa1
+	github.com/gptscript-ai/chat-completion-client v0.0.0-20240502162133-7dabc28eab59
 	github.com/hexops/autogold/v2 v2.2.1
 	github.com/jaytaylor/html2text v0.0.0-20230321000545-74c2419ad056
 	github.com/mholt/archiver/v4 v4.0.0-alpha.8

--- a/go.sum
+++ b/go.sum
@@ -123,8 +123,8 @@ github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
-github.com/gptscript-ai/chat-completion-client v0.0.0-20240404013040-49eb8f6affa1 h1:h0ikiEkB6lUgiOKN5ltZ7rzIvA13qjz8qcB/3wWdCws=
-github.com/gptscript-ai/chat-completion-client v0.0.0-20240404013040-49eb8f6affa1/go.mod h1:7P/o6/IWa1KqsntVf68hSnLKuu3+xuqm6lYhch1w4jo=
+github.com/gptscript-ai/chat-completion-client v0.0.0-20240502162133-7dabc28eab59 h1:Nda0GDkrmIDiAFHfaXu0eIp6SsBs0/4Zyo87ff3Qcqo=
+github.com/gptscript-ai/chat-completion-client v0.0.0-20240502162133-7dabc28eab59/go.mod h1:7P/o6/IWa1KqsntVf68hSnLKuu3+xuqm6lYhch1w4jo=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=

--- a/pkg/cli/gptscript.go
+++ b/pkg/cli/gptscript.go
@@ -243,7 +243,7 @@ func (r *GPTScript) PersistentPre(*cobra.Command, []string) error {
 		color.NoColor = !*r.Color
 	}
 
-	if r.DefaultModel != "gpt-4-turbo-preview" {
+	if r.DefaultModel != openai.DefaultModel {
 		log.Infof("WARNING: Changing the default model can have unknown behavior for existing tools. Use the model field per tool instead.")
 	}
 

--- a/pkg/loader/loader_test.go
+++ b/pkg/loader/loader_test.go
@@ -27,7 +27,7 @@ func TestHelloWorld(t *testing.T) {
   "entryToolId": "https://raw.githubusercontent.com/ibuildthecloud/test/bafe5a62174e8a0ea162277dcfe3a2ddb7eea928/example/sub/tool.gpt:1",
   "toolSet": {
     "https://raw.githubusercontent.com/ibuildthecloud/test/bafe5a62174e8a0ea162277dcfe3a2ddb7eea928/example/bob.gpt:1": {
-      "modelName": "gpt-4-turbo-preview",
+      "modelName": "gpt-4-turbo",
       "internalPrompt": null,
       "instructions": "Say hello world",
       "id": "https://raw.githubusercontent.com/ibuildthecloud/test/bafe5a62174e8a0ea162277dcfe3a2ddb7eea928/example/bob.gpt:1",
@@ -41,7 +41,7 @@ func TestHelloWorld(t *testing.T) {
       "workingDir": "https://raw.githubusercontent.com/ibuildthecloud/test/bafe5a62174e8a0ea162277dcfe3a2ddb7eea928/example"
     },
     "https://raw.githubusercontent.com/ibuildthecloud/test/bafe5a62174e8a0ea162277dcfe3a2ddb7eea928/example/sub/tool.gpt:1": {
-      "modelName": "gpt-4-turbo-preview",
+      "modelName": "gpt-4-turbo",
       "internalPrompt": null,
       "tools": [
         "../bob.gpt"
@@ -72,7 +72,7 @@ func TestHelloWorld(t *testing.T) {
   "toolSet": {
     "https://get.gptscript.ai/echo.gpt:1": {
       "description": "Returns back the input of the script",
-      "modelName": "gpt-4-turbo-preview",
+      "modelName": "gpt-4-turbo",
       "internalPrompt": null,
       "arguments": {
         "properties": {

--- a/pkg/loader/loader_test.go
+++ b/pkg/loader/loader_test.go
@@ -3,8 +3,10 @@ package loader
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
+	"github.com/gptscript-ai/gptscript/pkg/openai"
 	"github.com/hexops/autogold/v2"
 	"github.com/stretchr/testify/require"
 )
@@ -22,12 +24,12 @@ func TestHelloWorld(t *testing.T) {
 		"https://raw.githubusercontent.com/ibuildthecloud/test/bafe5a62174e8a0ea162277dcfe3a2ddb7eea928/example/sub/tool.gpt",
 		"")
 	require.NoError(t, err)
-	autogold.Expect(`{
+	autogold.Expect(strings.ReplaceAll(`{
   "name": "https://raw.githubusercontent.com/ibuildthecloud/test/bafe5a62174e8a0ea162277dcfe3a2ddb7eea928/example/sub/tool.gpt",
   "entryToolId": "https://raw.githubusercontent.com/ibuildthecloud/test/bafe5a62174e8a0ea162277dcfe3a2ddb7eea928/example/sub/tool.gpt:1",
   "toolSet": {
     "https://raw.githubusercontent.com/ibuildthecloud/test/bafe5a62174e8a0ea162277dcfe3a2ddb7eea928/example/bob.gpt:1": {
-      "modelName": "gpt-4-turbo",
+      "modelName": "MODEL",
       "internalPrompt": null,
       "instructions": "Say hello world",
       "id": "https://raw.githubusercontent.com/ibuildthecloud/test/bafe5a62174e8a0ea162277dcfe3a2ddb7eea928/example/bob.gpt:1",
@@ -41,7 +43,7 @@ func TestHelloWorld(t *testing.T) {
       "workingDir": "https://raw.githubusercontent.com/ibuildthecloud/test/bafe5a62174e8a0ea162277dcfe3a2ddb7eea928/example"
     },
     "https://raw.githubusercontent.com/ibuildthecloud/test/bafe5a62174e8a0ea162277dcfe3a2ddb7eea928/example/sub/tool.gpt:1": {
-      "modelName": "gpt-4-turbo",
+      "modelName": "MODEL",
       "internalPrompt": null,
       "tools": [
         "../bob.gpt"
@@ -61,18 +63,18 @@ func TestHelloWorld(t *testing.T) {
       "workingDir": "https://raw.githubusercontent.com/ibuildthecloud/test/bafe5a62174e8a0ea162277dcfe3a2ddb7eea928/example/sub"
     }
   }
-}`).Equal(t, toString(prg))
+}`, "MODEL", openai.DefaultModel)).Equal(t, toString(prg))
 
 	prg, err = Program(context.Background(), "https://get.gptscript.ai/echo.gpt", "")
 	require.NoError(t, err)
 
-	autogold.Expect(`{
+	autogold.Expect(strings.ReplaceAll(`{
   "name": "https://get.gptscript.ai/echo.gpt",
   "entryToolId": "https://get.gptscript.ai/echo.gpt:1",
   "toolSet": {
     "https://get.gptscript.ai/echo.gpt:1": {
       "description": "Returns back the input of the script",
-      "modelName": "gpt-4-turbo",
+      "modelName": "MODEL",
       "internalPrompt": null,
       "arguments": {
         "properties": {
@@ -95,7 +97,7 @@ func TestHelloWorld(t *testing.T) {
       "workingDir": "https://get.gptscript.ai/"
     }
   }
-}`).Equal(t, toString(prg))
+}`, "MODEL", openai.DefaultModel)).Equal(t, toString(prg))
 }
 
 func TestParse(t *testing.T) {

--- a/pkg/openai/client.go
+++ b/pkg/openai/client.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	DefaultModel = openai.GPT4TurboPreview
+	DefaultModel = openai.GPT4Turbo
 )
 
 var (
@@ -47,7 +47,7 @@ type Options struct {
 	APIVersion   string         `usage:"OpenAI API Version (for Azure)" name:"openai-api-version" env:"OPENAI_API_VERSION"`
 	APIType      openai.APIType `usage:"OpenAI API Type (valid: OPEN_AI, AZURE, AZURE_AD)" name:"openai-api-type" env:"OPENAI_API_TYPE"`
 	OrgID        string         `usage:"OpenAI organization ID" name:"openai-org-id" env:"OPENAI_ORG_ID"`
-	DefaultModel string         `usage:"Default LLM model to use" default:"gpt-4-turbo-preview"`
+	DefaultModel string         `usage:"Default LLM model to use" default:"gpt-4-turbo"`
 	ConfigFile   string         `usage:"Path to GPTScript config file" name:"config"`
 	SetSeed      bool           `usage:"-"`
 	CacheKey     string         `usage:"-"`

--- a/pkg/tests/runner_test.go
+++ b/pkg/tests/runner_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"os"
+	"strings"
 	"testing"
 
+	"github.com/gptscript-ai/gptscript/pkg/openai"
 	"github.com/gptscript-ai/gptscript/pkg/tests/tester"
 	"github.com/gptscript-ai/gptscript/pkg/types"
 	"github.com/hexops/autogold/v2"
@@ -218,7 +220,7 @@ func TestSubChat(t *testing.T) {
 	resp, err := r.Chat(context.Background(), nil, prg, os.Environ(), "Hello")
 	require.NoError(t, err)
 
-	autogold.Expect(`{
+	autogold.Expect(strings.ReplaceAll(`{
   "done": false,
   "content": "Assistant 1",
   "toolID": "testdata/TestSubChat/test.gpt:6",
@@ -227,7 +229,7 @@ func TestSubChat(t *testing.T) {
       "state": {
         "input": "Hello",
         "completion": {
-          "Model": "gpt-4-turbo-preview",
+          "Model": "MODEL",
           "InternalSystemPrompt": null,
           "Tools": [
             {
@@ -300,7 +302,7 @@ func TestSubChat(t *testing.T) {
           "continuation": {
             "state": {
               "completion": {
-                "Model": "gpt-4-turbo-preview",
+                "Model": "MODEL",
                 "InternalSystemPrompt": false,
                 "Tools": null,
                 "Messages": [
@@ -336,12 +338,12 @@ func TestSubChat(t *testing.T) {
     ],
     "subCallID": "call_1"
   }
-}`).Equal(t, toJSONString(t, resp))
+}`, "MODEL", openai.DefaultModel)).Equal(t, toJSONString(t, resp))
 
 	resp, err = r.Chat(context.Background(), resp.State, prg, os.Environ(), "User 1")
 	require.NoError(t, err)
 
-	autogold.Expect(`{
+	autogold.Expect(strings.ReplaceAll(`{
   "done": false,
   "content": "Assistant 2",
   "toolID": "testdata/TestSubChat/test.gpt:6",
@@ -350,7 +352,7 @@ func TestSubChat(t *testing.T) {
       "state": {
         "input": "Hello",
         "completion": {
-          "Model": "gpt-4-turbo-preview",
+          "Model": "MODEL",
           "InternalSystemPrompt": null,
           "Tools": [
             {
@@ -423,7 +425,7 @@ func TestSubChat(t *testing.T) {
           "continuation": {
             "state": {
               "completion": {
-                "Model": "gpt-4-turbo-preview",
+                "Model": "MODEL",
                 "InternalSystemPrompt": false,
                 "Tools": null,
                 "Messages": [
@@ -475,7 +477,7 @@ func TestSubChat(t *testing.T) {
     ],
     "subCallID": "call_1"
   }
-}`).Equal(t, toJSONString(t, resp))
+}`, "MODEL", openai.DefaultModel)).Equal(t, toJSONString(t, resp))
 }
 
 func TestChat(t *testing.T) {
@@ -492,7 +494,7 @@ func TestChat(t *testing.T) {
 	resp, err := r.Chat(context.Background(), nil, prg, os.Environ(), "Hello")
 	require.NoError(t, err)
 
-	autogold.Expect(`{
+	autogold.Expect(strings.ReplaceAll(`{
   "done": false,
   "content": "Assistant 1",
   "toolID": "testdata/TestChat/test.gpt:1",
@@ -501,7 +503,7 @@ func TestChat(t *testing.T) {
       "state": {
         "input": "Hello",
         "completion": {
-          "Model": "gpt-4-turbo-preview",
+          "Model": "MODEL",
           "InternalSystemPrompt": false,
           "Tools": null,
           "Messages": [
@@ -541,12 +543,12 @@ func TestChat(t *testing.T) {
     },
     "continuationToolID": "testdata/TestChat/test.gpt:1"
   }
-}`).Equal(t, toJSONString(t, resp))
+}`, "MODEL", openai.DefaultModel)).Equal(t, toJSONString(t, resp))
 
 	resp, err = r.Chat(context.Background(), resp.State, prg, os.Environ(), "User 1")
 	require.NoError(t, err)
 
-	autogold.Expect(`{
+	autogold.Expect(strings.ReplaceAll(`{
   "done": false,
   "content": "Assistant 2",
   "toolID": "testdata/TestChat/test.gpt:1",
@@ -555,7 +557,7 @@ func TestChat(t *testing.T) {
       "state": {
         "input": "Hello",
         "completion": {
-          "Model": "gpt-4-turbo-preview",
+          "Model": "MODEL",
           "InternalSystemPrompt": false,
           "Tools": null,
           "Messages": [
@@ -611,7 +613,7 @@ func TestChat(t *testing.T) {
     },
     "continuationToolID": "testdata/TestChat/test.gpt:1"
   }
-}`).Equal(t, toJSONString(t, resp))
+}`, "MODEL", openai.DefaultModel)).Equal(t, toJSONString(t, resp))
 }
 
 func TestChatRunNoError(t *testing.T) {

--- a/pkg/tests/testdata/TestCase/call1.golden
+++ b/pkg/tests/testdata/TestCase/call1.golden
@@ -1,5 +1,5 @@
 `{
-  "Model": "gpt-4-turbo-preview",
+  "Model": "gpt-4-turbo",
   "InternalSystemPrompt": null,
   "Tools": [
     {

--- a/pkg/tests/testdata/TestCase2/call1.golden
+++ b/pkg/tests/testdata/TestCase2/call1.golden
@@ -1,5 +1,5 @@
 `{
-  "Model": "gpt-4-turbo-preview",
+  "Model": "gpt-4-turbo",
   "InternalSystemPrompt": null,
   "Tools": [
     {

--- a/pkg/tests/testdata/TestChat/call1.golden
+++ b/pkg/tests/testdata/TestChat/call1.golden
@@ -1,5 +1,5 @@
 `{
-  "Model": "gpt-4-turbo-preview",
+  "Model": "gpt-4-turbo",
   "InternalSystemPrompt": false,
   "Tools": null,
   "Messages": [

--- a/pkg/tests/testdata/TestChat/call2.golden
+++ b/pkg/tests/testdata/TestChat/call2.golden
@@ -1,5 +1,5 @@
 `{
-  "Model": "gpt-4-turbo-preview",
+  "Model": "gpt-4-turbo",
   "InternalSystemPrompt": false,
   "Tools": null,
   "Messages": [

--- a/pkg/tests/testdata/TestChatRunNoError/call1.golden
+++ b/pkg/tests/testdata/TestChatRunNoError/call1.golden
@@ -1,5 +1,5 @@
 `{
-  "Model": "gpt-4-turbo-preview",
+  "Model": "gpt-4-turbo",
   "InternalSystemPrompt": false,
   "Tools": null,
   "Messages": [

--- a/pkg/tests/testdata/TestContext/call1.golden
+++ b/pkg/tests/testdata/TestContext/call1.golden
@@ -1,5 +1,5 @@
 `{
-  "Model": "gpt-4-turbo-preview",
+  "Model": "gpt-4-turbo",
   "InternalSystemPrompt": null,
   "Tools": null,
   "Messages": [

--- a/pkg/tests/testdata/TestContextArg/call1.golden
+++ b/pkg/tests/testdata/TestContextArg/call1.golden
@@ -1,5 +1,5 @@
 `{
-  "Model": "gpt-4-turbo-preview",
+  "Model": "gpt-4-turbo",
   "InternalSystemPrompt": null,
   "Tools": null,
   "Messages": [

--- a/pkg/tests/testdata/TestContextSubChat/call1.golden
+++ b/pkg/tests/testdata/TestContextSubChat/call1.golden
@@ -1,5 +1,5 @@
 `{
-  "Model": "gpt-4-turbo-preview",
+  "Model": "gpt-4-turbo",
   "InternalSystemPrompt": null,
   "Tools": [
     {

--- a/pkg/tests/testdata/TestContextSubChat/call10.golden
+++ b/pkg/tests/testdata/TestContextSubChat/call10.golden
@@ -1,5 +1,5 @@
 `{
-  "Model": "gpt-4-turbo-preview",
+  "Model": "gpt-4-turbo",
   "InternalSystemPrompt": false,
   "Tools": null,
   "Messages": [

--- a/pkg/tests/testdata/TestContextSubChat/call2.golden
+++ b/pkg/tests/testdata/TestContextSubChat/call2.golden
@@ -1,5 +1,5 @@
 `{
-  "Model": "gpt-4-turbo-preview",
+  "Model": "gpt-4-turbo",
   "InternalSystemPrompt": false,
   "Tools": [
     {

--- a/pkg/tests/testdata/TestContextSubChat/call3.golden
+++ b/pkg/tests/testdata/TestContextSubChat/call3.golden
@@ -1,5 +1,5 @@
 `{
-  "Model": "gpt-4-turbo-preview",
+  "Model": "gpt-4-turbo",
   "InternalSystemPrompt": false,
   "Tools": [
     {

--- a/pkg/tests/testdata/TestContextSubChat/call4.golden
+++ b/pkg/tests/testdata/TestContextSubChat/call4.golden
@@ -1,5 +1,5 @@
 `{
-  "Model": "gpt-4-turbo-preview",
+  "Model": "gpt-4-turbo",
   "InternalSystemPrompt": null,
   "Tools": [
     {

--- a/pkg/tests/testdata/TestContextSubChat/call5.golden
+++ b/pkg/tests/testdata/TestContextSubChat/call5.golden
@@ -1,5 +1,5 @@
 `{
-  "Model": "gpt-4-turbo-preview",
+  "Model": "gpt-4-turbo",
   "InternalSystemPrompt": false,
   "Tools": null,
   "Messages": [

--- a/pkg/tests/testdata/TestContextSubChat/call6.golden
+++ b/pkg/tests/testdata/TestContextSubChat/call6.golden
@@ -1,5 +1,5 @@
 `{
-  "Model": "gpt-4-turbo-preview",
+  "Model": "gpt-4-turbo",
   "InternalSystemPrompt": null,
   "Tools": [
     {

--- a/pkg/tests/testdata/TestContextSubChat/call7.golden
+++ b/pkg/tests/testdata/TestContextSubChat/call7.golden
@@ -1,5 +1,5 @@
 `{
-  "Model": "gpt-4-turbo-preview",
+  "Model": "gpt-4-turbo",
   "InternalSystemPrompt": false,
   "Tools": [
     {

--- a/pkg/tests/testdata/TestContextSubChat/call8.golden
+++ b/pkg/tests/testdata/TestContextSubChat/call8.golden
@@ -1,5 +1,5 @@
 `{
-  "Model": "gpt-4-turbo-preview",
+  "Model": "gpt-4-turbo",
   "InternalSystemPrompt": false,
   "Tools": [
     {

--- a/pkg/tests/testdata/TestContextSubChat/call9.golden
+++ b/pkg/tests/testdata/TestContextSubChat/call9.golden
@@ -1,5 +1,5 @@
 `{
-  "Model": "gpt-4-turbo-preview",
+  "Model": "gpt-4-turbo",
   "InternalSystemPrompt": null,
   "Tools": [
     {

--- a/pkg/tests/testdata/TestContextSubChat/step1.golden
+++ b/pkg/tests/testdata/TestContextSubChat/step1.golden
@@ -7,7 +7,7 @@
       "continuation": {
         "state": {
           "completion": {
-            "Model": "gpt-4-turbo-preview",
+            "Model": "gpt-4-turbo",
             "InternalSystemPrompt": null,
             "Tools": [
               {
@@ -76,7 +76,7 @@
               "state": {
                 "input": "Input to chatbot1",
                 "completion": {
-                  "Model": "gpt-4-turbo-preview",
+                  "Model": "gpt-4-turbo",
                   "InternalSystemPrompt": false,
                   "Tools": [
                     {

--- a/pkg/tests/testdata/TestContextSubChat/step2.golden
+++ b/pkg/tests/testdata/TestContextSubChat/step2.golden
@@ -7,7 +7,7 @@
       "state": {
         "input": "User 1",
         "completion": {
-          "Model": "gpt-4-turbo-preview",
+          "Model": "gpt-4-turbo",
           "InternalSystemPrompt": false,
           "Tools": null,
           "Messages": [

--- a/pkg/tests/testdata/TestContextSubChat/step3.golden
+++ b/pkg/tests/testdata/TestContextSubChat/step3.golden
@@ -7,7 +7,7 @@
       "state": {
         "input": "User 1",
         "completion": {
-          "Model": "gpt-4-turbo-preview",
+          "Model": "gpt-4-turbo",
           "InternalSystemPrompt": false,
           "Tools": null,
           "Messages": [
@@ -51,7 +51,7 @@
       "continuation": {
         "state": {
           "completion": {
-            "Model": "gpt-4-turbo-preview",
+            "Model": "gpt-4-turbo",
             "InternalSystemPrompt": null,
             "Tools": [
               {
@@ -120,7 +120,7 @@
               "state": {
                 "input": "Input to chatbot1 on resume",
                 "completion": {
-                  "Model": "gpt-4-turbo-preview",
+                  "Model": "gpt-4-turbo",
                   "InternalSystemPrompt": false,
                   "Tools": [
                     {

--- a/pkg/tests/testdata/TestContextSubChat/step4.golden
+++ b/pkg/tests/testdata/TestContextSubChat/step4.golden
@@ -7,7 +7,7 @@
       "state": {
         "input": "User 1",
         "completion": {
-          "Model": "gpt-4-turbo-preview",
+          "Model": "gpt-4-turbo",
           "InternalSystemPrompt": false,
           "Tools": null,
           "Messages": [

--- a/pkg/tests/testdata/TestCwd/call1.golden
+++ b/pkg/tests/testdata/TestCwd/call1.golden
@@ -1,5 +1,5 @@
 `{
-  "Model": "gpt-4-turbo-preview",
+  "Model": "gpt-4-turbo",
   "InternalSystemPrompt": null,
   "Tools": [
     {

--- a/pkg/tests/testdata/TestCwd/call2.golden
+++ b/pkg/tests/testdata/TestCwd/call2.golden
@@ -1,5 +1,5 @@
 `{
-  "Model": "gpt-4-turbo-preview",
+  "Model": "gpt-4-turbo",
   "InternalSystemPrompt": null,
   "Tools": [
     {

--- a/pkg/tests/testdata/TestCwd/call3.golden
+++ b/pkg/tests/testdata/TestCwd/call3.golden
@@ -1,5 +1,5 @@
 `{
-  "Model": "gpt-4-turbo-preview",
+  "Model": "gpt-4-turbo",
   "InternalSystemPrompt": null,
   "Tools": [
     {

--- a/pkg/tests/testdata/TestDualSubChat/call1.golden
+++ b/pkg/tests/testdata/TestDualSubChat/call1.golden
@@ -1,5 +1,5 @@
 `{
-  "Model": "gpt-4-turbo-preview",
+  "Model": "gpt-4-turbo",
   "InternalSystemPrompt": null,
   "Tools": [
     {

--- a/pkg/tests/testdata/TestDualSubChat/call2.golden
+++ b/pkg/tests/testdata/TestDualSubChat/call2.golden
@@ -1,5 +1,5 @@
 `{
-  "Model": "gpt-4-turbo-preview",
+  "Model": "gpt-4-turbo",
   "InternalSystemPrompt": false,
   "Tools": [
     {

--- a/pkg/tests/testdata/TestDualSubChat/call3.golden
+++ b/pkg/tests/testdata/TestDualSubChat/call3.golden
@@ -1,5 +1,5 @@
 `{
-  "Model": "gpt-4-turbo-preview",
+  "Model": "gpt-4-turbo",
   "InternalSystemPrompt": false,
   "Tools": [
     {

--- a/pkg/tests/testdata/TestDualSubChat/call4.golden
+++ b/pkg/tests/testdata/TestDualSubChat/call4.golden
@@ -1,5 +1,5 @@
 `{
-  "Model": "gpt-4-turbo-preview",
+  "Model": "gpt-4-turbo",
   "InternalSystemPrompt": false,
   "Tools": [
     {

--- a/pkg/tests/testdata/TestDualSubChat/call5.golden
+++ b/pkg/tests/testdata/TestDualSubChat/call5.golden
@@ -1,5 +1,5 @@
 `{
-  "Model": "gpt-4-turbo-preview",
+  "Model": "gpt-4-turbo",
   "InternalSystemPrompt": false,
   "Tools": [
     {

--- a/pkg/tests/testdata/TestDualSubChat/call6.golden
+++ b/pkg/tests/testdata/TestDualSubChat/call6.golden
@@ -1,5 +1,5 @@
 `{
-  "Model": "gpt-4-turbo-preview",
+  "Model": "gpt-4-turbo",
   "InternalSystemPrompt": false,
   "Tools": [
     {

--- a/pkg/tests/testdata/TestDualSubChat/call7.golden
+++ b/pkg/tests/testdata/TestDualSubChat/call7.golden
@@ -1,5 +1,5 @@
 `{
-  "Model": "gpt-4-turbo-preview",
+  "Model": "gpt-4-turbo",
   "InternalSystemPrompt": null,
   "Tools": [
     {

--- a/pkg/tests/testdata/TestDualSubChat/step1.golden
+++ b/pkg/tests/testdata/TestDualSubChat/step1.golden
@@ -7,7 +7,7 @@
       "state": {
         "input": "User 1",
         "completion": {
-          "Model": "gpt-4-turbo-preview",
+          "Model": "gpt-4-turbo",
           "InternalSystemPrompt": null,
           "Tools": [
             {
@@ -113,7 +113,7 @@
             "state": {
               "input": "Input to chatbot1",
               "completion": {
-                "Model": "gpt-4-turbo-preview",
+                "Model": "gpt-4-turbo",
                 "InternalSystemPrompt": false,
                 "Tools": [
                   {
@@ -179,7 +179,7 @@
             "state": {
               "input": "Input to chatbot2",
               "completion": {
-                "Model": "gpt-4-turbo-preview",
+                "Model": "gpt-4-turbo",
                 "InternalSystemPrompt": false,
                 "Tools": [
                   {

--- a/pkg/tests/testdata/TestDualSubChat/step2.golden
+++ b/pkg/tests/testdata/TestDualSubChat/step2.golden
@@ -7,7 +7,7 @@
       "state": {
         "input": "User 1",
         "completion": {
-          "Model": "gpt-4-turbo-preview",
+          "Model": "gpt-4-turbo",
           "InternalSystemPrompt": null,
           "Tools": [
             {
@@ -120,7 +120,7 @@
             "state": {
               "input": "Input to chatbot2",
               "completion": {
-                "Model": "gpt-4-turbo-preview",
+                "Model": "gpt-4-turbo",
                 "InternalSystemPrompt": false,
                 "Tools": [
                   {

--- a/pkg/tests/testdata/TestDualSubChat/step3.golden
+++ b/pkg/tests/testdata/TestDualSubChat/step3.golden
@@ -7,7 +7,7 @@
       "state": {
         "input": "User 1",
         "completion": {
-          "Model": "gpt-4-turbo-preview",
+          "Model": "gpt-4-turbo",
           "InternalSystemPrompt": null,
           "Tools": [
             {
@@ -120,7 +120,7 @@
             "state": {
               "input": "Input to chatbot2",
               "completion": {
-                "Model": "gpt-4-turbo-preview",
+                "Model": "gpt-4-turbo",
                 "InternalSystemPrompt": false,
                 "Tools": [
                   {

--- a/pkg/tests/testdata/TestExport/call1.golden
+++ b/pkg/tests/testdata/TestExport/call1.golden
@@ -1,5 +1,5 @@
 `{
-  "Model": "gpt-4-turbo-preview",
+  "Model": "gpt-4-turbo",
   "InternalSystemPrompt": null,
   "Tools": [
     {

--- a/pkg/tests/testdata/TestExport/call2.golden
+++ b/pkg/tests/testdata/TestExport/call2.golden
@@ -1,5 +1,5 @@
 `{
-  "Model": "gpt-4-turbo-preview",
+  "Model": "gpt-4-turbo",
   "InternalSystemPrompt": null,
   "Tools": null,
   "Messages": [

--- a/pkg/tests/testdata/TestExport/call3.golden
+++ b/pkg/tests/testdata/TestExport/call3.golden
@@ -1,5 +1,5 @@
 `{
-  "Model": "gpt-4-turbo-preview",
+  "Model": "gpt-4-turbo",
   "InternalSystemPrompt": null,
   "Tools": [
     {

--- a/pkg/tests/testdata/TestExportContext/call1.golden
+++ b/pkg/tests/testdata/TestExportContext/call1.golden
@@ -1,5 +1,5 @@
 `{
-  "Model": "gpt-4-turbo-preview",
+  "Model": "gpt-4-turbo",
   "InternalSystemPrompt": null,
   "Tools": [
     {

--- a/pkg/tests/testdata/TestSubChat/call1.golden
+++ b/pkg/tests/testdata/TestSubChat/call1.golden
@@ -1,5 +1,5 @@
 `{
-  "Model": "gpt-4-turbo-preview",
+  "Model": "gpt-4-turbo",
   "InternalSystemPrompt": null,
   "Tools": [
     {

--- a/pkg/tests/testdata/TestSubChat/call2.golden
+++ b/pkg/tests/testdata/TestSubChat/call2.golden
@@ -1,5 +1,5 @@
 `{
-  "Model": "gpt-4-turbo-preview",
+  "Model": "gpt-4-turbo",
   "InternalSystemPrompt": false,
   "Tools": null,
   "Messages": [

--- a/pkg/tests/testdata/TestSubChat/call3.golden
+++ b/pkg/tests/testdata/TestSubChat/call3.golden
@@ -1,5 +1,5 @@
 `{
-  "Model": "gpt-4-turbo-preview",
+  "Model": "gpt-4-turbo",
   "InternalSystemPrompt": false,
   "Tools": null,
   "Messages": [


### PR DESCRIPTION
Update the default model to `gpt-4-turbo` (`gpt-4-turbo-2024-04-09`), which is newer than the present default `gpt-4-turbo-preview` (`gpt-4-0125-preview`).

Depends on https://github.com/gptscript-ai/chat-completion-client/pull/1
