### PR TITLE
fix: stop discarding first line shebangs

### DIFF
--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -372,11 +372,6 @@ func parse(input io.Reader) ([]Node, error) {
 		}
 
 		if !context.inBody {
-			// If the very first line is #! just skip because this is a unix interpreter declaration
-			if strings.HasPrefix(line, "#!") && lineNo == 1 {
-				continue
-			}
-
 			// This is a comment
 			if strings.HasPrefix(line, "#") && !strings.HasPrefix(line, "#!") {
 				continue

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -131,3 +131,21 @@ name: bad
 		}}},
 	}}).Equal(t, out)
 }
+
+func TestParseFirstLineShebang(t *testing.T) {
+	var input = `#!/usr/bin/env sh
+echo "hello"
+`
+	out, err := Parse(strings.NewReader(input), Options{
+		AssignGlobals: true,
+	})
+	require.NoError(t, err)
+	autogold.Expect(Document{Nodes: []Node{
+		{ToolNode: &ToolNode{
+			Tool: types.Tool{
+				Instructions: "#!/usr/bin/env sh\necho \"hello\"",
+				Source:       types.ToolSource{LineNo: 1},
+			},
+		}},
+	}}).Equal(t, out)
+}


### PR DESCRIPTION
The code explicitly discards the first line of a gptscript file if it starts with a shebang. However, if the first line is blank, then the shebang is kept as expected.

This is inconsistent behavior that this change attempts to rectify.