### PR TITLE
chore: prevent panics on invalid state input

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -331,6 +331,10 @@ func (e *Engine) complete(ctx context.Context, state *State) (*Return, error) {
 }
 
 func (e *Engine) Continue(ctx Context, state *State, results ...CallResult) (*Return, error) {
+	if state == nil {
+		return nil, fmt.Errorf("invalid continue call, missing state")
+	}
+
 	var added bool
 
 	state = &State{

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -479,6 +479,10 @@ func (r *Runner) resume(callCtx engine.Context, monitor Monitor, env []string, s
 		return nil, fmt.Errorf("invalid state, resume should not have StartContinuation set to true")
 	}
 
+	if state.Continuation == nil {
+		return nil, errors.New("invalid state, resume should have Continuation data")
+	}
+
 	progress, progressClose := streamProgress(&callCtx, monitor)
 	defer progressClose()
 


### PR DESCRIPTION
added just enough checks to prevent some panics on invalid chat state inputs encountered while investigating https://github.com/gptscript-ai/gptscript/issues/311