### PR TITLE
fix: print instructions last when fmt-ing

### DIFF
--- a/pkg/types/tool.go
+++ b/pkg/types/tool.go
@@ -267,15 +267,17 @@ func (t Tool) String() string {
 	if t.Parameters.InternalPrompt != nil {
 		_, _ = fmt.Fprintf(buf, "Internal Prompt: %v\n", *t.Parameters.InternalPrompt)
 	}
-	if t.Instructions != "" && t.BuiltinFunc == nil {
-		_, _ = fmt.Fprintln(buf)
-		_, _ = fmt.Fprintln(buf, t.Instructions)
-	}
 	if len(t.Parameters.Credentials) > 0 {
 		_, _ = fmt.Fprintf(buf, "Credentials: %s\n", strings.Join(t.Parameters.Credentials, ", "))
 	}
 	if t.Chat {
 		_, _ = fmt.Fprintf(buf, "Chat: true\n")
+	}
+
+	// Instructions should be printed last
+	if t.Instructions != "" && t.BuiltinFunc == nil {
+		_, _ = fmt.Fprintln(buf)
+		_, _ = fmt.Fprintln(buf, t.Instructions)
 	}
 
 	return buf.String()


### PR DESCRIPTION
If instructions are not printed last, then anything printed after the instruction is parsed as instructions. For example:

```
Hello, how are you?
Chat: true
```

would not be parsed as a chat tool.

This change will ensure that things that are fmt-ed will also be parsed the same way.