### PR TITLE
fix: tool names should be used instead of filename

### DIFF
--- a/pkg/loader/loader.go
+++ b/pkg/loader/loader.go
@@ -242,7 +242,7 @@ func link(ctx context.Context, cache *cache.Client, prg *types.Program, base *so
 			tool.ToolMapping[targetToolName] = linkedTool.ID
 			toolNames[targetToolName] = struct{}{}
 		} else {
-			toolName, subTool := SplitToolRef(targetToolName)
+			toolName, subTool := types.SplitToolRef(targetToolName)
 			resolvedTool, err := resolve(ctx, cache, prg, base, toolName, subTool)
 			if err != nil {
 				return types.Tool{}, fmt.Errorf("failed resolving %s at %s: %w", targetToolName, base, err)
@@ -295,7 +295,7 @@ func Program(ctx context.Context, name, subToolName string, opts ...Options) (ty
 	opt := complete(opts...)
 
 	if subToolName == "" {
-		name, subToolName = SplitToolRef(name)
+		name, subToolName = types.SplitToolRef(name)
 	}
 	prg := types.Program{
 		Name:    name,
@@ -344,24 +344,6 @@ func input(ctx context.Context, cache *cache.Client, base *source, name string) 
 	}
 
 	return nil, fmt.Errorf("can not load tools path=%s name=%s", base.Path, name)
-}
-
-func SplitToolRef(targetToolName string) (toolName, subTool string) {
-	var (
-		fields = strings.Fields(targetToolName)
-		idx    = slices.Index(fields, "from")
-	)
-
-	defer func() {
-		toolName, _ = types.SplitArg(toolName)
-	}()
-
-	if idx == -1 {
-		return strings.TrimSpace(targetToolName), ""
-	}
-
-	return strings.Join(fields[idx+1:], " "),
-		strings.Join(fields[:idx], " ")
 }
 
 func isOpenAPI(data []byte) bool {

--- a/pkg/loader/loader_test.go
+++ b/pkg/loader/loader_test.go
@@ -99,11 +99,3 @@ func TestHelloWorld(t *testing.T) {
   }
 }`, "MODEL", openai.DefaultModel)).Equal(t, toString(prg))
 }
-
-func TestParse(t *testing.T) {
-	tool, subTool := SplitToolRef("a from b with x")
-	autogold.Expect([]string{"b", "a"}).Equal(t, []string{tool, subTool})
-
-	tool, subTool = SplitToolRef("a with x")
-	autogold.Expect([]string{"a", ""}).Equal(t, []string{tool, subTool})
-}

--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -46,7 +46,7 @@ func (c *Client) Call(ctx context.Context, messageRequest types.CompletionReques
 		return nil, fmt.Errorf("failed to find remote model %s", messageRequest.Model)
 	}
 
-	_, modelName := loader.SplitToolRef(messageRequest.Model)
+	_, modelName := types.SplitToolRef(messageRequest.Model)
 	messageRequest.Model = modelName
 	return client.Call(ctx, messageRequest, status)
 }
@@ -71,7 +71,7 @@ func (c *Client) ListModels(ctx context.Context, providers ...string) (result []
 }
 
 func (c *Client) Supports(ctx context.Context, modelName string) (bool, error) {
-	toolName, modelNameSuffix := loader.SplitToolRef(modelName)
+	toolName, modelNameSuffix := types.SplitToolRef(modelName)
 	if modelNameSuffix == "" {
 		return false, nil
 	}

--- a/pkg/types/toolname_test.go
+++ b/pkg/types/toolname_test.go
@@ -10,4 +10,16 @@ func TestToolNormalizer(t *testing.T) {
 	autogold.Expect("bobTool").Equal(t, ToolNormalizer("bob-tool"))
 	autogold.Expect("bobTool").Equal(t, ToolNormalizer("bob_tool"))
 	autogold.Expect("bobTool").Equal(t, ToolNormalizer("BOB tOOL"))
+	autogold.Expect("barList").Equal(t, ToolNormalizer("bar_list from ./foo.yaml"))
+	autogold.Expect("barList").Equal(t, ToolNormalizer("bar_list from ./foo.gpt"))
+	autogold.Expect("write").Equal(t, ToolNormalizer("sys.write"))
+	autogold.Expect("gpt4VVision").Equal(t, ToolNormalizer("github.com/gptscript-ai/gpt4-v-vision"))
+}
+
+func TestParse(t *testing.T) {
+	tool, subTool := SplitToolRef("a from b with x")
+	autogold.Expect([]string{"b", "a"}).Equal(t, []string{tool, subTool})
+
+	tool, subTool = SplitToolRef("a with x")
+	autogold.Expect([]string{"a", ""}).Equal(t, []string{tool, subTool})
 }


### PR DESCRIPTION
Uses the toolname before the from otherwise it was using the filename and appending numbers losing context.