### PR TITLE
fix: do not lowercase all items in tool(like) lists

### DIFF
--- a/pkg/chat/chat.go
+++ b/pkg/chat/chat.go
@@ -41,6 +41,8 @@ func Start(ctx context.Context, prevState runner.ChatState, chatter Chatter, prg
 	}
 	defer prompter.Close()
 
+	// We will want the tool name to be displayed in the prompt
+	var prevResp runner.ChatResponse
 	for {
 		var (
 			input string
@@ -53,7 +55,7 @@ func Start(ctx context.Context, prevState runner.ChatState, chatter Chatter, prg
 			return err
 		}
 
-		prompter.SetPrompt(getPrompt(prg, resp))
+		prompter.SetPrompt(getPrompt(prg, prevResp))
 
 		if startInput != "" {
 			input = startInput
@@ -79,5 +81,6 @@ func Start(ctx context.Context, prevState runner.ChatState, chatter Chatter, prg
 		}
 
 		prevState = resp.State
+		prevResp = resp
 	}
 }

--- a/pkg/loader/github/github.go
+++ b/pkg/loader/github/github.go
@@ -41,7 +41,7 @@ func getCommitLsRemote(ctx context.Context, account, repo, ref string) (string, 
 }
 
 // regexp to match a git commit id
-var commitRegexp = regexp.MustCompile("^[a-f0-9]{40}$")
+var commitRegexp = regexp.MustCompile("^[a-z0-9]{40}$")
 
 func getCommit(ctx context.Context, account, repo, ref string) (string, error) {
 	if commitRegexp.MatchString(ref) {

--- a/pkg/loader/github/github.go
+++ b/pkg/loader/github/github.go
@@ -41,7 +41,7 @@ func getCommitLsRemote(ctx context.Context, account, repo, ref string) (string, 
 }
 
 // regexp to match a git commit id
-var commitRegexp = regexp.MustCompile("^[a-z0-9]{40}$")
+var commitRegexp = regexp.MustCompile("^[a-f0-9]{40}$")
 
 func getCommit(ctx context.Context, account, repo, ref string) (string, error) {
 	if commitRegexp.MatchString(ref) {

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -101,15 +101,15 @@ func isParam(line string, tool *types.Tool) (_ bool, err error) {
 		}
 		tool.Parameters.Chat = v
 	case "export":
-		tool.Parameters.Export = append(tool.Parameters.Export, csv(strings.ToLower(value))...)
+		tool.Parameters.Export = append(tool.Parameters.Export, csv(value)...)
 	case "tool", "tools":
-		tool.Parameters.Tools = append(tool.Parameters.Tools, csv(strings.ToLower(value))...)
+		tool.Parameters.Tools = append(tool.Parameters.Tools, csv(value)...)
 	case "globaltool", "globaltools":
-		tool.Parameters.GlobalTools = append(tool.Parameters.GlobalTools, csv(strings.ToLower(value))...)
+		tool.Parameters.GlobalTools = append(tool.Parameters.GlobalTools, csv(value)...)
 	case "exportcontext":
-		tool.Parameters.ExportContext = append(tool.Parameters.ExportContext, csv(strings.ToLower(value))...)
+		tool.Parameters.ExportContext = append(tool.Parameters.ExportContext, csv(value)...)
 	case "context":
-		tool.Parameters.Context = append(tool.Parameters.Context, csv(strings.ToLower(value))...)
+		tool.Parameters.Context = append(tool.Parameters.Context, csv(value)...)
 	case "args", "arg", "param", "params", "parameters", "parameter":
 		if err := addArg(value, tool); err != nil {
 			return false, err

--- a/pkg/tests/testdata/TestCase/call1.golden
+++ b/pkg/tests/testdata/TestCase/call1.golden
@@ -5,7 +5,7 @@
     {
       "function": {
         "toolID": "testdata/TestCase/test.gpt:6",
-        "name": "bob",
+        "name": "Bob",
         "description": "I'm Bob, a friendly guy.",
         "parameters": {
           "properties": {

--- a/pkg/tests/testdata/TestCase2/call1.golden
+++ b/pkg/tests/testdata/TestCase2/call1.golden
@@ -5,7 +5,7 @@
     {
       "function": {
         "toolID": "testdata/TestCase2/test.gpt:6",
-        "name": "bob",
+        "name": "Bob",
         "description": "I'm Bob, a friendly guy.",
         "parameters": {
           "properties": {


### PR DESCRIPTION
When importing things from github or other case sensitive location the previous functionality would lowercase everything causing clones from VCS to fail.

This fix removes the calls to lowercase tools and contexts along with the other places they occur.