### PR TITLE
docs: improve sentiments example model compatibility

### DIFF
--- a/examples/sentiments.gpt
+++ b/examples/sentiments.gpt
@@ -1,11 +1,8 @@
 tools: github.com/gptscript-ai/browser, sentiments
 description: get the sentiments expressed in a tweet
-args: url: URL of the tweet to analyze
+parameters: url: URL of the tweet to analyze
 
-Perform the actions in the following order:
-
-Get the text of the tweet referenced by $url.
-Then, analyze the sentiments expressed in this tweet.
+Get the text of the tweet at ${url}. After getting the text, get its sentiments.
 
 ---
 name: sentiments


### PR DESCRIPTION
# Description

Re-engineer the `sentiments.gpt` example tool body prompt wording so that it works with `claude-3-opus` and `gemini-1.5`.

## Notes

- The existing prompt is useful in identifying the shortcomings of these LLMs, so it may be useful to keep around in some capacity.
- `claude-3-opus` is interesting because it, along with `gpt-4-turbo` and `gpt-4o`, are capable of inferring the necessary sequence of chained tool calls and come to the correct result with a prompt as basic as `Get the sentiments of the tweet at ${url}.`. For that same basic prompt, `gemini-1.5` fails to chain functions at all and just immediately calls `sentiments` with hallucinated text.
