### PR TITLE
feat: add chat-ui option

### DIFF
--- a/pkg/cli/eval.go
+++ b/pkg/cli/eval.go
@@ -79,7 +79,7 @@ func (e *Eval) Run(cmd *cobra.Command, args []string) error {
 		}, os.Environ(), toolInput)
 	}
 
-	toolOutput, err := runner.Run(cmd.Context(), prg, os.Environ(), toolInput)
+	toolOutput, err := runner.Run(cmd.Context(), prg, opts.Env, toolInput)
 	if err != nil {
 		return err
 	}

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -12,6 +12,14 @@ func execEquals(bin, check string) bool {
 		bin == check+".exe"
 }
 
+func VarOrDefault(key, defaultValue string) string {
+	if val := os.Getenv(key); val != "" {
+		return val
+	}
+
+	return defaultValue
+}
+
 func ToEnvLike(v string) string {
 	v = strings.ReplaceAll(v, ".", "_")
 	v = strings.ReplaceAll(v, "-", "_")


### PR DESCRIPTION
The chat UI option is sugar to launch the chat-builder tool. If the user enables the chat-ui option, then the appropriate setup is done to launch the chat-builder UI tool for the user. If the a file is provided, then the UI should launch to the "run" UI and the user can chat with the provided tool. If no file is provided, then the "browse" UI is opened and the user can decide what to do.

The most important secondary option is the --chdir option. If the user provides a file, then the current directory will be set to the directory where that file exists. If the user provides the --chdir option, then the file path should be absolute or relative to this chdir.