### PR TITLE
chore: generate shell completions on brew install

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -60,6 +60,7 @@ brews:
   - description: "GPTScript CLI"
     install: |
       bin.install "gptscript"
+      generate_completions_from_executable(bin/"gptscript", "completion", shells: [:bash, :zsh, :fish])
     homepage: "https://github.com/gptscript-ai/gptscript"
     skip_upload: false
     folder: "Formula"


### PR DESCRIPTION
Update goreleaser homebrew tap config to generate shell completions for `gptscript` on install.