### PR TITLE
Remove gen-docs make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,8 +42,5 @@ validate: tidy lint
 ci: build
 	./bin/gptscript ./scripts/ci.gpt
 
-gen-docs: build
-	./bin/gptscript ./scripts/gen-docs.gpt
-
 serve-docs:
 	(cd docs && npm i && npm start)


### PR DESCRIPTION
The target is broken - it is calling a gptscript that was deleted awhile
ago. We probably do want a new version of gen-docs, but this isn't it.
So, I'm deleting it for now.

Signed-off-by: Craig Jellick <craig@acorn.io>
