### PR TITLE
fix: do not add readOnly fields to the requestBody

### DIFF
--- a/pkg/loader/openapi.go
+++ b/pkg/loader/openapi.go
@@ -199,6 +199,12 @@ func getOpenAPITools(t *openapi3.T, defaultHost string) ([]types.Tool, error) {
 						arg.Description = content.Schema.Value.Description
 					}
 
+					// Read Only can not be sent in the request body, so we remove it
+					for key, property := range arg.Properties {
+						if property.Value.ReadOnly {
+							delete(arg.Properties, key)
+						}
+					}
 					// Unfortunately, the request body doesn't contain any good descriptor for it,
 					// so we just use "requestBodyContent" as the name of the arg.
 					tool.Parameters.Arguments.Properties["requestBodyContent"] = &openapi3.SchemaRef{Value: arg}


### PR DESCRIPTION
According to the spec readOnly fields SHOULD NOT be sent in the request, but maybe present in the response. The LLM has made several errors making calls when these fields are present by including the readOnly fields in the request and getting HTTP 422's.

This change loops through the args, and drops readOnly fields from the requestBodyContent arg on the tool.