### PR TITLE
fix: use random available port by default

### DIFF
--- a/pkg/cli/gptscript.go
+++ b/pkg/cli/gptscript.go
@@ -59,7 +59,7 @@ type GPTScript struct {
 	ListModels         bool   `usage:"List the models available and exit" local:"true"`
 	ListTools          bool   `usage:"List built-in tools and exit" local:"true"`
 	Server             bool   `usage:"Start server" local:"true"`
-	ListenAddress      string `usage:"Server listen address" default:"127.0.0.1:9090" local:"true"`
+	ListenAddress      string `usage:"Server listen address" default:"127.0.0.1:0" local:"true"`
 	Chdir              string `usage:"Change current working directory" short:"C"`
 	Daemon             bool   `usage:"Run tool as a daemon" local:"true" hidden:"true"`
 	Ports              string `usage:"The port range to use for ephemeral daemon ports (ex: 11000-12000)" hidden:"true"`

--- a/pkg/sdkserver/routes.go
+++ b/pkg/sdkserver/routes.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -165,7 +164,14 @@ func (s *server) execHandler(w http.ResponseWriter, r *http.Request) {
 
 	reqObject.Env = append(os.Environ(), reqObject.Env...)
 	// Don't overwrite the PromptURLEnvVar if it is already set in the environment.
-	if !slices.ContainsFunc(reqObject.Env, func(s string) bool { return strings.HasPrefix(s, types.PromptTokenEnvVar+"=") }) {
+	var promptTokenAlreadySet bool
+	for _, env := range reqObject.Env {
+		if strings.HasPrefix(env, types.PromptTokenEnvVar+"=") {
+			promptTokenAlreadySet = true
+			break
+		}
+	}
+	if !promptTokenAlreadySet {
 		// Append a prompt URL for this run.
 		reqObject.Env = append(reqObject.Env, fmt.Sprintf("%s=http://%s/prompt/%s", types.PromptURLEnvVar, s.address, runID), fmt.Sprintf("%s=%s", types.PromptTokenEnvVar, s.token))
 	}


### PR DESCRIPTION
Instead of using a default port of 9090, this change will set the port for the various servers to a random available port.