### PR TITLE
chore: support sending ToolDefs as JSON in sdkserver

### DIFF
--- a/pkg/sdkserver/routes.go
+++ b/pkg/sdkserver/routes.go
@@ -85,7 +85,7 @@ func (s *server) listTools(w http.ResponseWriter, r *http.Request) {
 		} else if reqObject.File != "" {
 			prg, err = loader.Program(r.Context(), reqObject.File, reqObject.SubTool, loader.Options{Cache: s.client.Cache})
 		} else {
-			prg, err = loader.ProgramFromSource(r.Context(), reqObject.ToolDef.String(), reqObject.SubTool, loader.Options{Cache: s.client.Cache})
+			prg, err = loader.ProgramFromSource(r.Context(), reqObject.ToolDefs.String(), reqObject.SubTool, loader.Options{Cache: s.client.Cache})
 		}
 		if err != nil {
 			writeError(logger, w, http.StatusInternalServerError, fmt.Errorf("failed to load program: %w", err))
@@ -178,7 +178,7 @@ func (s *server) execHandler(w http.ResponseWriter, r *http.Request) {
 
 	logger.Debugf("executing tool: %+v", reqObject)
 	var (
-		def           fmt.Stringer = &reqObject.ToolDef
+		def           fmt.Stringer = &reqObject.ToolDefs
 		programLoader loaderFunc   = loader.ProgramFromSource
 	)
 	if reqObject.Content != "" {

--- a/pkg/sdkserver/types.go
+++ b/pkg/sdkserver/types.go
@@ -2,6 +2,7 @@ package sdkserver
 
 import (
 	"maps"
+	"strings"
 	"time"
 
 	"github.com/gptscript-ai/gptscript/pkg/cache"
@@ -25,12 +26,26 @@ const (
 	Prompt      runner.EventType = "prompt"
 )
 
+type toolDefs []types.ToolDef
+
+func (t toolDefs) String() string {
+	s := new(strings.Builder)
+	for i, tool := range t {
+		s.WriteString(tool.String())
+		if i != len(t)-1 {
+			s.WriteString("\n\n---\n\n")
+		}
+	}
+
+	return s.String()
+}
+
 type toolOrFileRequest struct {
-	cache.Options `json:",inline"`
-	types.ToolDef `json:",inline"`
 	content       `json:",inline"`
 	file          `json:",inline"`
+	cache.Options `json:",inline"`
 
+	ToolDefs          toolDefs `json:"toolDefs,inline"`
 	SubTool           string   `json:"subTool"`
 	Input             string   `json:"input"`
 	ChatState         string   `json:"chatState"`


### PR DESCRIPTION
This change allows the removal of the "to string" functions/methods in the SDKs.