### PR TITLE
fix: use entire env for credential prompting

### DIFF
--- a/pkg/gptscript/gptscript.go
+++ b/pkg/gptscript/gptscript.go
@@ -58,6 +58,9 @@ func complete(opts *Options) (result *Options) {
 	if len(result.Env) == 0 {
 		result.Env = os.Environ()
 	}
+	if result.CredentialContext == "" {
+		opts.CredentialContext = "default"
+	}
 	return
 }
 
@@ -107,9 +110,10 @@ func New(opts *Options) (*GPTScript, error) {
 		closeServer()
 		return nil, err
 	}
-	oaiClient.SetEnvs(extraEnv)
+	opts.Env = append(opts.Env, extraEnv...)
+	oaiClient.SetEnvs(opts.Env)
 
-	remoteClient := remote.New(runner, extraEnv, cacheClient, cliCfg, opts.CredentialContext)
+	remoteClient := remote.New(runner, opts.Env, cacheClient, cliCfg, opts.CredentialContext)
 	if err := registry.AddClient(remoteClient); err != nil {
 		closeServer()
 		return nil, err


### PR DESCRIPTION
If the URL and token environment variable are set outside gptscript, then the credential prompting tool needs those variables. In this case, the extraEnv is nil and doesn't allow prompting to work.

Additionally, the credential context default is needed when completing the opts for the SDK server.