### PR TITLE
fix: pass ExtraEnv to tui

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/google/uuid v1.6.0
 	github.com/gptscript-ai/chat-completion-client v0.0.0-20240531200700-af8e7ecf0379
-	github.com/gptscript-ai/tui v0.0.0-20240604233332-4a5ff43cdc58
+	github.com/gptscript-ai/tui v0.0.0-20240605185737-d36cdf2ed691
 	github.com/hexops/autogold/v2 v2.2.1
 	github.com/hexops/valast v1.4.4
 	github.com/jaytaylor/html2text v0.0.0-20230321000545-74c2419ad056

--- a/go.sum
+++ b/go.sum
@@ -175,8 +175,8 @@ github.com/gptscript-ai/chat-completion-client v0.0.0-20240531200700-af8e7ecf037
 github.com/gptscript-ai/chat-completion-client v0.0.0-20240531200700-af8e7ecf0379/go.mod h1:7P/o6/IWa1KqsntVf68hSnLKuu3+xuqm6lYhch1w4jo=
 github.com/gptscript-ai/go-gptscript v0.0.0-20240604231423-7a845df843b1 h1:SHoqsU8Ne2V4zfrFve9kQn4vcv4N4TItD6Oju+pzKV8=
 github.com/gptscript-ai/go-gptscript v0.0.0-20240604231423-7a845df843b1/go.mod h1:h1yYzC0rgB5Kk7lwdba+Xs6cWkuJfLq6sPRna45OVG0=
-github.com/gptscript-ai/tui v0.0.0-20240604233332-4a5ff43cdc58 h1:kbr6cY4VdvxAfJf+xk6x/gxDzmgZMkX2ZfLcyskGYsw=
-github.com/gptscript-ai/tui v0.0.0-20240604233332-4a5ff43cdc58/go.mod h1:At6zmCk0XrJ2J1yo95fzbEDOGwaPPEMwxxcQGJx7IGE=
+github.com/gptscript-ai/tui v0.0.0-20240605185737-d36cdf2ed691 h1:7F0s0xY6bm5GfsjMldmcw07f+Ph9cQEcFQywu9CIYZA=
+github.com/gptscript-ai/tui v0.0.0-20240605185737-d36cdf2ed691/go.mod h1:At6zmCk0XrJ2J1yo95fzbEDOGwaPPEMwxxcQGJx7IGE=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=

--- a/pkg/cli/gptscript.go
+++ b/pkg/cli/gptscript.go
@@ -459,6 +459,7 @@ func (r *GPTScript) Run(cmd *cobra.Command, args []string) (retErr error) {
 				Workspace:           r.Workspace,
 				SaveChatStateFile:   r.SaveChatStateFile,
 				ChatState:           chatState,
+				ExtraEnv:            gptScript.ExtraEnv,
 			})
 		}
 		return chat.Start(cmd.Context(), chatState, gptScript, func() (types.Program, error) {

--- a/pkg/gptscript/gptscript.go
+++ b/pkg/gptscript/gptscript.go
@@ -32,7 +32,7 @@ type GPTScript struct {
 	Cache                  *cache.Client
 	WorkspacePath          string
 	DeleteWorkspaceOnClose bool
-	extraEnv               []string
+	ExtraEnv               []string
 	close                  func()
 }
 
@@ -125,7 +125,7 @@ func New(opts *Options) (*GPTScript, error) {
 		Cache:                  cacheClient,
 		WorkspacePath:          opts.Workspace,
 		DeleteWorkspaceOnClose: opts.Workspace == "",
-		extraEnv:               extraEnv,
+		ExtraEnv:               extraEnv,
 		close:                  closeServer,
 	}, nil
 }
@@ -147,7 +147,7 @@ func (g *GPTScript) getEnv(env []string) ([]string, error) {
 	if err := os.MkdirAll(g.WorkspacePath, 0700); err != nil {
 		return nil, err
 	}
-	return slices.Concat(g.extraEnv, []string{
+	return slices.Concat(g.ExtraEnv, []string{
 		fmt.Sprintf("GPTSCRIPT_WORKSPACE_DIR=%s", g.WorkspacePath),
 		fmt.Sprintf("GPTSCRIPT_WORKSPACE_ID=%s", hash.ID(g.WorkspacePath)),
 	}, env), nil


### PR DESCRIPTION
Passing these extra environment variables allows the tui to know that it doesn't need to handle prompting the user, and gptscript will handle it.