### PR TITLE
chore: bump kin-openapi dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/docker/cli v26.0.0+incompatible
 	github.com/docker/docker-credential-helpers v0.8.1
 	github.com/fatih/color v1.17.0
-	github.com/getkin/kin-openapi v0.123.0
+	github.com/getkin/kin-openapi v0.124.0
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/google/uuid v1.6.0
 	github.com/gptscript-ai/chat-completion-client v0.0.0-20240531200700-af8e7ecf0379

--- a/go.sum
+++ b/go.sum
@@ -114,8 +114,8 @@ github.com/frankban/quicktest v1.14.3/go.mod h1:mgiwOwqx65TmIk1wJ6Q7wvnVMocbUork
 github.com/frankban/quicktest v1.14.4/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
-github.com/getkin/kin-openapi v0.123.0 h1:zIik0mRwFNLyvtXK274Q6ut+dPh6nlxBp0x7mNrPhs8=
-github.com/getkin/kin-openapi v0.123.0/go.mod h1:wb1aSZA/iWmorQP9KTAS/phLj/t17B5jT7+fS8ed9NM=
+github.com/getkin/kin-openapi v0.124.0 h1:VSFNMB9C9rTKBnQ/fpyDU8ytMTr4dWI9QovSKj9kz/M=
+github.com/getkin/kin-openapi v0.124.0/go.mod h1:wb1aSZA/iWmorQP9KTAS/phLj/t17B5jT7+fS8ed9NM=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-openapi/jsonpointer v0.20.2 h1:mQc3nmndL8ZBzStEo3JYF8wzmeWffDH4VbXz58sAx6Q=

--- a/pkg/loader/openapi.go
+++ b/pkg/loader/openapi.go
@@ -136,7 +136,7 @@ func getOpenAPITools(t *openapi3.T, defaultHost string) ([]types.Tool, error) {
 						Name:        operation.OperationID,
 						Description: toolDesc,
 						Arguments: &openapi3.Schema{
-							Type:       "object",
+							Type:       &openapi3.Types{"object"},
 							Properties: openapi3.Schemas{},
 							Required:   []string{},
 						},

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -51,7 +51,7 @@ func csv(line string) (result []string) {
 func addArg(line string, tool *types.Tool) error {
 	if tool.Parameters.Arguments == nil {
 		tool.Parameters.Arguments = &openapi3.Schema{
-			Type:       "object",
+			Type:       &openapi3.Types{"object"},
 			Properties: openapi3.Schemas{},
 		}
 	}
@@ -64,7 +64,7 @@ func addArg(line string, tool *types.Tool) error {
 	tool.Parameters.Arguments.Properties[key] = &openapi3.SchemaRef{
 		Value: &openapi3.Schema{
 			Description: strings.TrimSpace(value),
-			Type:        "string",
+			Type:        &openapi3.Types{"string"},
 		},
 	}
 

--- a/pkg/system/prompt.go
+++ b/pkg/system/prompt.go
@@ -27,12 +27,12 @@ You don't move to the next step until you have a result.
 var DefaultPromptParameter = "defaultPromptParameter"
 
 var DefaultToolSchema = openapi3.Schema{
-	Type: "object",
+	Type: &openapi3.Types{"object"},
 	Properties: openapi3.Schemas{
 		DefaultPromptParameter: &openapi3.SchemaRef{
 			Value: &openapi3.Schema{
 				Description: "Prompt to send to the tool or assistant. This may be instructions or question.",
-				Type:        "string",
+				Type:        &openapi3.Types{"string"},
 			},
 		},
 	},

--- a/pkg/types/jsonschema.go
+++ b/pkg/types/jsonschema.go
@@ -6,7 +6,7 @@ import (
 
 func ObjectSchema(kv ...string) *openapi3.Schema {
 	s := &openapi3.Schema{
-		Type:       "object",
+		Type:       &openapi3.Types{"object"},
 		Properties: openapi3.Schemas{},
 	}
 	for i, v := range kv {
@@ -14,7 +14,7 @@ func ObjectSchema(kv ...string) *openapi3.Schema {
 			s.Properties[kv[i-1]] = &openapi3.SchemaRef{
 				Value: &openapi3.Schema{
 					Description: v,
-					Type:        "string",
+					Type:        &openapi3.Types{"string"},
 				},
 			}
 		}


### PR DESCRIPTION
Bumped our openapi dependency while writing the smoke test framework and noticed there's a breaking change. Since we need to do this eventually, I figured I should get this out of the way sooner.
