### PR TITLE
fix: give the remote client the full environment

### DIFF
--- a/pkg/gptscript/gptscript.go
+++ b/pkg/gptscript/gptscript.go
@@ -110,9 +110,11 @@ func New(opts *Options) (*GPTScript, error) {
 		closeServer()
 		return nil, err
 	}
-	oaiClient.SetEnvs(extraEnv)
 
-	remoteClient := remote.New(runner, extraEnv, cacheClient, cliCfg, opts.CredentialContext)
+	fullEnv := append(opts.Env, extraEnv...)
+	oaiClient.SetEnvs(fullEnv)
+
+	remoteClient := remote.New(runner, fullEnv, cacheClient, cliCfg, opts.CredentialContext)
 	if err := registry.AddClient(remoteClient); err != nil {
 		closeServer()
 		return nil, err

--- a/pkg/prompt/server.go
+++ b/pkg/prompt/server.go
@@ -14,18 +14,11 @@ import (
 )
 
 func NewServer(ctx context.Context, envs []string) ([]string, error) {
-	var extraEnvs []string
 	for _, env := range envs {
-		for _, prefix := range []string{types.PromptURLEnvVar, types.PromptTokenEnvVar} {
-			v, ok := strings.CutPrefix(env, prefix+"=")
-			if ok && v != "" {
-				extraEnvs = append(extraEnvs, env)
-			}
+		v, ok := strings.CutPrefix(env, types.PromptTokenEnvVar+"=")
+		if ok && v != "" {
+			return nil, nil
 		}
-	}
-
-	if len(extraEnvs) == 2 {
-		return extraEnvs, nil
 	}
 
 	l, err := net.Listen("tcp", "127.0.0.1:0")


### PR DESCRIPTION
This change will give the remote client the full environment instead of just the extra env vars. Doing this allows the provider tools to detect credentials and other environment variables set by the user or system.