### PR TITLE
fix: infinite loop while creating gptscript toolset based on name

### DIFF
--- a/pkg/types/toolname.go
+++ b/pkg/types/toolname.go
@@ -92,6 +92,6 @@ func PickToolName(toolName string, existing map[string]struct{}) string {
 			existing[testName] = struct{}{}
 			return testName
 		}
-		toolName += "0"
+		testName += "0"
 	}
 }


### PR DESCRIPTION
The tool names have to be unique, so if two tools are added with the same name, they have a 0 appended to them. In this case we got into an infinite loop because toolName was incremented not the variable under test. So we ended up in an infite loop.