### PR TITLE
fix: allow daemons on Windows

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -17,7 +17,6 @@ func SysDaemon() error {
 	}()
 
 	cmd := exec.CommandContext(ctx, os.Args[2], os.Args[3:]...)
-	cmd.Stdin = os.Stdin
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout
 	return cmd.Run()

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -43,7 +43,7 @@ func complete(opts *Options) (result *Options) {
 
 	result.ListenAddress = types.FirstSet(result.ListenAddress, result.ListenAddress)
 	if result.ListenAddress == "" {
-		result.ListenAddress = "127.0.0.1:9090"
+		result.ListenAddress = "127.0.0.1:0"
 	}
 
 	return


### PR DESCRIPTION
Windows won't allow the forked command to start while stdin is being held open. This means that daemons won't work on Windows. This fix bypasses this by not providing os.Stdin to the forked command.