### PR TITLE
fix: stop binding os.Stdin to sub commands

### DIFF
--- a/pkg/engine/cmd.go
+++ b/pkg/engine/cmd.go
@@ -73,7 +73,6 @@ func (e *Engine) runCommand(ctx Context, tool types.Tool, input string, toolCate
 
 	output := &bytes.Buffer{}
 	all := &bytes.Buffer{}
-	cmd.Stdin = os.Stdin
 	cmd.Stderr = io.MultiWriter(all, os.Stderr)
 	cmd.Stdout = io.MultiWriter(all, output)
 


### PR DESCRIPTION
Binding os.Stdin, which will not be closed in gptscript, causes issues with Windows because the subcommand will wait for stdin to be closed before launching. Since we are not using stdin with subcommands, this binding can safely be removed.