### PR TITLE
chore: ensure gptscript stack uses the same binary

### DIFF
--- a/pkg/cli/gptscript.go
+++ b/pkg/cli/gptscript.go
@@ -221,7 +221,7 @@ func (r *GPTScript) PersistentPre(*cobra.Command, []string) error {
 		}
 	}
 
-	_ = os.Setenv("GPTSCRIPT_BIN", system.Bin())
+	_ = os.Setenv(system.BinEnvVar, system.Bin())
 
 	if r.DefaultModel != "" {
 		builtin.SetDefaultModel(r.DefaultModel)
@@ -344,6 +344,9 @@ func (r *GPTScript) Run(cmd *cobra.Command, args []string) (retErr error) {
 			}
 
 			gptOpt.Env = append(gptOpt.Env, "SCRIPTS_PATH="+filepath.Dir(absPathToScript))
+			if os.Getenv(system.BinEnvVar) == "" {
+				gptOpt.Env = append(gptOpt.Env, system.BinEnvVar+"="+system.Bin())
+			}
 
 			args = append([]string{args[0]}, "--file="+filepath.Base(args[1]))
 			if len(args) > 2 {

--- a/pkg/system/bin.go
+++ b/pkg/system/bin.go
@@ -2,8 +2,10 @@ package system
 
 import "os"
 
+const BinEnvVar = "GPTSCRIPT_BIN"
+
 func Bin() string {
-	bin := os.Getenv("GPTSCRIPT_BIN")
+	bin := os.Getenv(BinEnvVar)
 	if bin != "" {
 		return bin
 	}


### PR DESCRIPTION
When starting gptscript in the various modes (CLI, UI, server, etc), the same binary should be used for the whole stack via the GPTSCRIPT_BIN environment variable. This change does exactly that.