### PR TITLE
feat: add sdkserver support for remote file parsing

### DIFF
--- a/pkg/cli/parse.go
+++ b/pkg/cli/parse.go
@@ -2,12 +2,10 @@ package cli
 
 import (
 	"encoding/json"
-	"fmt"
 	"os"
 	"strings"
 
 	"github.com/gptscript-ai/gptscript/pkg/input"
-	"github.com/gptscript-ai/gptscript/pkg/loader"
 	"github.com/gptscript-ai/gptscript/pkg/parser"
 	"github.com/spf13/cobra"
 )
@@ -28,25 +26,9 @@ func locationName(l string) string {
 }
 
 func (e *Parse) Run(_ *cobra.Command, args []string) error {
-	var (
-		content string
-		err     error
-	)
-
-	// Attempt to read the file first, if that fails, try to load the URL. Finally,
-	// return an error if both fail.
-	content, err = input.FromFile(args[0])
+	content, err := input.FromLocation(args[0])
 	if err != nil {
-		log.Debugf("failed to read file %s (due to %v) attempting to load the URL...", args[0], err)
-		content, err = loader.ContentFromURL(args[0])
-		if err != nil {
-			return err
-		}
-		// If the content is empty and there was no error, this is not a remote file. Return a generic
-		// error indicating that the file could not be loaded.
-		if content == "" {
-			return fmt.Errorf("failed to load %v", args[0])
-		}
+		return err
 	}
 
 	docs, err := parser.Parse(strings.NewReader(content), parser.Options{

--- a/pkg/input/input.go
+++ b/pkg/input/input.go
@@ -5,6 +5,8 @@ import (
 	"io"
 	"os"
 	"strings"
+
+	"github.com/gptscript-ai/gptscript/pkg/loader"
 )
 
 func FromArgs(args []string) string {
@@ -38,4 +40,24 @@ func FromFile(file string) (string, error) {
 	}
 
 	return "", nil
+}
+
+// FromLocation takes a string that can be a file path or a URL to a file and returns the content of that file.
+func FromLocation(s string) (string, error) {
+	// Attempt to read the file first, if that fails, try to load the URL. Finally,
+	// return an error if both fail.
+	content, err := FromFile(s)
+	if err != nil {
+		log.Debugf("failed to read file %s (due to %v) attempting to load the URL...", s, err)
+		content, err = loader.ContentFromURL(s)
+		if err != nil {
+			return "", err
+		}
+		// If the content is empty and there was no error, this is not a remote file. Return a generic
+		// error indicating that the file could not be loaded.
+		if content == "" {
+			return "", fmt.Errorf("failed to load %v", s)
+		}
+	}
+	return content, nil
 }


### PR DESCRIPTION
Add the ability to parse remote scripts in the sdkserver.

To test this, you can do the following after pulling the branch down locally:

```sh
go run main.go --debug --listen-address 127.0.0.1:9090 sdkserver
```

and in a separate tab:

```sh
curl http://localhost:9090/parse -d '{"file":"github.com/gptscript-ai/cli-demo"}'
```