### PR TITLE
enhance: automatically use the generic credential tool for OpenAPI

### DIFF
--- a/pkg/loader/openapi.go
+++ b/pkg/loader/openapi.go
@@ -278,6 +278,17 @@ func getOpenAPITools(t *openapi3.T, defaultHost string) ([]types.Tool, error) {
 				return nil, err
 			}
 
+			if len(infos) > 0 {
+				// Set up credential tools for the first set of infos.
+				for _, info := range infos[0] {
+					operationServerURL, err := url.Parse(operationServer)
+					if err != nil {
+						return nil, fmt.Errorf("failed to parse operation server URL: %w", err)
+					}
+					tool.Credentials = info.GetCredentialToolStrings(operationServerURL.Hostname())
+				}
+			}
+
 			// Register
 			toolNames = append(toolNames, tool.Parameters.Name)
 			tools = append(tools, tool)

--- a/pkg/types/tool.go
+++ b/pkg/types/tool.go
@@ -411,7 +411,9 @@ func (t ToolDef) String() string {
 		_, _ = fmt.Fprintf(buf, "Internal Prompt: %v\n", *t.Parameters.InternalPrompt)
 	}
 	if len(t.Parameters.Credentials) > 0 {
-		_, _ = fmt.Fprintf(buf, "Credentials: %s\n", strings.Join(t.Parameters.Credentials, ", "))
+		for _, cred := range t.Parameters.Credentials {
+			_, _ = fmt.Fprintf(buf, "Credential: %s\n", cred)
+		}
 	}
 	if t.Parameters.Chat {
 		_, _ = fmt.Fprintf(buf, "Chat: true\n")

--- a/pkg/types/tool_test.go
+++ b/pkg/types/tool_test.go
@@ -50,7 +50,8 @@ Temperature: 0.800000
 Parameter: arg1: desc1
 Parameter: arg2: desc2
 Internal Prompt: true
-Credentials: Credential1, Credential2
+Credential: Credential1
+Credential: Credential2
 Chat: true
 
 This is a sample instruction


### PR DESCRIPTION
This is a relatively simple change that just adds a `Credential:` line or two to each tool generated for an OpenAPI definition, if there is some supported security scheme for the particular operation (i.e. API key, HTTP bearer token, HTTP basic auth).

This works seamlessly with existing OpenAPI tool examples such as the DigitalOcean agent.