### PR TITLE
fix: only complete CLI args when running gptscript

### DIFF
--- a/pkg/gptscript/gptscript.go
+++ b/pkg/gptscript/gptscript.go
@@ -48,26 +48,20 @@ type Options struct {
 	Env               []string
 }
 
-func complete(opts ...Options) (Options, error) {
-	var (
-		result Options
-		err    error
-	)
-
+func complete(opts ...Options) Options {
+	var result Options
 	for _, opt := range opts {
 		result.Cache = cache.Complete(result.Cache, opt.Cache)
 		result.Monitor = monitor.Complete(result.Monitor, opt.Monitor)
 		result.Runner = runner.Complete(result.Runner, opt.Runner)
-		result.OpenAI, err = openai.Complete(result.OpenAI, opt.OpenAI)
-		if err != nil {
-			return Options{}, err
-		}
+		result.OpenAI = openai.Complete(result.OpenAI, opt.OpenAI)
 
 		result.CredentialContext = types.FirstSet(opt.CredentialContext, result.CredentialContext)
 		result.Quiet = types.FirstSet(opt.Quiet, result.Quiet)
 		result.Workspace = types.FirstSet(opt.Workspace, result.Workspace)
 		result.Env = append(result.Env, opt.Env...)
 	}
+
 	if result.Quiet == nil {
 		result.Quiet = new(bool)
 	}
@@ -78,15 +72,11 @@ func complete(opts ...Options) (Options, error) {
 		result.CredentialContext = "default"
 	}
 
-	return result, nil
+	return result
 }
 
 func New(o ...Options) (*GPTScript, error) {
-	opts, err := complete(o...)
-	if err != nil {
-		return nil, err
-	}
-
+	opts := complete(o...)
 	registry := llm.NewRegistry()
 
 	cacheClient, err := cache.New(opts.Cache)

--- a/pkg/openai/client.go
+++ b/pkg/openai/client.go
@@ -58,7 +58,7 @@ type Options struct {
 	Cache        *cache.Client
 }
 
-func Complete(opts ...Options) (result Options, err error) {
+func Complete(opts ...Options) (result Options) {
 	for _, opt := range opts {
 		result.BaseURL = types.FirstSet(opt.BaseURL, result.BaseURL)
 		result.APIKey = types.FirstSet(opt.APIKey, result.APIKey)
@@ -69,6 +69,12 @@ func Complete(opts ...Options) (result Options, err error) {
 		result.CacheKey = types.FirstSet(opt.CacheKey, result.CacheKey)
 	}
 
+	return result
+}
+
+func complete(opts ...Options) (Options, error) {
+	var err error
+	result := Complete(opts...)
 	if result.Cache == nil {
 		result.Cache, err = cache.New(cache.Options{
 			DisableCache: true,
@@ -87,7 +93,7 @@ func Complete(opts ...Options) (result Options, err error) {
 }
 
 func NewClient(credStore credentials.CredentialStore, opts ...Options) (*Client, error) {
-	opt, err := Complete(opts...)
+	opt, err := complete(opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -64,6 +64,11 @@ func Complete(opts ...Options) (result Options) {
 			result.Authorizer = opt.Authorizer
 		}
 	}
+	return
+}
+
+func complete(opts ...Options) Options {
+	result := Complete(opts...)
 	if result.MonitorFactory == nil {
 		result.MonitorFactory = noopFactory{}
 	}
@@ -76,7 +81,7 @@ func Complete(opts ...Options) (result Options) {
 	if result.Authorizer == nil {
 		result.Authorizer = DefaultAuthorizer
 	}
-	return
+	return result
 }
 
 type Runner struct {
@@ -91,7 +96,7 @@ type Runner struct {
 }
 
 func New(client engine.Model, credStore credentials.CredentialStore, opts ...Options) (*Runner, error) {
-	opt := Complete(opts...)
+	opt := complete(opts...)
 
 	runner := &Runner{
 		c:              client,


### PR DESCRIPTION
A previous change completed all the options, including setting defaults when running gptscripts. This caused issues with "no-op" defaults being set before they should have. This change will only complete the CLI args and wait for the remaining defaults to be set until all CLI args have be completed.