### PR TITLE
fix: redact output of credential tools

### DIFF
--- a/pkg/runner/monitor.go
+++ b/pkg/runner/monitor.go
@@ -33,17 +33,17 @@ type credWrapper struct {
 	m Monitor
 }
 
-func (n credWrapper) Event(e Event) {
+func (c credWrapper) Event(e Event) {
 	if e.Type == EventTypeCallFinish {
 		e.Content = "credential tool output redacted"
 	}
-	n.m.Event(e)
+	c.m.Event(e)
 }
 
-func (n credWrapper) Stop(s string, err error) {
-	n.m.Stop(s, err)
+func (c credWrapper) Stop(s string, err error) {
+	c.m.Stop(s, err)
 }
 
-func (n credWrapper) Pause() func() {
-	return n.m.Pause()
+func (c credWrapper) Pause() func() {
+	return c.m.Pause()
 }

--- a/pkg/runner/monitor.go
+++ b/pkg/runner/monitor.go
@@ -28,22 +28,3 @@ func (n noopMonitor) Stop(string, error) {}
 func (n noopMonitor) Pause() func() {
 	return func() {}
 }
-
-type credWrapper struct {
-	m Monitor
-}
-
-func (c credWrapper) Event(e Event) {
-	if e.Type == EventTypeCallFinish {
-		e.Content = "credential tool output redacted"
-	}
-	c.m.Event(e)
-}
-
-func (c credWrapper) Stop(s string, err error) {
-	c.m.Stop(s, err)
-}
-
-func (c credWrapper) Pause() func() {
-	return c.m.Pause()
-}

--- a/pkg/runner/monitor.go
+++ b/pkg/runner/monitor.go
@@ -28,3 +28,22 @@ func (n noopMonitor) Stop(string, error) {}
 func (n noopMonitor) Pause() func() {
 	return func() {}
 }
+
+type credWrapper struct {
+	m Monitor
+}
+
+func (n credWrapper) Event(e Event) {
+	if e.Type == EventTypeCallFinish {
+		e.Content = "credential tool output redacted"
+	}
+	n.m.Event(e)
+}
+
+func (n credWrapper) Stop(s string, err error) {
+	n.m.Stop(s, err)
+}
+
+func (n credWrapper) Pause() func() {
+	return n.m.Pause()
+}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -858,7 +858,7 @@ func (r *Runner) handleCredentials(callCtx engine.Context, monitor Monitor, env 
 				return nil, fmt.Errorf("failed to create subcall context for tool %s: %w", credToolName, err)
 			}
 
-			res, err := r.call(subCtx, monitor, env, input)
+			res, err := r.call(subCtx, credWrapper{monitor}, env, input)
 			if err != nil {
 				return nil, fmt.Errorf("failed to run credential tool %s: %w", credToolName, err)
 			}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -787,6 +787,7 @@ func (r *Runner) subCalls(callCtx engine.Context, monitor Monitor, env []string,
 }
 
 func getFinishEventContent(state State, callCtx engine.Context) string {
+	// If it is a credential tool, the finish event contains its output, which is sensitive, so we don't return it.
 	if callCtx.ToolCategory == engine.CredentialToolCategory {
 		return ""
 	}


### PR DESCRIPTION
for #483

~~This creates a little wrapper type around the monitor, to be used only for credential calls, so that we do not print the plaintext output to the console.~~

Update: this instead excludes the output of credential tools from the CallFinish Event entirely, so the Monitor never has a chance to see it.