### PR TITLE
bug: large openapi schemas require n^2 memory

### DIFF
--- a/pkg/cli/gptscript.go
+++ b/pkg/cli/gptscript.go
@@ -453,7 +453,7 @@ func (r *GPTScript) Run(cmd *cobra.Command, args []string) (retErr error) {
 	}
 
 	if prg.IsChat() || r.ForceChat {
-		if !r.DisableTUI && !r.Debug && !r.DebugMessages {
+		if !r.DisableTUI && !r.Debug && !r.DebugMessages && !r.NoTrunc {
 			// Don't use cmd.Context() because then sigint will cancel everything
 			return tui.Run(context.Background(), args[0], tui.RunOptions{
 				OpenAIAPIKey:        r.OpenAIOptions.APIKey,

--- a/pkg/types/tool.go
+++ b/pkg/types/tool.go
@@ -30,6 +30,13 @@ type ErrToolNotFound struct {
 	ToolName string
 }
 
+func ToToolName(toolName, subTool string) string {
+	if subTool == "" {
+		return toolName
+	}
+	return fmt.Sprintf("%s from %s", subTool, toolName)
+}
+
 func NewErrToolNotFound(toolName string) *ErrToolNotFound {
 	return &ErrToolNotFound{
 		ToolName: toolName,


### PR DESCRIPTION
Use a shared map instance so that memory doesn't blow up because the
tool mapping is implicitly n*n.
