### PR TITLE
chore: fix smoke workflow name

### DIFF
--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -1,4 +1,4 @@
-name: test
+name: smoke
 
 on:
   pull_request_target:


### PR DESCRIPTION
The current name is "test" which conflicts with the existing "test"
workflow and causes the GitHub UI to get confused.

