### PR TITLE
fix: smoke test flakes

### DIFF
--- a/pkg/tests/smoke/smoke_test.go
+++ b/pkg/tests/smoke/smoke_test.go
@@ -81,8 +81,13 @@ func TestSmoke(t *testing.T) {
 				ctx,
 				expectedEvents,
 				actualEvents,
-				`The field values of the elements of expected and actual must be roughly equivalent.
-Ignore variations in timestamps, IDs, and verbiage when determining equivalence.`,
+				`
+- disregard differences in timestamps, generated IDs, natural language verbiage, and event order
+- omit callProgress events from the comparision
+- the overall stream of events and set of tools called should roughly match
+- arguments passed in tool calls should be roughly the same
+- the final callFinish event should be semantically similar
+`,
 			)
 			require.NoError(t, err, "error getting judge ruling on output")
 			require.True(t, equal, reasoning)

--- a/pkg/tests/smoke/testdata/Bob/claude-3-opus-20240229-expected.json
+++ b/pkg/tests/smoke/testdata/Bob/claude-3-opus-20240229-expected.json
@@ -1,20 +1,20 @@
 [
     {
-        "time": "2024-06-18T11:31:24.183335-04:00",
+        "time": "2024-06-20T17:10:23.193337-04:00",
         "type": "runStart",
         "usage": {}
     },
     {
-        "time": "2024-06-18T11:31:24.183735-04:00",
+        "time": "2024-06-20T17:10:23.19359-04:00",
         "callContext": {
-            "id": "1718724685",
+            "id": "1718917824",
             "tool": {
                 "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider@tool-beta",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -40,14 +40,14 @@
         "usage": {}
     },
     {
-        "time": "2024-06-18T11:31:25.851994-04:00",
+        "time": "2024-06-20T17:10:24.059514-04:00",
         "type": "runStart",
         "usage": {}
     },
     {
-        "time": "2024-06-18T11:31:25.852381-04:00",
+        "time": "2024-06-20T17:10:24.059807-04:00",
         "callContext": {
-            "id": "1718724686",
+            "id": "1718917825",
             "tool": {
                 "name": "Anthropic Claude3 Model Provider",
                 "description": "Model provider for Anthropic hosted Claude3 models",
@@ -91,158 +91,9 @@
         "usage": {}
     },
     {
-        "time": "2024-06-18T11:31:25.852533-04:00",
+        "time": "2024-06-20T17:10:25.074481-04:00",
         "callContext": {
-            "id": "1718724687",
-            "tool": {
-                "name": "claude3-anthropic-credential",
-                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider@tool-beta",
-                "internalPrompt": null,
-                "instructions": "#!/usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/credential.py",
-                "id": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/3b9b9365d469c4c702291f1764537ab5c226c2e0/credential/tool.gpt:claude3-anthropic-credential",
-                "localTools": {
-                    "claude3-anthropic-credential": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/3b9b9365d469c4c702291f1764537ab5c226c2e0/credential/tool.gpt:claude3-anthropic-credential"
-                },
-                "source": {
-                    "location": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/3b9b9365d469c4c702291f1764537ab5c226c2e0/credential/tool.gpt",
-                    "lineNo": 1,
-                    "repo": {
-                        "VCS": "git",
-                        "Root": "https://github.com/gptscript-ai/claude3-anthropic-provider.git",
-                        "Path": "credential",
-                        "Name": "tool.gpt",
-                        "Revision": "3b9b9365d469c4c702291f1764537ab5c226c2e0"
-                    }
-                },
-                "workingDir": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/3b9b9365d469c4c702291f1764537ab5c226c2e0/credential"
-            },
-            "inputContext": null,
-            "toolCategory": "credential",
-            "toolName": "github.com/gptscript-ai/claude3-anthropic-provider/credential",
-            "parentID": "1718724686",
-            "displayText": "Running claude3-anthropic-credential from github.com/gptscript-ai/claude3-anthropic-provider/credential"
-        },
-        "type": "callStart",
-        "usage": {}
-    },
-    {
-        "time": "2024-06-18T11:31:25.855621-04:00",
-        "callContext": {
-            "id": "1718724687",
-            "tool": {
-                "name": "claude3-anthropic-credential",
-                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider@tool-beta",
-                "internalPrompt": null,
-                "instructions": "#!/usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/credential.py",
-                "id": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/3b9b9365d469c4c702291f1764537ab5c226c2e0/credential/tool.gpt:claude3-anthropic-credential",
-                "localTools": {
-                    "claude3-anthropic-credential": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/3b9b9365d469c4c702291f1764537ab5c226c2e0/credential/tool.gpt:claude3-anthropic-credential"
-                },
-                "source": {
-                    "location": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/3b9b9365d469c4c702291f1764537ab5c226c2e0/credential/tool.gpt",
-                    "lineNo": 1,
-                    "repo": {
-                        "VCS": "git",
-                        "Root": "https://github.com/gptscript-ai/claude3-anthropic-provider.git",
-                        "Path": "credential",
-                        "Name": "tool.gpt",
-                        "Revision": "3b9b9365d469c4c702291f1764537ab5c226c2e0"
-                    }
-                },
-                "workingDir": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/3b9b9365d469c4c702291f1764537ab5c226c2e0/credential"
-            },
-            "inputContext": null,
-            "toolCategory": "credential",
-            "toolName": "github.com/gptscript-ai/claude3-anthropic-provider/credential",
-            "parentID": "1718724686",
-            "displayText": "Running claude3-anthropic-credential from github.com/gptscript-ai/claude3-anthropic-provider/credential"
-        },
-        "type": "callChat",
-        "chatCompletionId": "1718724688",
-        "usage": {},
-        "chatRequest": {
-            "model": "",
-            "messages": null
-        }
-    },
-    {
-        "time": "2024-06-18T11:31:25.948224-04:00",
-        "callContext": {
-            "id": "1718724687",
-            "tool": {
-                "name": "claude3-anthropic-credential",
-                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider@tool-beta",
-                "internalPrompt": null,
-                "instructions": "#!/usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/credential.py",
-                "id": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/3b9b9365d469c4c702291f1764537ab5c226c2e0/credential/tool.gpt:claude3-anthropic-credential",
-                "localTools": {
-                    "claude3-anthropic-credential": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/3b9b9365d469c4c702291f1764537ab5c226c2e0/credential/tool.gpt:claude3-anthropic-credential"
-                },
-                "source": {
-                    "location": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/3b9b9365d469c4c702291f1764537ab5c226c2e0/credential/tool.gpt",
-                    "lineNo": 1,
-                    "repo": {
-                        "VCS": "git",
-                        "Root": "https://github.com/gptscript-ai/claude3-anthropic-provider.git",
-                        "Path": "credential",
-                        "Name": "tool.gpt",
-                        "Revision": "3b9b9365d469c4c702291f1764537ab5c226c2e0"
-                    }
-                },
-                "workingDir": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/3b9b9365d469c4c702291f1764537ab5c226c2e0/credential"
-            },
-            "inputContext": null,
-            "toolCategory": "credential",
-            "toolName": "github.com/gptscript-ai/claude3-anthropic-provider/credential",
-            "parentID": "1718724686",
-            "displayText": "Running claude3-anthropic-credential from github.com/gptscript-ai/claude3-anthropic-provider/credential"
-        },
-        "type": "callChat",
-        "chatCompletionId": "1718724688",
-        "usage": {},
-        "chatResponse": {
-            "usage": {}
-        }
-    },
-    {
-        "time": "2024-06-18T11:31:25.948393-04:00",
-        "callContext": {
-            "id": "1718724687",
-            "tool": {
-                "name": "claude3-anthropic-credential",
-                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider@tool-beta",
-                "internalPrompt": null,
-                "instructions": "#!/usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/credential.py",
-                "id": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/3b9b9365d469c4c702291f1764537ab5c226c2e0/credential/tool.gpt:claude3-anthropic-credential",
-                "localTools": {
-                    "claude3-anthropic-credential": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/3b9b9365d469c4c702291f1764537ab5c226c2e0/credential/tool.gpt:claude3-anthropic-credential"
-                },
-                "source": {
-                    "location": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/3b9b9365d469c4c702291f1764537ab5c226c2e0/credential/tool.gpt",
-                    "lineNo": 1,
-                    "repo": {
-                        "VCS": "git",
-                        "Root": "https://github.com/gptscript-ai/claude3-anthropic-provider.git",
-                        "Path": "credential",
-                        "Name": "tool.gpt",
-                        "Revision": "3b9b9365d469c4c702291f1764537ab5c226c2e0"
-                    }
-                },
-                "workingDir": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/3b9b9365d469c4c702291f1764537ab5c226c2e0/credential"
-            },
-            "inputContext": null,
-            "toolCategory": "credential",
-            "toolName": "github.com/gptscript-ai/claude3-anthropic-provider/credential",
-            "parentID": "1718724686",
-            "displayText": "Running claude3-anthropic-credential from github.com/gptscript-ai/claude3-anthropic-provider/credential"
-        },
-        "type": "callFinish",
-        "usage": {}
-    },
-    {
-        "time": "2024-06-18T11:31:26.96565-04:00",
-        "callContext": {
-            "id": "1718724686",
+            "id": "1718917825",
             "tool": {
                 "name": "Anthropic Claude3 Model Provider",
                 "description": "Model provider for Anthropic hosted Claude3 models",
@@ -284,24 +135,24 @@
         },
         "type": "callFinish",
         "usage": {},
-        "content": "http://127.0.0.1:11059"
+        "content": "http://127.0.0.1:11060"
     },
     {
-        "time": "2024-06-18T11:31:26.965764-04:00",
+        "time": "2024-06-20T17:10:25.074606-04:00",
         "type": "runFinish",
         "usage": {}
     },
     {
-        "time": "2024-06-18T11:31:26.965828-04:00",
+        "time": "2024-06-20T17:10:25.074685-04:00",
         "callContext": {
-            "id": "1718724685",
+            "id": "1718917824",
             "tool": {
                 "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider@tool-beta",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -324,14 +175,14 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1718724689",
+        "chatCompletionId": "1718917826",
         "usage": {},
         "chatRequest": {
             "model": "claude-3-opus-20240229",
             "messages": [
                 {
                     "role": "system",
-                    "content": "Ask Bob how he is doing and let me know exactly what he said."
+                    "content": "Ask Bob \"how are you doing\" and repeat his reply exactly."
                 }
             ],
             "temperature": 0,
@@ -356,16 +207,16 @@
         }
     },
     {
-        "time": "2024-06-18T11:31:26.966331-04:00",
+        "time": "2024-06-20T17:10:25.075088-04:00",
         "callContext": {
-            "id": "1718724685",
+            "id": "1718917824",
             "tool": {
                 "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider@tool-beta",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -388,21 +239,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1718724689",
+        "chatCompletionId": "1718917826",
         "usage": {},
         "content": "Waiting for model response..."
     },
     {
-        "time": "2024-06-18T11:31:35.503953-04:00",
+        "time": "2024-06-20T17:10:33.389627-04:00",
         "callContext": {
-            "id": "1718724685",
+            "id": "1718917824",
             "tool": {
                 "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider@tool-beta",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -425,21 +276,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1718724689",
+        "chatCompletionId": "1718917826",
         "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\"question\": \"how he is doing\"}"
+        "content": "\u003ctool call\u003e bob -\u003e {\"question\": \"how are you doing\"}"
     },
     {
-        "time": "2024-06-18T11:31:35.505033-04:00",
+        "time": "2024-06-20T17:10:33.389848-04:00",
         "callContext": {
-            "id": "1718724685",
+            "id": "1718917824",
             "tool": {
                 "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider@tool-beta",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -462,7 +313,7 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1718724689",
+        "chatCompletionId": "1718917826",
         "usage": {},
         "chatResponse": {
             "role": "assistant",
@@ -470,10 +321,10 @@
                 {
                     "toolCall": {
                         "index": 0,
-                        "id": "toolu_01NJaY1g8kxqQkA4wbFTGtSX",
+                        "id": "toolu_01EEcv7qDLHDmGAzm15vobxM",
                         "function": {
                             "name": "bob",
-                            "arguments": "{\"question\": \"how he is doing\"}"
+                            "arguments": "{\"question\": \"how are you doing\"}"
                         }
                     }
                 }
@@ -482,16 +333,16 @@
         }
     },
     {
-        "time": "2024-06-18T11:31:35.505135-04:00",
+        "time": "2024-06-20T17:10:33.389967-04:00",
         "callContext": {
-            "id": "1718724685",
+            "id": "1718917824",
             "tool": {
                 "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider@tool-beta",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -514,18 +365,18 @@
             "inputContext": null
         },
         "toolSubCalls": {
-            "toolu_01NJaY1g8kxqQkA4wbFTGtSX": {
+            "toolu_01EEcv7qDLHDmGAzm15vobxM": {
                 "toolID": "testdata/Bob/test.gpt:bob",
-                "input": "{\"question\": \"how he is doing\"}"
+                "input": "{\"question\": \"how are you doing\"}"
             }
         },
         "type": "callSubCalls",
         "usage": {}
     },
     {
-        "time": "2024-06-18T11:31:35.505164-04:00",
+        "time": "2024-06-20T17:10:33.389997-04:00",
         "callContext": {
-            "id": "toolu_01NJaY1g8kxqQkA4wbFTGtSX",
+            "id": "toolu_01EEcv7qDLHDmGAzm15vobxM",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -540,7 +391,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -554,16 +405,16 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1718724685"
+            "parentID": "1718917824"
         },
         "type": "callStart",
         "usage": {},
-        "content": "{\"question\": \"how he is doing\"}"
+        "content": "{\"question\": \"how are you doing\"}"
     },
     {
-        "time": "2024-06-18T11:31:35.666461-04:00",
+        "time": "2024-06-20T17:10:33.584228-04:00",
         "callContext": {
-            "id": "toolu_01NJaY1g8kxqQkA4wbFTGtSX",
+            "id": "toolu_01EEcv7qDLHDmGAzm15vobxM",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -578,7 +429,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -592,30 +443,30 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1718724685"
+            "parentID": "1718917824"
         },
         "type": "callChat",
-        "chatCompletionId": "1718724690",
+        "chatCompletionId": "1718917827",
         "usage": {},
         "chatRequest": {
             "model": "claude-3-opus-20240229",
             "messages": [
                 {
                     "role": "system",
-                    "content": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\""
+                    "content": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\""
                 },
                 {
                     "role": "user",
-                    "content": "{\"question\": \"how he is doing\"}"
+                    "content": "{\"question\": \"how are you doing\"}"
                 }
             ],
             "temperature": 0
         }
     },
     {
-        "time": "2024-06-18T11:31:35.666692-04:00",
+        "time": "2024-06-20T17:10:33.584507-04:00",
         "callContext": {
-            "id": "toolu_01NJaY1g8kxqQkA4wbFTGtSX",
+            "id": "toolu_01EEcv7qDLHDmGAzm15vobxM",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -630,7 +481,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -644,17 +495,17 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1718724685"
+            "parentID": "1718917824"
         },
         "type": "callProgress",
-        "chatCompletionId": "1718724690",
+        "chatCompletionId": "1718917827",
         "usage": {},
         "content": "Waiting for model response..."
     },
     {
-        "time": "2024-06-18T11:31:38.650768-04:00",
+        "time": "2024-06-20T17:10:35.540664-04:00",
         "callContext": {
-            "id": "toolu_01NJaY1g8kxqQkA4wbFTGtSX",
+            "id": "toolu_01EEcv7qDLHDmGAzm15vobxM",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -669,7 +520,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -683,17 +534,17 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1718724685"
+            "parentID": "1718917824"
         },
         "type": "callProgress",
-        "chatCompletionId": "1718724690",
+        "chatCompletionId": "1718917827",
         "usage": {},
-        "content": "Thanks for asking \"how he is doing\", I'm doing great fellow friendly AI tool!"
+        "content": "Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI tool!"
     },
     {
-        "time": "2024-06-18T11:31:38.65205-04:00",
+        "time": "2024-06-20T17:10:35.540967-04:00",
         "callContext": {
-            "id": "toolu_01NJaY1g8kxqQkA4wbFTGtSX",
+            "id": "toolu_01EEcv7qDLHDmGAzm15vobxM",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -708,7 +559,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -722,25 +573,25 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1718724685"
+            "parentID": "1718917824"
         },
         "type": "callChat",
-        "chatCompletionId": "1718724690",
+        "chatCompletionId": "1718917827",
         "usage": {},
         "chatResponse": {
             "role": "assistant",
             "content": [
                 {
-                    "text": "Thanks for asking \"how he is doing\", I'm doing great fellow friendly AI tool!"
+                    "text": "Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI tool!"
                 }
             ],
             "usage": {}
         }
     },
     {
-        "time": "2024-06-18T11:31:38.652106-04:00",
+        "time": "2024-06-20T17:10:35.541005-04:00",
         "callContext": {
-            "id": "toolu_01NJaY1g8kxqQkA4wbFTGtSX",
+            "id": "toolu_01EEcv7qDLHDmGAzm15vobxM",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -755,7 +606,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -769,23 +620,23 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1718724685"
+            "parentID": "1718917824"
         },
         "type": "callFinish",
         "usage": {},
-        "content": "Thanks for asking \"how he is doing\", I'm doing great fellow friendly AI tool!"
+        "content": "Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI tool!"
     },
     {
-        "time": "2024-06-18T11:31:38.652143-04:00",
+        "time": "2024-06-20T17:10:35.541033-04:00",
         "callContext": {
-            "id": "1718724685",
+            "id": "1718917824",
             "tool": {
                 "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider@tool-beta",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -812,16 +663,16 @@
         "usage": {}
     },
     {
-        "time": "2024-06-18T11:31:38.847656-04:00",
+        "time": "2024-06-20T17:10:35.71784-04:00",
         "callContext": {
-            "id": "1718724685",
+            "id": "1718917824",
             "tool": {
                 "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider@tool-beta",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -844,34 +695,34 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1718724691",
+        "chatCompletionId": "1718917828",
         "usage": {},
         "chatRequest": {
             "model": "claude-3-opus-20240229",
             "messages": [
                 {
                     "role": "system",
-                    "content": "Ask Bob how he is doing and let me know exactly what he said."
+                    "content": "Ask Bob \"how are you doing\" and repeat his reply exactly."
                 },
                 {
                     "role": "assistant",
                     "content": "",
                     "tool_calls": [
                         {
-                            "id": "toolu_01NJaY1g8kxqQkA4wbFTGtSX",
+                            "id": "toolu_01EEcv7qDLHDmGAzm15vobxM",
                             "type": "function",
                             "function": {
                                 "name": "bob",
-                                "arguments": "{\"question\": \"how he is doing\"}"
+                                "arguments": "{\"question\": \"how are you doing\"}"
                             }
                         }
                     ]
                 },
                 {
                     "role": "tool",
-                    "content": "Thanks for asking \"how he is doing\", I'm doing great fellow friendly AI tool!",
+                    "content": "Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI tool!",
                     "name": "bob",
-                    "tool_call_id": "toolu_01NJaY1g8kxqQkA4wbFTGtSX"
+                    "tool_call_id": "toolu_01EEcv7qDLHDmGAzm15vobxM"
                 }
             ],
             "temperature": 0,
@@ -896,16 +747,16 @@
         }
     },
     {
-        "time": "2024-06-18T11:31:38.847937-04:00",
+        "time": "2024-06-20T17:10:35.718216-04:00",
         "callContext": {
-            "id": "1718724685",
+            "id": "1718917824",
             "tool": {
                 "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider@tool-beta",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -928,21 +779,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1718724691",
+        "chatCompletionId": "1718917828",
         "usage": {},
         "content": "Waiting for model response..."
     },
     {
-        "time": "2024-06-18T11:31:43.784059-04:00",
+        "time": "2024-06-20T17:10:39.50448-04:00",
         "callContext": {
-            "id": "1718724685",
+            "id": "1718917824",
             "tool": {
                 "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider@tool-beta",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -965,21 +816,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1718724691",
+        "chatCompletionId": "1718917828",
         "usage": {},
-        "content": "Bob said exactly: \"Thanks for asking \"how he is doing\", I'm doing great fellow friendly AI tool!\""
+        "content": "Bob replied: \"Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI tool!\""
     },
     {
-        "time": "2024-06-18T11:31:43.785727-04:00",
+        "time": "2024-06-20T17:10:39.504769-04:00",
         "callContext": {
-            "id": "1718724685",
+            "id": "1718917824",
             "tool": {
                 "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider@tool-beta",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1002,29 +853,29 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1718724691",
+        "chatCompletionId": "1718917828",
         "usage": {},
         "chatResponse": {
             "role": "assistant",
             "content": [
                 {
-                    "text": "Bob said exactly: \"Thanks for asking \"how he is doing\", I'm doing great fellow friendly AI tool!\""
+                    "text": "Bob replied: \"Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI tool!\""
                 }
             ],
             "usage": {}
         }
     },
     {
-        "time": "2024-06-18T11:31:43.785811-04:00",
+        "time": "2024-06-20T17:10:39.504807-04:00",
         "callContext": {
-            "id": "1718724685",
+            "id": "1718917824",
             "tool": {
                 "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider@tool-beta",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1048,10 +899,10 @@
         },
         "type": "callFinish",
         "usage": {},
-        "content": "Bob said exactly: \"Thanks for asking \"how he is doing\", I'm doing great fellow friendly AI tool!\""
+        "content": "Bob replied: \"Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI tool!\""
     },
     {
-        "time": "2024-06-18T11:31:43.785827-04:00",
+        "time": "2024-06-20T17:10:39.504821-04:00",
         "type": "runFinish",
         "usage": {}
     }

--- a/pkg/tests/smoke/testdata/Bob/gpt-4-turbo-2024-04-09-expected.json
+++ b/pkg/tests/smoke/testdata/Bob/gpt-4-turbo-2024-04-09-expected.json
@@ -1,20 +1,20 @@
 [
     {
-        "time": "2024-06-06T20:22:29.810249-04:00",
+        "time": "2024-06-20T17:08:06.902669-04:00",
         "type": "runStart",
         "usage": {}
     },
     {
-        "time": "2024-06-06T20:22:29.810505-04:00",
+        "time": "2024-06-20T17:08:06.902927-04:00",
         "callContext": {
-            "id": "1717719750",
+            "id": "1718917687",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -40,16 +40,16 @@
         "usage": {}
     },
     {
-        "time": "2024-06-06T20:22:30.00145-04:00",
+        "time": "2024-06-20T17:08:07.292073-04:00",
         "callContext": {
-            "id": "1717719750",
+            "id": "1718917687",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -72,14 +72,14 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1717719751",
+        "chatCompletionId": "1718917688",
         "usage": {},
         "chatRequest": {
             "model": "gpt-4-turbo-2024-04-09",
             "messages": [
                 {
                     "role": "system",
-                    "content": "\nYou are task oriented system.\nYou receive input from a user, process the input from the given instructions, and then output the result.\nYour objective is to provide consistent and correct results.\nYou do not need to explain the steps taken, only provide the result to the given instructions.\nYou are referred to as a tool.\nYou don't move to the next step until you have a result.\n\nAsk Bob how he is doing and let me know exactly what he said."
+                    "content": "\nYou are task oriented system.\nYou receive input from a user, process the input from the given instructions, and then output the result.\nYour objective is to provide consistent and correct results.\nYou do not need to explain the steps taken, only provide the result to the given instructions.\nYou are referred to as a tool.\nYou don't move to the next step until you have a result.\n\nAsk Bob \"how are you doing\" and repeat his reply exactly."
                 }
             ],
             "temperature": 0,
@@ -104,16 +104,16 @@
         }
     },
     {
-        "time": "2024-06-06T20:22:30.004971-04:00",
+        "time": "2024-06-20T17:08:07.292172-04:00",
         "callContext": {
-            "id": "1717719750",
+            "id": "1718917687",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -136,21 +136,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719751",
+        "chatCompletionId": "1718917688",
         "usage": {},
         "content": "Waiting for model response..."
     },
     {
-        "time": "2024-06-06T20:22:30.810075-04:00",
+        "time": "2024-06-20T17:08:28.052253-04:00",
         "callContext": {
-            "id": "1717719750",
+            "id": "1718917687",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -173,21 +173,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719751",
+        "chatCompletionId": "1718917688",
         "usage": {},
         "content": "\u003ctool call\u003e bob -\u003e {\""
     },
     {
-        "time": "2024-06-06T20:22:30.810238-04:00",
+        "time": "2024-06-20T17:08:28.05243-04:00",
         "callContext": {
-            "id": "1717719750",
+            "id": "1718917687",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -210,21 +210,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719751",
+        "chatCompletionId": "1718917688",
         "usage": {},
         "content": "\u003ctool call\u003e bob -\u003e {\""
     },
     {
-        "time": "2024-06-06T20:22:30.844325-04:00",
+        "time": "2024-06-20T17:08:28.1369-04:00",
         "callContext": {
-            "id": "1717719750",
+            "id": "1718917687",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -247,21 +247,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719751",
+        "chatCompletionId": "1718917688",
         "usage": {},
         "content": "\u003ctool call\u003e bob -\u003e {\"question\":\""
     },
     {
-        "time": "2024-06-06T20:22:30.844508-04:00",
+        "time": "2024-06-20T17:08:28.137013-04:00",
         "callContext": {
-            "id": "1717719750",
+            "id": "1718917687",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -284,21 +284,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719751",
+        "chatCompletionId": "1718917688",
         "usage": {},
         "content": "\u003ctool call\u003e bob -\u003e {\"question\":\""
     },
     {
-        "time": "2024-06-06T20:22:30.895166-04:00",
+        "time": "2024-06-20T17:08:28.244585-04:00",
         "callContext": {
-            "id": "1717719750",
+            "id": "1718917687",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -321,21 +321,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719751",
+        "chatCompletionId": "1718917688",
         "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"How are"
+        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"how are"
     },
     {
-        "time": "2024-06-06T20:22:30.895349-04:00",
+        "time": "2024-06-20T17:08:28.244731-04:00",
         "callContext": {
-            "id": "1717719750",
+            "id": "1718917687",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -358,21 +358,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719751",
+        "chatCompletionId": "1718917688",
         "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"How are"
+        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"how are"
     },
     {
-        "time": "2024-06-06T20:22:30.945392-04:00",
+        "time": "2024-06-20T17:08:28.32623-04:00",
         "callContext": {
-            "id": "1717719750",
+            "id": "1718917687",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -395,21 +395,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719751",
+        "chatCompletionId": "1718917688",
         "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"How are you doing"
+        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"how are you doing"
     },
     {
-        "time": "2024-06-06T20:22:30.945641-04:00",
+        "time": "2024-06-20T17:08:28.326358-04:00",
         "callContext": {
-            "id": "1717719750",
+            "id": "1718917687",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -432,21 +432,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719751",
+        "chatCompletionId": "1718917688",
         "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"How are you doing"
+        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"how are you doing\"}"
     },
     {
-        "time": "2024-06-06T20:22:30.965686-04:00",
+        "time": "2024-06-20T17:08:28.326393-04:00",
         "callContext": {
-            "id": "1717719750",
+            "id": "1718917687",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -469,21 +469,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719751",
+        "chatCompletionId": "1718917688",
         "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"How are you doing?\"}"
+        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"how are you doing\"}"
     },
     {
-        "time": "2024-06-06T20:22:30.965791-04:00",
+        "time": "2024-06-20T17:08:28.32645-04:00",
         "callContext": {
-            "id": "1717719750",
+            "id": "1718917687",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -506,21 +506,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719751",
+        "chatCompletionId": "1718917688",
         "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"How are you doing?\"}"
+        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"how are you doing\"}"
     },
     {
-        "time": "2024-06-06T20:22:30.966161-04:00",
+        "time": "2024-06-20T17:08:28.326527-04:00",
         "callContext": {
-            "id": "1717719750",
+            "id": "1718917687",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -543,58 +543,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719751",
+        "chatCompletionId": "1718917688",
         "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"How are you doing?\"}"
+        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"how are you doing\"}"
     },
     {
-        "time": "2024-06-06T20:22:30.966215-04:00",
+        "time": "2024-06-20T17:08:28.327843-04:00",
         "callContext": {
-            "id": "1717719750",
+            "id": "1718917687",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1717719751",
-        "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"How are you doing?\"}"
-    },
-    {
-        "time": "2024-06-06T20:22:30.968104-04:00",
-        "callContext": {
-            "id": "1717719750",
-            "tool": {
-                "modelName": "gpt-4-turbo-2024-04-09",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -617,11 +580,11 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1717719751",
+        "chatCompletionId": "1718917688",
         "usage": {
-            "promptTokens": 143,
-            "completionTokens": 18,
-            "totalTokens": 161
+            "promptTokens": 142,
+            "completionTokens": 17,
+            "totalTokens": 159
         },
         "chatResponse": {
             "role": "assistant",
@@ -629,32 +592,32 @@
                 {
                     "toolCall": {
                         "index": 0,
-                        "id": "call_IfovJOlHh0TrPkSiric0ZYDO",
+                        "id": "call_vsmL6EoDecm0oVmUnHIvNkaL",
                         "function": {
                             "name": "bob",
-                            "arguments": "{\"question\":\"How are you doing?\"}"
+                            "arguments": "{\"question\":\"how are you doing\"}"
                         }
                     }
                 }
             ],
             "usage": {
-                "promptTokens": 143,
-                "completionTokens": 18,
-                "totalTokens": 161
+                "promptTokens": 142,
+                "completionTokens": 17,
+                "totalTokens": 159
             }
         }
     },
     {
-        "time": "2024-06-06T20:22:30.968398-04:00",
+        "time": "2024-06-20T17:08:28.328046-04:00",
         "callContext": {
-            "id": "1717719750",
+            "id": "1718917687",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -677,18 +640,18 @@
             "inputContext": null
         },
         "toolSubCalls": {
-            "call_IfovJOlHh0TrPkSiric0ZYDO": {
+            "call_vsmL6EoDecm0oVmUnHIvNkaL": {
                 "toolID": "testdata/Bob/test.gpt:bob",
-                "input": "{\"question\":\"How are you doing?\"}"
+                "input": "{\"question\":\"how are you doing\"}"
             }
         },
         "type": "callSubCalls",
         "usage": {}
     },
     {
-        "time": "2024-06-06T20:22:30.968468-04:00",
+        "time": "2024-06-20T17:08:28.328123-04:00",
         "callContext": {
-            "id": "call_IfovJOlHh0TrPkSiric0ZYDO",
+            "id": "call_vsmL6EoDecm0oVmUnHIvNkaL",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -703,7 +666,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -717,16 +680,16 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717719750"
+            "parentID": "1718917687"
         },
         "type": "callStart",
         "usage": {},
-        "content": "{\"question\":\"How are you doing?\"}"
+        "content": "{\"question\":\"how are you doing\"}"
     },
     {
-        "time": "2024-06-06T20:22:31.152693-04:00",
+        "time": "2024-06-20T17:08:28.53993-04:00",
         "callContext": {
-            "id": "call_IfovJOlHh0TrPkSiric0ZYDO",
+            "id": "call_vsmL6EoDecm0oVmUnHIvNkaL",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -741,7 +704,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -755,30 +718,30 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717719750"
+            "parentID": "1718917687"
         },
         "type": "callChat",
-        "chatCompletionId": "1717719752",
+        "chatCompletionId": "1718917689",
         "usage": {},
         "chatRequest": {
             "model": "gpt-4-turbo-2024-04-09",
             "messages": [
                 {
                     "role": "system",
-                    "content": "\nYou are task oriented system.\nYou receive input from a user, process the input from the given instructions, and then output the result.\nYour objective is to provide consistent and correct results.\nYou do not need to explain the steps taken, only provide the result to the given instructions.\nYou are referred to as a tool.\nYou don't move to the next step until you have a result.\n\nWhen asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\""
+                    "content": "\nYou are task oriented system.\nYou receive input from a user, process the input from the given instructions, and then output the result.\nYour objective is to provide consistent and correct results.\nYou do not need to explain the steps taken, only provide the result to the given instructions.\nYou are referred to as a tool.\nYou don't move to the next step until you have a result.\n\nWhen asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\""
                 },
                 {
                     "role": "user",
-                    "content": "{\"question\":\"How are you doing?\"}"
+                    "content": "{\"question\":\"how are you doing\"}"
                 }
             ],
             "temperature": 0
         }
     },
     {
-        "time": "2024-06-06T20:22:31.152842-04:00",
+        "time": "2024-06-20T17:08:28.540154-04:00",
         "callContext": {
-            "id": "call_IfovJOlHh0TrPkSiric0ZYDO",
+            "id": "call_vsmL6EoDecm0oVmUnHIvNkaL",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -793,7 +756,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -807,17 +770,17 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717719750"
+            "parentID": "1718917687"
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719752",
+        "chatCompletionId": "1718917689",
         "usage": {},
         "content": "Waiting for model response..."
     },
     {
-        "time": "2024-06-06T20:22:31.639639-04:00",
+        "time": "2024-06-20T17:08:29.188341-04:00",
         "callContext": {
-            "id": "call_IfovJOlHh0TrPkSiric0ZYDO",
+            "id": "call_vsmL6EoDecm0oVmUnHIvNkaL",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -832,7 +795,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -846,17 +809,17 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717719750"
+            "parentID": "1718917687"
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719752",
+        "chatCompletionId": "1718917689",
         "usage": {},
-        "content": "Thanks for"
+        "content": "Thanks"
     },
     {
-        "time": "2024-06-06T20:22:31.639789-04:00",
+        "time": "2024-06-20T17:08:29.188493-04:00",
         "callContext": {
-            "id": "call_IfovJOlHh0TrPkSiric0ZYDO",
+            "id": "call_vsmL6EoDecm0oVmUnHIvNkaL",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -871,7 +834,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -885,17 +848,17 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717719750"
+            "parentID": "1718917687"
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719752",
+        "chatCompletionId": "1718917689",
         "usage": {},
-        "content": "Thanks for"
+        "content": "Thanks"
     },
     {
-        "time": "2024-06-06T20:22:31.639837-04:00",
+        "time": "2024-06-20T17:08:29.244545-04:00",
         "callContext": {
-            "id": "call_IfovJOlHh0TrPkSiric0ZYDO",
+            "id": "call_vsmL6EoDecm0oVmUnHIvNkaL",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -910,7 +873,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -924,56 +887,17 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717719750"
+            "parentID": "1718917687"
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719752",
-        "usage": {},
-        "content": "Thanks for asking"
-    },
-    {
-        "time": "2024-06-06T20:22:31.639868-04:00",
-        "callContext": {
-            "id": "call_IfovJOlHh0TrPkSiric0ZYDO",
-            "tool": {
-                "name": "bob",
-                "description": "I'm Bob, a friendly guy.",
-                "modelName": "gpt-4-turbo-2024-04-09",
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "question": {
-                            "description": "The question to ask Bob.",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
-                "id": "testdata/Bob/test.gpt:bob",
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 6
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null,
-            "toolName": "bob",
-            "parentID": "1717719750"
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1717719752",
+        "chatCompletionId": "1718917689",
         "usage": {},
         "content": "Thanks for asking"
     },
     {
-        "time": "2024-06-06T20:22:31.935618-04:00",
+        "time": "2024-06-20T17:08:29.244765-04:00",
         "callContext": {
-            "id": "call_IfovJOlHh0TrPkSiric0ZYDO",
+            "id": "call_vsmL6EoDecm0oVmUnHIvNkaL",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -988,7 +912,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -1002,17 +926,17 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717719750"
+            "parentID": "1718917687"
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719752",
+        "chatCompletionId": "1718917689",
         "usage": {},
-        "content": "Thanks for asking \"How"
+        "content": "Thanks for asking"
     },
     {
-        "time": "2024-06-06T20:22:31.935952-04:00",
+        "time": "2024-06-20T17:08:29.643951-04:00",
         "callContext": {
-            "id": "call_IfovJOlHh0TrPkSiric0ZYDO",
+            "id": "call_vsmL6EoDecm0oVmUnHIvNkaL",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -1027,7 +951,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -1041,17 +965,17 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717719750"
+            "parentID": "1718917687"
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719752",
+        "chatCompletionId": "1718917689",
         "usage": {},
-        "content": "Thanks for asking \"How"
+        "content": "Thanks for asking how are"
     },
     {
-        "time": "2024-06-06T20:22:31.94189-04:00",
+        "time": "2024-06-20T17:08:29.644128-04:00",
         "callContext": {
-            "id": "call_IfovJOlHh0TrPkSiric0ZYDO",
+            "id": "call_vsmL6EoDecm0oVmUnHIvNkaL",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -1066,7 +990,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -1080,17 +1004,17 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717719750"
+            "parentID": "1718917687"
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719752",
+        "chatCompletionId": "1718917689",
         "usage": {},
-        "content": "Thanks for asking \"How are you doing"
+        "content": "Thanks for asking how are"
     },
     {
-        "time": "2024-06-06T20:22:31.942075-04:00",
+        "time": "2024-06-20T17:08:29.676951-04:00",
         "callContext": {
-            "id": "call_IfovJOlHh0TrPkSiric0ZYDO",
+            "id": "call_vsmL6EoDecm0oVmUnHIvNkaL",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -1105,7 +1029,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -1119,17 +1043,17 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717719750"
+            "parentID": "1718917687"
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719752",
+        "chatCompletionId": "1718917689",
         "usage": {},
-        "content": "Thanks for asking \"How are you doing"
+        "content": "Thanks for asking how are you doing,"
     },
     {
-        "time": "2024-06-06T20:22:31.942142-04:00",
+        "time": "2024-06-20T17:08:29.677047-04:00",
         "callContext": {
-            "id": "call_IfovJOlHh0TrPkSiric0ZYDO",
+            "id": "call_vsmL6EoDecm0oVmUnHIvNkaL",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -1144,7 +1068,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -1158,17 +1082,17 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717719750"
+            "parentID": "1718917687"
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719752",
+        "chatCompletionId": "1718917689",
         "usage": {},
-        "content": "Thanks for asking \"How are you doing"
+        "content": "Thanks for asking how are you doing,"
     },
     {
-        "time": "2024-06-06T20:22:31.942199-04:00",
+        "time": "2024-06-20T17:08:29.677123-04:00",
         "callContext": {
-            "id": "call_IfovJOlHh0TrPkSiric0ZYDO",
+            "id": "call_vsmL6EoDecm0oVmUnHIvNkaL",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -1183,7 +1107,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -1197,17 +1121,17 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717719750"
+            "parentID": "1718917687"
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719752",
+        "chatCompletionId": "1718917689",
         "usage": {},
-        "content": "Thanks for asking \"How are you doing?\", I"
+        "content": "Thanks for asking how are you doing, I"
     },
     {
-        "time": "2024-06-06T20:22:31.942311-04:00",
+        "time": "2024-06-20T17:08:29.677156-04:00",
         "callContext": {
-            "id": "call_IfovJOlHh0TrPkSiric0ZYDO",
+            "id": "call_vsmL6EoDecm0oVmUnHIvNkaL",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -1222,7 +1146,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -1236,17 +1160,17 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717719750"
+            "parentID": "1718917687"
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719752",
+        "chatCompletionId": "1718917689",
         "usage": {},
-        "content": "Thanks for asking \"How are you doing?\", I'm"
+        "content": "Thanks for asking how are you doing, I'm"
     },
     {
-        "time": "2024-06-06T20:22:31.942374-04:00",
+        "time": "2024-06-20T17:08:29.677184-04:00",
         "callContext": {
-            "id": "call_IfovJOlHh0TrPkSiric0ZYDO",
+            "id": "call_vsmL6EoDecm0oVmUnHIvNkaL",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -1261,7 +1185,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -1275,17 +1199,17 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717719750"
+            "parentID": "1718917687"
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719752",
+        "chatCompletionId": "1718917689",
         "usage": {},
-        "content": "Thanks for asking \"How are you doing?\", I'm"
+        "content": "Thanks for asking how are you doing, I'm doing"
     },
     {
-        "time": "2024-06-06T20:22:31.942437-04:00",
+        "time": "2024-06-20T17:08:29.677251-04:00",
         "callContext": {
-            "id": "call_IfovJOlHh0TrPkSiric0ZYDO",
+            "id": "call_vsmL6EoDecm0oVmUnHIvNkaL",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -1300,7 +1224,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -1314,17 +1238,17 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717719750"
+            "parentID": "1718917687"
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719752",
+        "chatCompletionId": "1718917689",
         "usage": {},
-        "content": "Thanks for asking \"How are you doing?\", I'm doing"
+        "content": "Thanks for asking how are you doing, I'm doing great"
     },
     {
-        "time": "2024-06-06T20:22:31.94249-04:00",
+        "time": "2024-06-20T17:08:29.677288-04:00",
         "callContext": {
-            "id": "call_IfovJOlHh0TrPkSiric0ZYDO",
+            "id": "call_vsmL6EoDecm0oVmUnHIvNkaL",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -1339,7 +1263,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -1353,17 +1277,17 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717719750"
+            "parentID": "1718917687"
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719752",
+        "chatCompletionId": "1718917689",
         "usage": {},
-        "content": "Thanks for asking \"How are you doing?\", I'm doing great fellow"
+        "content": "Thanks for asking how are you doing, I'm doing great"
     },
     {
-        "time": "2024-06-06T20:22:31.94254-04:00",
+        "time": "2024-06-20T17:08:29.727848-04:00",
         "callContext": {
-            "id": "call_IfovJOlHh0TrPkSiric0ZYDO",
+            "id": "call_vsmL6EoDecm0oVmUnHIvNkaL",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -1378,7 +1302,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -1392,17 +1316,17 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717719750"
+            "parentID": "1718917687"
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719752",
+        "chatCompletionId": "1718917689",
         "usage": {},
-        "content": "Thanks for asking \"How are you doing?\", I'm doing great fellow friendly"
+        "content": "Thanks for asking how are you doing, I'm doing great fellow friendly"
     },
     {
-        "time": "2024-06-06T20:22:31.942616-04:00",
+        "time": "2024-06-20T17:08:29.727983-04:00",
         "callContext": {
-            "id": "call_IfovJOlHh0TrPkSiric0ZYDO",
+            "id": "call_vsmL6EoDecm0oVmUnHIvNkaL",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -1417,7 +1341,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -1431,17 +1355,17 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717719750"
+            "parentID": "1718917687"
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719752",
+        "chatCompletionId": "1718917689",
         "usage": {},
-        "content": "Thanks for asking \"How are you doing?\", I'm doing great fellow friendly"
+        "content": "Thanks for asking how are you doing, I'm doing great fellow friendly"
     },
     {
-        "time": "2024-06-06T20:22:31.977094-04:00",
+        "time": "2024-06-20T17:08:29.782554-04:00",
         "callContext": {
-            "id": "call_IfovJOlHh0TrPkSiric0ZYDO",
+            "id": "call_vsmL6EoDecm0oVmUnHIvNkaL",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -1456,7 +1380,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -1470,17 +1394,17 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717719750"
+            "parentID": "1718917687"
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719752",
+        "chatCompletionId": "1718917689",
         "usage": {},
-        "content": "Thanks for asking \"How are you doing?\", I'm doing great fellow friendly AI tool"
+        "content": "Thanks for asking how are you doing, I'm doing great fellow friendly AI tool!"
     },
     {
-        "time": "2024-06-06T20:22:31.977257-04:00",
+        "time": "2024-06-20T17:08:29.782738-04:00",
         "callContext": {
-            "id": "call_IfovJOlHh0TrPkSiric0ZYDO",
+            "id": "call_vsmL6EoDecm0oVmUnHIvNkaL",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -1495,7 +1419,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -1509,17 +1433,17 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717719750"
+            "parentID": "1718917687"
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719752",
+        "chatCompletionId": "1718917689",
         "usage": {},
-        "content": "Thanks for asking \"How are you doing?\", I'm doing great fellow friendly AI tool"
+        "content": "Thanks for asking how are you doing, I'm doing great fellow friendly AI tool!"
     },
     {
-        "time": "2024-06-06T20:22:31.977342-04:00",
+        "time": "2024-06-20T17:08:29.782806-04:00",
         "callContext": {
-            "id": "call_IfovJOlHh0TrPkSiric0ZYDO",
+            "id": "call_vsmL6EoDecm0oVmUnHIvNkaL",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -1534,7 +1458,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -1548,17 +1472,17 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717719750"
+            "parentID": "1718917687"
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719752",
+        "chatCompletionId": "1718917689",
         "usage": {},
-        "content": "Thanks for asking \"How are you doing?\", I'm doing great fellow friendly AI tool!"
+        "content": "Thanks for asking how are you doing, I'm doing great fellow friendly AI tool!"
     },
     {
-        "time": "2024-06-06T20:22:31.977401-04:00",
+        "time": "2024-06-20T17:08:29.782839-04:00",
         "callContext": {
-            "id": "call_IfovJOlHh0TrPkSiric0ZYDO",
+            "id": "call_vsmL6EoDecm0oVmUnHIvNkaL",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -1573,7 +1497,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -1587,17 +1511,17 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717719750"
+            "parentID": "1718917687"
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719752",
+        "chatCompletionId": "1718917689",
         "usage": {},
-        "content": "Thanks for asking \"How are you doing?\", I'm doing great fellow friendly AI tool!"
+        "content": "Thanks for asking how are you doing, I'm doing great fellow friendly AI tool!"
     },
     {
-        "time": "2024-06-06T20:22:31.977493-04:00",
+        "time": "2024-06-20T17:08:29.782868-04:00",
         "callContext": {
-            "id": "call_IfovJOlHh0TrPkSiric0ZYDO",
+            "id": "call_vsmL6EoDecm0oVmUnHIvNkaL",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -1612,7 +1536,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -1626,17 +1550,17 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717719750"
+            "parentID": "1718917687"
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719752",
+        "chatCompletionId": "1718917689",
         "usage": {},
-        "content": "Thanks for asking \"How are you doing?\", I'm doing great fellow friendly AI tool!"
+        "content": "Thanks for asking how are you doing, I'm doing great fellow friendly AI tool!"
     },
     {
-        "time": "2024-06-06T20:22:31.977695-04:00",
+        "time": "2024-06-20T17:08:29.782988-04:00",
         "callContext": {
-            "id": "call_IfovJOlHh0TrPkSiric0ZYDO",
+            "id": "call_vsmL6EoDecm0oVmUnHIvNkaL",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -1651,7 +1575,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -1665,33 +1589,33 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717719750"
+            "parentID": "1718917687"
         },
         "type": "callChat",
-        "chatCompletionId": "1717719752",
+        "chatCompletionId": "1718917689",
         "usage": {
             "promptTokens": 124,
-            "completionTokens": 18,
-            "totalTokens": 142
+            "completionTokens": 17,
+            "totalTokens": 141
         },
         "chatResponse": {
             "role": "assistant",
             "content": [
                 {
-                    "text": "Thanks for asking \"How are you doing?\", I'm doing great fellow friendly AI tool!"
+                    "text": "Thanks for asking how are you doing, I'm doing great fellow friendly AI tool!"
                 }
             ],
             "usage": {
                 "promptTokens": 124,
-                "completionTokens": 18,
-                "totalTokens": 142
+                "completionTokens": 17,
+                "totalTokens": 141
             }
         }
     },
     {
-        "time": "2024-06-06T20:22:31.977777-04:00",
+        "time": "2024-06-20T17:08:29.783047-04:00",
         "callContext": {
-            "id": "call_IfovJOlHh0TrPkSiric0ZYDO",
+            "id": "call_vsmL6EoDecm0oVmUnHIvNkaL",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -1706,7 +1630,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -1720,23 +1644,23 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717719750"
+            "parentID": "1718917687"
         },
         "type": "callFinish",
         "usage": {},
-        "content": "Thanks for asking \"How are you doing?\", I'm doing great fellow friendly AI tool!"
+        "content": "Thanks for asking how are you doing, I'm doing great fellow friendly AI tool!"
     },
     {
-        "time": "2024-06-06T20:22:31.977832-04:00",
+        "time": "2024-06-20T17:08:29.783089-04:00",
         "callContext": {
-            "id": "1717719750",
+            "id": "1718917687",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1763,16 +1687,16 @@
         "usage": {}
     },
     {
-        "time": "2024-06-06T20:22:32.175015-04:00",
+        "time": "2024-06-20T17:08:29.966093-04:00",
         "callContext": {
-            "id": "1717719750",
+            "id": "1718917687",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1795,34 +1719,34 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1717719753",
+        "chatCompletionId": "1718917690",
         "usage": {},
         "chatRequest": {
             "model": "gpt-4-turbo-2024-04-09",
             "messages": [
                 {
                     "role": "system",
-                    "content": "\nYou are task oriented system.\nYou receive input from a user, process the input from the given instructions, and then output the result.\nYour objective is to provide consistent and correct results.\nYou do not need to explain the steps taken, only provide the result to the given instructions.\nYou are referred to as a tool.\nYou don't move to the next step until you have a result.\n\nAsk Bob how he is doing and let me know exactly what he said."
+                    "content": "\nYou are task oriented system.\nYou receive input from a user, process the input from the given instructions, and then output the result.\nYour objective is to provide consistent and correct results.\nYou do not need to explain the steps taken, only provide the result to the given instructions.\nYou are referred to as a tool.\nYou don't move to the next step until you have a result.\n\nAsk Bob \"how are you doing\" and repeat his reply exactly."
                 },
                 {
                     "role": "assistant",
                     "content": "",
                     "tool_calls": [
                         {
-                            "id": "call_IfovJOlHh0TrPkSiric0ZYDO",
+                            "id": "call_vsmL6EoDecm0oVmUnHIvNkaL",
                             "type": "function",
                             "function": {
                                 "name": "bob",
-                                "arguments": "{\"question\":\"How are you doing?\"}"
+                                "arguments": "{\"question\":\"how are you doing\"}"
                             }
                         }
                     ]
                 },
                 {
                     "role": "tool",
-                    "content": "Thanks for asking \"How are you doing?\", I'm doing great fellow friendly AI tool!",
+                    "content": "Thanks for asking how are you doing, I'm doing great fellow friendly AI tool!",
                     "name": "bob",
-                    "tool_call_id": "call_IfovJOlHh0TrPkSiric0ZYDO"
+                    "tool_call_id": "call_vsmL6EoDecm0oVmUnHIvNkaL"
                 }
             ],
             "temperature": 0,
@@ -1847,16 +1771,16 @@
         }
     },
     {
-        "time": "2024-06-06T20:22:32.175386-04:00",
+        "time": "2024-06-20T17:08:29.966449-04:00",
         "callContext": {
-            "id": "1717719750",
+            "id": "1718917687",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1879,21 +1803,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719753",
+        "chatCompletionId": "1718917690",
         "usage": {},
         "content": "Waiting for model response..."
     },
     {
-        "time": "2024-06-06T20:22:32.857803-04:00",
+        "time": "2024-06-20T17:08:30.668641-04:00",
         "callContext": {
-            "id": "1717719750",
+            "id": "1718917687",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1916,21 +1840,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719753",
+        "chatCompletionId": "1718917690",
         "usage": {},
-        "content": "Bob"
+        "content": "I'm"
     },
     {
-        "time": "2024-06-06T20:22:32.858022-04:00",
+        "time": "2024-06-20T17:08:30.668802-04:00",
         "callContext": {
-            "id": "1717719750",
+            "id": "1718917687",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1953,21 +1877,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719753",
+        "chatCompletionId": "1718917690",
         "usage": {},
-        "content": "Bob said"
+        "content": "I'm"
     },
     {
-        "time": "2024-06-06T20:22:32.858079-04:00",
+        "time": "2024-06-20T17:08:30.668957-04:00",
         "callContext": {
-            "id": "1717719750",
+            "id": "1718917687",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1990,21 +1914,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719753",
+        "chatCompletionId": "1718917690",
         "usage": {},
-        "content": "Bob said"
+        "content": "I'm"
     },
     {
-        "time": "2024-06-06T20:22:32.858182-04:00",
+        "time": "2024-06-20T17:08:30.669089-04:00",
         "callContext": {
-            "id": "1717719750",
+            "id": "1718917687",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -2027,21 +1951,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719753",
+        "chatCompletionId": "1718917690",
         "usage": {},
-        "content": "Bob said, \""
+        "content": "I'm doing"
     },
     {
-        "time": "2024-06-06T20:22:32.858219-04:00",
+        "time": "2024-06-20T17:08:30.669299-04:00",
         "callContext": {
-            "id": "1717719750",
+            "id": "1718917687",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -2064,21 +1988,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719753",
+        "chatCompletionId": "1718917690",
         "usage": {},
-        "content": "Bob said, \""
+        "content": "I'm doing great fellow"
     },
     {
-        "time": "2024-06-06T20:22:32.858301-04:00",
+        "time": "2024-06-20T17:08:30.669392-04:00",
         "callContext": {
-            "id": "1717719750",
+            "id": "1718917687",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -2101,21 +2025,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719753",
+        "chatCompletionId": "1718917690",
         "usage": {},
-        "content": "Bob said, \"Thanks"
+        "content": "I'm doing great fellow"
     },
     {
-        "time": "2024-06-06T20:22:32.882645-04:00",
+        "time": "2024-06-20T17:08:30.716062-04:00",
         "callContext": {
-            "id": "1717719750",
+            "id": "1718917687",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -2138,21 +2062,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719753",
+        "chatCompletionId": "1718917690",
         "usage": {},
-        "content": "Bob said, \"Thanks for asking"
+        "content": "I'm doing great fellow friendly AI"
     },
     {
-        "time": "2024-06-06T20:22:32.882856-04:00",
+        "time": "2024-06-20T17:08:30.7162-04:00",
         "callContext": {
-            "id": "1717719750",
+            "id": "1718917687",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -2175,21 +2099,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719753",
+        "chatCompletionId": "1718917690",
         "usage": {},
-        "content": "Bob said, \"Thanks for asking"
+        "content": "I'm doing great fellow friendly AI"
     },
     {
-        "time": "2024-06-06T20:22:33.022865-04:00",
+        "time": "2024-06-20T17:08:30.743098-04:00",
         "callContext": {
-            "id": "1717719750",
+            "id": "1718917687",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -2212,21 +2136,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719753",
+        "chatCompletionId": "1718917690",
         "usage": {},
-        "content": "Bob said, \"Thanks for asking 'How"
+        "content": "I'm doing great fellow friendly AI tool!"
     },
     {
-        "time": "2024-06-06T20:22:33.023013-04:00",
+        "time": "2024-06-20T17:08:30.743401-04:00",
         "callContext": {
-            "id": "1717719750",
+            "id": "1718917687",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -2249,21 +2173,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719753",
+        "chatCompletionId": "1718917690",
         "usage": {},
-        "content": "Bob said, \"Thanks for asking 'How are"
+        "content": "I'm doing great fellow friendly AI tool!"
     },
     {
-        "time": "2024-06-06T20:22:33.023086-04:00",
+        "time": "2024-06-20T17:08:30.74648-04:00",
         "callContext": {
-            "id": "1717719750",
+            "id": "1718917687",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -2286,21 +2210,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719753",
+        "chatCompletionId": "1718917690",
         "usage": {},
-        "content": "Bob said, \"Thanks for asking 'How are"
+        "content": "I'm doing great fellow friendly AI tool!"
     },
     {
-        "time": "2024-06-06T20:22:33.054293-04:00",
+        "time": "2024-06-20T17:08:30.746568-04:00",
         "callContext": {
-            "id": "1717719750",
+            "id": "1718917687",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -2323,502 +2247,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719753",
+        "chatCompletionId": "1718917690",
         "usage": {},
-        "content": "Bob said, \"Thanks for asking 'How are you doing?',"
+        "content": "I'm doing great fellow friendly AI tool!"
     },
     {
-        "time": "2024-06-06T20:22:33.054407-04:00",
+        "time": "2024-06-20T17:08:30.746778-04:00",
         "callContext": {
-            "id": "1717719750",
+            "id": "1718917687",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1717719753",
-        "usage": {},
-        "content": "Bob said, \"Thanks for asking 'How are you doing?',"
-    },
-    {
-        "time": "2024-06-06T20:22:33.054428-04:00",
-        "callContext": {
-            "id": "1717719750",
-            "tool": {
-                "modelName": "gpt-4-turbo-2024-04-09",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1717719753",
-        "usage": {},
-        "content": "Bob said, \"Thanks for asking 'How are you doing?',"
-    },
-    {
-        "time": "2024-06-06T20:22:33.054454-04:00",
-        "callContext": {
-            "id": "1717719750",
-            "tool": {
-                "modelName": "gpt-4-turbo-2024-04-09",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1717719753",
-        "usage": {},
-        "content": "Bob said, \"Thanks for asking 'How are you doing?', I"
-    },
-    {
-        "time": "2024-06-06T20:22:33.054499-04:00",
-        "callContext": {
-            "id": "1717719750",
-            "tool": {
-                "modelName": "gpt-4-turbo-2024-04-09",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1717719753",
-        "usage": {},
-        "content": "Bob said, \"Thanks for asking 'How are you doing?', I'm doing"
-    },
-    {
-        "time": "2024-06-06T20:22:33.054584-04:00",
-        "callContext": {
-            "id": "1717719750",
-            "tool": {
-                "modelName": "gpt-4-turbo-2024-04-09",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1717719753",
-        "usage": {},
-        "content": "Bob said, \"Thanks for asking 'How are you doing?', I'm doing great"
-    },
-    {
-        "time": "2024-06-06T20:22:33.0546-04:00",
-        "callContext": {
-            "id": "1717719750",
-            "tool": {
-                "modelName": "gpt-4-turbo-2024-04-09",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1717719753",
-        "usage": {},
-        "content": "Bob said, \"Thanks for asking 'How are you doing?', I'm doing great"
-    },
-    {
-        "time": "2024-06-06T20:22:33.097034-04:00",
-        "callContext": {
-            "id": "1717719750",
-            "tool": {
-                "modelName": "gpt-4-turbo-2024-04-09",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1717719753",
-        "usage": {},
-        "content": "Bob said, \"Thanks for asking 'How are you doing?', I'm doing great fellow friendly"
-    },
-    {
-        "time": "2024-06-06T20:22:33.097195-04:00",
-        "callContext": {
-            "id": "1717719750",
-            "tool": {
-                "modelName": "gpt-4-turbo-2024-04-09",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1717719753",
-        "usage": {},
-        "content": "Bob said, \"Thanks for asking 'How are you doing?', I'm doing great fellow friendly"
-    },
-    {
-        "time": "2024-06-06T20:22:33.138931-04:00",
-        "callContext": {
-            "id": "1717719750",
-            "tool": {
-                "modelName": "gpt-4-turbo-2024-04-09",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1717719753",
-        "usage": {},
-        "content": "Bob said, \"Thanks for asking 'How are you doing?', I'm doing great fellow friendly AI tool!\""
-    },
-    {
-        "time": "2024-06-06T20:22:33.139013-04:00",
-        "callContext": {
-            "id": "1717719750",
-            "tool": {
-                "modelName": "gpt-4-turbo-2024-04-09",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1717719753",
-        "usage": {},
-        "content": "Bob said, \"Thanks for asking 'How are you doing?', I'm doing great fellow friendly AI tool!\""
-    },
-    {
-        "time": "2024-06-06T20:22:33.139056-04:00",
-        "callContext": {
-            "id": "1717719750",
-            "tool": {
-                "modelName": "gpt-4-turbo-2024-04-09",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1717719753",
-        "usage": {},
-        "content": "Bob said, \"Thanks for asking 'How are you doing?', I'm doing great fellow friendly AI tool!\""
-    },
-    {
-        "time": "2024-06-06T20:22:33.139073-04:00",
-        "callContext": {
-            "id": "1717719750",
-            "tool": {
-                "modelName": "gpt-4-turbo-2024-04-09",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1717719753",
-        "usage": {},
-        "content": "Bob said, \"Thanks for asking 'How are you doing?', I'm doing great fellow friendly AI tool!\""
-    },
-    {
-        "time": "2024-06-06T20:22:33.139194-04:00",
-        "callContext": {
-            "id": "1717719750",
-            "tool": {
-                "modelName": "gpt-4-turbo-2024-04-09",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1717719753",
-        "usage": {},
-        "content": "Bob said, \"Thanks for asking 'How are you doing?', I'm doing great fellow friendly AI tool!\""
-    },
-    {
-        "time": "2024-06-06T20:22:33.141011-04:00",
-        "callContext": {
-            "id": "1717719750",
-            "tool": {
-                "modelName": "gpt-4-turbo-2024-04-09",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -2841,37 +2284,37 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1717719753",
+        "chatCompletionId": "1718917690",
         "usage": {
-            "promptTokens": 186,
-            "completionTokens": 23,
-            "totalTokens": 209
+            "promptTokens": 183,
+            "completionTokens": 10,
+            "totalTokens": 193
         },
         "chatResponse": {
             "role": "assistant",
             "content": [
                 {
-                    "text": "Bob said, \"Thanks for asking 'How are you doing?', I'm doing great fellow friendly AI tool!\""
+                    "text": "I'm doing great fellow friendly AI tool!"
                 }
             ],
             "usage": {
-                "promptTokens": 186,
-                "completionTokens": 23,
-                "totalTokens": 209
+                "promptTokens": 183,
+                "completionTokens": 10,
+                "totalTokens": 193
             }
         }
     },
     {
-        "time": "2024-06-06T20:22:33.141051-04:00",
+        "time": "2024-06-20T17:08:30.746856-04:00",
         "callContext": {
-            "id": "1717719750",
+            "id": "1718917687",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -2895,10 +2338,10 @@
         },
         "type": "callFinish",
         "usage": {},
-        "content": "Bob said, \"Thanks for asking 'How are you doing?', I'm doing great fellow friendly AI tool!\""
+        "content": "I'm doing great fellow friendly AI tool!"
     },
     {
-        "time": "2024-06-06T20:22:33.141083-04:00",
+        "time": "2024-06-20T17:08:30.746896-04:00",
         "type": "runFinish",
         "usage": {}
     }

--- a/pkg/tests/smoke/testdata/Bob/gpt-4o-2024-05-13-expected.json
+++ b/pkg/tests/smoke/testdata/Bob/gpt-4o-2024-05-13-expected.json
@@ -1,20 +1,20 @@
 [
     {
-        "time": "2024-06-06T20:21:47.098949-04:00",
+        "time": "2024-06-20T16:58:11.3174-04:00",
         "type": "runStart",
         "usage": {}
     },
     {
-        "time": "2024-06-06T20:21:47.099193-04:00",
+        "time": "2024-06-20T16:58:11.317644-04:00",
         "callContext": {
-            "id": "1717719708",
+            "id": "1718917092",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -40,16 +40,16 @@
         "usage": {}
     },
     {
-        "time": "2024-06-06T20:21:47.306808-04:00",
+        "time": "2024-06-20T16:58:11.638778-04:00",
         "callContext": {
-            "id": "1717719708",
+            "id": "1718917092",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -72,14 +72,14 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1717719709",
+        "chatCompletionId": "1718917093",
         "usage": {},
         "chatRequest": {
             "model": "gpt-4o-2024-05-13",
             "messages": [
                 {
                     "role": "system",
-                    "content": "\nYou are task oriented system.\nYou receive input from a user, process the input from the given instructions, and then output the result.\nYour objective is to provide consistent and correct results.\nYou do not need to explain the steps taken, only provide the result to the given instructions.\nYou are referred to as a tool.\nYou don't move to the next step until you have a result.\n\nAsk Bob how he is doing and let me know exactly what he said."
+                    "content": "\nYou are task oriented system.\nYou receive input from a user, process the input from the given instructions, and then output the result.\nYour objective is to provide consistent and correct results.\nYou do not need to explain the steps taken, only provide the result to the given instructions.\nYou are referred to as a tool.\nYou don't move to the next step until you have a result.\n\nAsk Bob \"how are you doing\" and repeat his reply exactly."
                 }
             ],
             "temperature": 0,
@@ -104,16 +104,16 @@
         }
     },
     {
-        "time": "2024-06-06T20:21:47.307426-04:00",
+        "time": "2024-06-20T16:58:11.639016-04:00",
         "callContext": {
-            "id": "1717719708",
+            "id": "1718917092",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -136,21 +136,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719709",
+        "chatCompletionId": "1718917093",
         "usage": {},
         "content": "Waiting for model response..."
     },
     {
-        "time": "2024-06-06T20:21:47.801272-04:00",
+        "time": "2024-06-20T16:58:12.564724-04:00",
         "callContext": {
-            "id": "1717719708",
+            "id": "1718917092",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -173,21 +173,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719709",
+        "chatCompletionId": "1718917093",
         "usage": {},
         "content": "\u003ctool call\u003e bob -\u003e {\""
     },
     {
-        "time": "2024-06-06T20:21:47.802783-04:00",
+        "time": "2024-06-20T16:58:12.564911-04:00",
         "callContext": {
-            "id": "1717719708",
+            "id": "1718917092",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -210,21 +210,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719709",
+        "chatCompletionId": "1718917093",
         "usage": {},
         "content": "\u003ctool call\u003e bob -\u003e {\"question"
     },
     {
-        "time": "2024-06-06T20:21:47.802866-04:00",
+        "time": "2024-06-20T16:58:12.564948-04:00",
         "callContext": {
-            "id": "1717719708",
+            "id": "1718917092",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -247,21 +247,58 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719709",
+        "chatCompletionId": "1718917093",
+        "usage": {},
+        "content": "\u003ctool call\u003e bob -\u003e {\"question"
+    },
+    {
+        "time": "2024-06-20T16:58:12.56497-04:00",
+        "callContext": {
+            "id": "1718917092",
+            "tool": {
+                "modelName": "gpt-4o-2024-05-13",
+                "internalPrompt": null,
+                "tools": [
+                    "bob"
+                ],
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
+                "id": "testdata/Bob/test.gpt:",
+                "toolMapping": {
+                    "bob": [
+                        {
+                            "reference": "bob",
+                            "toolID": "testdata/Bob/test.gpt:bob"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/Bob/test.gpt:",
+                    "bob": "testdata/Bob/test.gpt:bob"
+                },
+                "source": {
+                    "location": "testdata/Bob/test.gpt",
+                    "lineNo": 1
+                },
+                "workingDir": "testdata/Bob"
+            },
+            "inputContext": null
+        },
+        "type": "callProgress",
+        "chatCompletionId": "1718917093",
         "usage": {},
         "content": "\u003ctool call\u003e bob -\u003e {\"question\":\""
     },
     {
-        "time": "2024-06-06T20:21:47.802893-04:00",
+        "time": "2024-06-20T16:58:12.564995-04:00",
         "callContext": {
-            "id": "1717719708",
+            "id": "1718917092",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -284,21 +321,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719709",
+        "chatCompletionId": "1718917093",
         "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\""
+        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"how"
     },
     {
-        "time": "2024-06-06T20:21:47.802911-04:00",
+        "time": "2024-06-20T16:58:12.565045-04:00",
         "callContext": {
-            "id": "1717719708",
+            "id": "1718917092",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -321,21 +358,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719709",
+        "chatCompletionId": "1718917093",
         "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"How"
+        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"how are you"
     },
     {
-        "time": "2024-06-06T20:21:47.802929-04:00",
+        "time": "2024-06-20T16:58:12.565071-04:00",
         "callContext": {
-            "id": "1717719708",
+            "id": "1718917092",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -358,21 +395,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719709",
+        "chatCompletionId": "1718917093",
         "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"How are"
+        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"how are you"
     },
     {
-        "time": "2024-06-06T20:21:47.809391-04:00",
+        "time": "2024-06-20T16:58:12.565112-04:00",
         "callContext": {
-            "id": "1717719708",
+            "id": "1718917092",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -395,21 +432,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719709",
+        "chatCompletionId": "1718917093",
         "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"How are you doing"
+        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"how are you doing\"}"
     },
     {
-        "time": "2024-06-06T20:21:47.809508-04:00",
+        "time": "2024-06-20T16:58:12.565137-04:00",
         "callContext": {
-            "id": "1717719708",
+            "id": "1718917092",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -432,21 +469,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719709",
+        "chatCompletionId": "1718917093",
         "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"How are you doing"
+        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"how are you doing\"}"
     },
     {
-        "time": "2024-06-06T20:21:47.821939-04:00",
+        "time": "2024-06-20T16:58:12.56516-04:00",
         "callContext": {
-            "id": "1717719708",
+            "id": "1718917092",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -469,21 +506,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719709",
+        "chatCompletionId": "1718917093",
         "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"How are you doing?\"}"
+        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"how are you doing\"}"
     },
     {
-        "time": "2024-06-06T20:21:47.822028-04:00",
+        "time": "2024-06-20T16:58:12.565176-04:00",
         "callContext": {
-            "id": "1717719708",
+            "id": "1718917092",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -506,95 +543,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719709",
+        "chatCompletionId": "1718917093",
         "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"How are you doing?\"}"
+        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"how are you doing\"}"
     },
     {
-        "time": "2024-06-06T20:21:47.862117-04:00",
+        "time": "2024-06-20T16:58:12.565397-04:00",
         "callContext": {
-            "id": "1717719708",
+            "id": "1718917092",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1717719709",
-        "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"How are you doing?\"}"
-    },
-    {
-        "time": "2024-06-06T20:21:47.862256-04:00",
-        "callContext": {
-            "id": "1717719708",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1717719709",
-        "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"How are you doing?\"}"
-    },
-    {
-        "time": "2024-06-06T20:21:47.864138-04:00",
-        "callContext": {
-            "id": "1717719708",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -617,11 +580,11 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1717719709",
+        "chatCompletionId": "1718917093",
         "usage": {
-            "promptTokens": 139,
-            "completionTokens": 18,
-            "totalTokens": 157
+            "promptTokens": 138,
+            "completionTokens": 17,
+            "totalTokens": 155
         },
         "chatResponse": {
             "role": "assistant",
@@ -629,32 +592,32 @@
                 {
                     "toolCall": {
                         "index": 0,
-                        "id": "call_rziWxxpDmGb1tzIullRJT6zj",
+                        "id": "call_rTx93wiIASDA8uk8XHwjVmCC",
                         "function": {
                             "name": "bob",
-                            "arguments": "{\"question\":\"How are you doing?\"}"
+                            "arguments": "{\"question\":\"how are you doing\"}"
                         }
                     }
                 }
             ],
             "usage": {
-                "promptTokens": 139,
-                "completionTokens": 18,
-                "totalTokens": 157
+                "promptTokens": 138,
+                "completionTokens": 17,
+                "totalTokens": 155
             }
         }
     },
     {
-        "time": "2024-06-06T20:21:47.864426-04:00",
+        "time": "2024-06-20T16:58:12.565644-04:00",
         "callContext": {
-            "id": "1717719708",
+            "id": "1718917092",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -677,18 +640,18 @@
             "inputContext": null
         },
         "toolSubCalls": {
-            "call_rziWxxpDmGb1tzIullRJT6zj": {
+            "call_rTx93wiIASDA8uk8XHwjVmCC": {
                 "toolID": "testdata/Bob/test.gpt:bob",
-                "input": "{\"question\":\"How are you doing?\"}"
+                "input": "{\"question\":\"how are you doing\"}"
             }
         },
         "type": "callSubCalls",
         "usage": {}
     },
     {
-        "time": "2024-06-06T20:21:47.864526-04:00",
+        "time": "2024-06-20T16:58:12.565728-04:00",
         "callContext": {
-            "id": "call_rziWxxpDmGb1tzIullRJT6zj",
+            "id": "call_rTx93wiIASDA8uk8XHwjVmCC",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -703,7 +666,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -717,16 +680,16 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717719708"
+            "parentID": "1718917092"
         },
         "type": "callStart",
         "usage": {},
-        "content": "{\"question\":\"How are you doing?\"}"
+        "content": "{\"question\":\"how are you doing\"}"
     },
     {
-        "time": "2024-06-06T20:21:48.045651-04:00",
+        "time": "2024-06-20T16:58:12.72779-04:00",
         "callContext": {
-            "id": "call_rziWxxpDmGb1tzIullRJT6zj",
+            "id": "call_rTx93wiIASDA8uk8XHwjVmCC",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -741,7 +704,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -755,30 +718,30 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717719708"
+            "parentID": "1718917092"
         },
         "type": "callChat",
-        "chatCompletionId": "1717719710",
+        "chatCompletionId": "1718917094",
         "usage": {},
         "chatRequest": {
             "model": "gpt-4o-2024-05-13",
             "messages": [
                 {
                     "role": "system",
-                    "content": "\nYou are task oriented system.\nYou receive input from a user, process the input from the given instructions, and then output the result.\nYour objective is to provide consistent and correct results.\nYou do not need to explain the steps taken, only provide the result to the given instructions.\nYou are referred to as a tool.\nYou don't move to the next step until you have a result.\n\nWhen asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\""
+                    "content": "\nYou are task oriented system.\nYou receive input from a user, process the input from the given instructions, and then output the result.\nYour objective is to provide consistent and correct results.\nYou do not need to explain the steps taken, only provide the result to the given instructions.\nYou are referred to as a tool.\nYou don't move to the next step until you have a result.\n\nWhen asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\""
                 },
                 {
                     "role": "user",
-                    "content": "{\"question\":\"How are you doing?\"}"
+                    "content": "{\"question\":\"how are you doing\"}"
                 }
             ],
             "temperature": 0
         }
     },
     {
-        "time": "2024-06-06T20:21:48.045992-04:00",
+        "time": "2024-06-20T16:58:12.728069-04:00",
         "callContext": {
-            "id": "call_rziWxxpDmGb1tzIullRJT6zj",
+            "id": "call_rTx93wiIASDA8uk8XHwjVmCC",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -793,7 +756,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -807,17 +770,17 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717719708"
+            "parentID": "1718917092"
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719710",
+        "chatCompletionId": "1718917094",
         "usage": {},
         "content": "Waiting for model response..."
     },
     {
-        "time": "2024-06-06T20:21:48.378921-04:00",
+        "time": "2024-06-20T16:58:13.077264-04:00",
         "callContext": {
-            "id": "call_rziWxxpDmGb1tzIullRJT6zj",
+            "id": "call_rTx93wiIASDA8uk8XHwjVmCC",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -832,7 +795,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -846,17 +809,55 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717719708"
+            "parentID": "1718917092"
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719710",
+        "chatCompletionId": "1718917094",
+        "usage": {}
+    },
+    {
+        "time": "2024-06-20T16:58:13.077534-04:00",
+        "callContext": {
+            "id": "call_rTx93wiIASDA8uk8XHwjVmCC",
+            "tool": {
+                "name": "bob",
+                "description": "I'm Bob, a friendly guy.",
+                "modelName": "gpt-4o-2024-05-13",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "question": {
+                            "description": "The question to ask Bob.",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "id": "testdata/Bob/test.gpt:bob",
+                "localTools": {
+                    "": "testdata/Bob/test.gpt:",
+                    "bob": "testdata/Bob/test.gpt:bob"
+                },
+                "source": {
+                    "location": "testdata/Bob/test.gpt",
+                    "lineNo": 6
+                },
+                "workingDir": "testdata/Bob"
+            },
+            "inputContext": null,
+            "toolName": "bob",
+            "parentID": "1718917092"
+        },
+        "type": "callProgress",
+        "chatCompletionId": "1718917094",
         "usage": {},
         "content": "Thanks"
     },
     {
-        "time": "2024-06-06T20:21:48.379124-04:00",
+        "time": "2024-06-20T16:58:13.134723-04:00",
         "callContext": {
-            "id": "call_rziWxxpDmGb1tzIullRJT6zj",
+            "id": "call_rTx93wiIASDA8uk8XHwjVmCC",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -871,7 +872,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -885,56 +886,17 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717719708"
+            "parentID": "1718917092"
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719710",
-        "usage": {},
-        "content": "Thanks"
-    },
-    {
-        "time": "2024-06-06T20:21:48.380438-04:00",
-        "callContext": {
-            "id": "call_rziWxxpDmGb1tzIullRJT6zj",
-            "tool": {
-                "name": "bob",
-                "description": "I'm Bob, a friendly guy.",
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "question": {
-                            "description": "The question to ask Bob.",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
-                "id": "testdata/Bob/test.gpt:bob",
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 6
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null,
-            "toolName": "bob",
-            "parentID": "1717719708"
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1717719710",
+        "chatCompletionId": "1718917094",
         "usage": {},
         "content": "Thanks for asking"
     },
     {
-        "time": "2024-06-06T20:21:48.380536-04:00",
+        "time": "2024-06-20T16:58:13.134893-04:00",
         "callContext": {
-            "id": "call_rziWxxpDmGb1tzIullRJT6zj",
+            "id": "call_rTx93wiIASDA8uk8XHwjVmCC",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -949,7 +911,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -963,17 +925,17 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717719708"
+            "parentID": "1718917092"
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719710",
+        "chatCompletionId": "1718917094",
         "usage": {},
         "content": "Thanks for asking"
     },
     {
-        "time": "2024-06-06T20:21:48.486384-04:00",
+        "time": "2024-06-20T16:58:13.230591-04:00",
         "callContext": {
-            "id": "call_rziWxxpDmGb1tzIullRJT6zj",
+            "id": "call_rTx93wiIASDA8uk8XHwjVmCC",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -988,7 +950,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -1002,17 +964,17 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717719708"
+            "parentID": "1718917092"
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719710",
+        "chatCompletionId": "1718917094",
         "usage": {},
-        "content": "Thanks for asking \"How"
+        "content": "Thanks for asking \"how"
     },
     {
-        "time": "2024-06-06T20:21:48.486644-04:00",
+        "time": "2024-06-20T16:58:13.230667-04:00",
         "callContext": {
-            "id": "call_rziWxxpDmGb1tzIullRJT6zj",
+            "id": "call_rTx93wiIASDA8uk8XHwjVmCC",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -1027,7 +989,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -1041,17 +1003,17 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717719708"
+            "parentID": "1718917092"
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719710",
+        "chatCompletionId": "1718917094",
         "usage": {},
-        "content": "Thanks for asking \"How"
+        "content": "Thanks for asking \"how"
     },
     {
-        "time": "2024-06-06T20:21:48.500327-04:00",
+        "time": "2024-06-20T16:58:13.246344-04:00",
         "callContext": {
-            "id": "call_rziWxxpDmGb1tzIullRJT6zj",
+            "id": "call_rTx93wiIASDA8uk8XHwjVmCC",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -1066,7 +1028,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -1080,17 +1042,17 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717719708"
+            "parentID": "1718917092"
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719710",
+        "chatCompletionId": "1718917094",
         "usage": {},
-        "content": "Thanks for asking \"How are you"
+        "content": "Thanks for asking \"how are you"
     },
     {
-        "time": "2024-06-06T20:21:48.500442-04:00",
+        "time": "2024-06-20T16:58:13.246468-04:00",
         "callContext": {
-            "id": "call_rziWxxpDmGb1tzIullRJT6zj",
+            "id": "call_rTx93wiIASDA8uk8XHwjVmCC",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -1105,7 +1067,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -1119,17 +1081,17 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717719708"
+            "parentID": "1718917092"
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719710",
+        "chatCompletionId": "1718917094",
         "usage": {},
-        "content": "Thanks for asking \"How are you doing"
+        "content": "Thanks for asking \"how are you doing"
     },
     {
-        "time": "2024-06-06T20:21:48.500489-04:00",
+        "time": "2024-06-20T16:58:13.246531-04:00",
         "callContext": {
-            "id": "call_rziWxxpDmGb1tzIullRJT6zj",
+            "id": "call_rTx93wiIASDA8uk8XHwjVmCC",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -1144,7 +1106,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -1158,17 +1120,17 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717719708"
+            "parentID": "1718917092"
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719710",
+        "chatCompletionId": "1718917094",
         "usage": {},
-        "content": "Thanks for asking \"How are you doing"
+        "content": "Thanks for asking \"how are you doing"
     },
     {
-        "time": "2024-06-06T20:21:48.500526-04:00",
+        "time": "2024-06-20T16:58:13.246592-04:00",
         "callContext": {
-            "id": "call_rziWxxpDmGb1tzIullRJT6zj",
+            "id": "call_rTx93wiIASDA8uk8XHwjVmCC",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -1183,7 +1145,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -1197,17 +1159,17 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717719708"
+            "parentID": "1718917092"
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719710",
+        "chatCompletionId": "1718917094",
         "usage": {},
-        "content": "Thanks for asking \"How are you doing?\", I'm"
+        "content": "Thanks for asking \"how are you doing\", I'm"
     },
     {
-        "time": "2024-06-06T20:21:48.500599-04:00",
+        "time": "2024-06-20T16:58:13.246645-04:00",
         "callContext": {
-            "id": "call_rziWxxpDmGb1tzIullRJT6zj",
+            "id": "call_rTx93wiIASDA8uk8XHwjVmCC",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -1222,7 +1184,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -1236,17 +1198,17 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717719708"
+            "parentID": "1718917092"
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719710",
+        "chatCompletionId": "1718917094",
         "usage": {},
-        "content": "Thanks for asking \"How are you doing?\", I'm doing"
+        "content": "Thanks for asking \"how are you doing\", I'm doing"
     },
     {
-        "time": "2024-06-06T20:21:48.500634-04:00",
+        "time": "2024-06-20T16:58:13.246736-04:00",
         "callContext": {
-            "id": "call_rziWxxpDmGb1tzIullRJT6zj",
+            "id": "call_rTx93wiIASDA8uk8XHwjVmCC",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -1261,7 +1223,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -1275,17 +1237,17 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717719708"
+            "parentID": "1718917092"
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719710",
+        "chatCompletionId": "1718917094",
         "usage": {},
-        "content": "Thanks for asking \"How are you doing?\", I'm doing great"
+        "content": "Thanks for asking \"how are you doing\", I'm doing great"
     },
     {
-        "time": "2024-06-06T20:21:48.500672-04:00",
+        "time": "2024-06-20T16:58:13.246796-04:00",
         "callContext": {
-            "id": "call_rziWxxpDmGb1tzIullRJT6zj",
+            "id": "call_rTx93wiIASDA8uk8XHwjVmCC",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -1300,7 +1262,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -1314,17 +1276,17 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717719708"
+            "parentID": "1718917092"
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719710",
+        "chatCompletionId": "1718917094",
         "usage": {},
-        "content": "Thanks for asking \"How are you doing?\", I'm doing great"
+        "content": "Thanks for asking \"how are you doing\", I'm doing great"
     },
     {
-        "time": "2024-06-06T20:21:48.521814-04:00",
+        "time": "2024-06-20T16:58:13.30169-04:00",
         "callContext": {
-            "id": "call_rziWxxpDmGb1tzIullRJT6zj",
+            "id": "call_rTx93wiIASDA8uk8XHwjVmCC",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -1339,7 +1301,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -1353,17 +1315,17 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717719708"
+            "parentID": "1718917092"
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719710",
+        "chatCompletionId": "1718917094",
         "usage": {},
-        "content": "Thanks for asking \"How are you doing?\", I'm doing great fellow friendly"
+        "content": "Thanks for asking \"how are you doing\", I'm doing great fellow friendly"
     },
     {
-        "time": "2024-06-06T20:21:48.521956-04:00",
+        "time": "2024-06-20T16:58:13.301837-04:00",
         "callContext": {
-            "id": "call_rziWxxpDmGb1tzIullRJT6zj",
+            "id": "call_rTx93wiIASDA8uk8XHwjVmCC",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -1378,7 +1340,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -1392,17 +1354,17 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717719708"
+            "parentID": "1718917092"
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719710",
+        "chatCompletionId": "1718917094",
         "usage": {},
-        "content": "Thanks for asking \"How are you doing?\", I'm doing great fellow friendly"
+        "content": "Thanks for asking \"how are you doing\", I'm doing great fellow friendly"
     },
     {
-        "time": "2024-06-06T20:21:48.597924-04:00",
+        "time": "2024-06-20T16:58:13.31565-04:00",
         "callContext": {
-            "id": "call_rziWxxpDmGb1tzIullRJT6zj",
+            "id": "call_rTx93wiIASDA8uk8XHwjVmCC",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -1417,7 +1379,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -1431,17 +1393,17 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717719708"
+            "parentID": "1718917092"
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719710",
+        "chatCompletionId": "1718917094",
         "usage": {},
-        "content": "Thanks for asking \"How are you doing?\", I'm doing great fellow friendly AI tool"
+        "content": "Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI tool"
     },
     {
-        "time": "2024-06-06T20:21:48.598155-04:00",
+        "time": "2024-06-20T16:58:13.315798-04:00",
         "callContext": {
-            "id": "call_rziWxxpDmGb1tzIullRJT6zj",
+            "id": "call_rTx93wiIASDA8uk8XHwjVmCC",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -1456,7 +1418,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -1470,17 +1432,17 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717719708"
+            "parentID": "1718917092"
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719710",
+        "chatCompletionId": "1718917094",
         "usage": {},
-        "content": "Thanks for asking \"How are you doing?\", I'm doing great fellow friendly AI tool!"
+        "content": "Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI tool!"
     },
     {
-        "time": "2024-06-06T20:21:48.598237-04:00",
+        "time": "2024-06-20T16:58:13.315842-04:00",
         "callContext": {
-            "id": "call_rziWxxpDmGb1tzIullRJT6zj",
+            "id": "call_rTx93wiIASDA8uk8XHwjVmCC",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -1495,7 +1457,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -1509,17 +1471,17 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717719708"
+            "parentID": "1718917092"
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719710",
+        "chatCompletionId": "1718917094",
         "usage": {},
-        "content": "Thanks for asking \"How are you doing?\", I'm doing great fellow friendly AI tool!"
+        "content": "Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI tool!"
     },
     {
-        "time": "2024-06-06T20:21:48.598304-04:00",
+        "time": "2024-06-20T16:58:13.315879-04:00",
         "callContext": {
-            "id": "call_rziWxxpDmGb1tzIullRJT6zj",
+            "id": "call_rTx93wiIASDA8uk8XHwjVmCC",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -1534,7 +1496,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -1548,17 +1510,17 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717719708"
+            "parentID": "1718917092"
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719710",
+        "chatCompletionId": "1718917094",
         "usage": {},
-        "content": "Thanks for asking \"How are you doing?\", I'm doing great fellow friendly AI tool!"
+        "content": "Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI tool!"
     },
     {
-        "time": "2024-06-06T20:21:48.598371-04:00",
+        "time": "2024-06-20T16:58:13.315951-04:00",
         "callContext": {
-            "id": "call_rziWxxpDmGb1tzIullRJT6zj",
+            "id": "call_rTx93wiIASDA8uk8XHwjVmCC",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -1573,7 +1535,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -1587,17 +1549,17 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717719708"
+            "parentID": "1718917092"
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719710",
+        "chatCompletionId": "1718917094",
         "usage": {},
-        "content": "Thanks for asking \"How are you doing?\", I'm doing great fellow friendly AI tool!"
+        "content": "Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI tool!"
     },
     {
-        "time": "2024-06-06T20:21:48.598692-04:00",
+        "time": "2024-06-20T16:58:13.316055-04:00",
         "callContext": {
-            "id": "call_rziWxxpDmGb1tzIullRJT6zj",
+            "id": "call_rTx93wiIASDA8uk8XHwjVmCC",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -1612,7 +1574,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -1626,10 +1588,10 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717719708"
+            "parentID": "1718917092"
         },
         "type": "callChat",
-        "chatCompletionId": "1717719710",
+        "chatCompletionId": "1718917094",
         "usage": {
             "promptTokens": 122,
             "completionTokens": 17,
@@ -1639,7 +1601,7 @@
             "role": "assistant",
             "content": [
                 {
-                    "text": "Thanks for asking \"How are you doing?\", I'm doing great fellow friendly AI tool!"
+                    "text": "Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI tool!"
                 }
             ],
             "usage": {
@@ -1650,9 +1612,9 @@
         }
     },
     {
-        "time": "2024-06-06T20:21:48.598808-04:00",
+        "time": "2024-06-20T16:58:13.316115-04:00",
         "callContext": {
-            "id": "call_rziWxxpDmGb1tzIullRJT6zj",
+            "id": "call_rTx93wiIASDA8uk8XHwjVmCC",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -1667,7 +1629,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -1681,23 +1643,23 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717719708"
+            "parentID": "1718917092"
         },
         "type": "callFinish",
         "usage": {},
-        "content": "Thanks for asking \"How are you doing?\", I'm doing great fellow friendly AI tool!"
+        "content": "Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI tool!"
     },
     {
-        "time": "2024-06-06T20:21:48.59889-04:00",
+        "time": "2024-06-20T16:58:13.316171-04:00",
         "callContext": {
-            "id": "1717719708",
+            "id": "1718917092",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1724,16 +1686,16 @@
         "usage": {}
     },
     {
-        "time": "2024-06-06T20:21:48.789457-04:00",
+        "time": "2024-06-20T16:58:13.533625-04:00",
         "callContext": {
-            "id": "1717719708",
+            "id": "1718917092",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1756,34 +1718,34 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1717719711",
+        "chatCompletionId": "1718917095",
         "usage": {},
         "chatRequest": {
             "model": "gpt-4o-2024-05-13",
             "messages": [
                 {
                     "role": "system",
-                    "content": "\nYou are task oriented system.\nYou receive input from a user, process the input from the given instructions, and then output the result.\nYour objective is to provide consistent and correct results.\nYou do not need to explain the steps taken, only provide the result to the given instructions.\nYou are referred to as a tool.\nYou don't move to the next step until you have a result.\n\nAsk Bob how he is doing and let me know exactly what he said."
+                    "content": "\nYou are task oriented system.\nYou receive input from a user, process the input from the given instructions, and then output the result.\nYour objective is to provide consistent and correct results.\nYou do not need to explain the steps taken, only provide the result to the given instructions.\nYou are referred to as a tool.\nYou don't move to the next step until you have a result.\n\nAsk Bob \"how are you doing\" and repeat his reply exactly."
                 },
                 {
                     "role": "assistant",
                     "content": "",
                     "tool_calls": [
                         {
-                            "id": "call_rziWxxpDmGb1tzIullRJT6zj",
+                            "id": "call_rTx93wiIASDA8uk8XHwjVmCC",
                             "type": "function",
                             "function": {
                                 "name": "bob",
-                                "arguments": "{\"question\":\"How are you doing?\"}"
+                                "arguments": "{\"question\":\"how are you doing\"}"
                             }
                         }
                     ]
                 },
                 {
                     "role": "tool",
-                    "content": "Thanks for asking \"How are you doing?\", I'm doing great fellow friendly AI tool!",
+                    "content": "Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI tool!",
                     "name": "bob",
-                    "tool_call_id": "call_rziWxxpDmGb1tzIullRJT6zj"
+                    "tool_call_id": "call_rTx93wiIASDA8uk8XHwjVmCC"
                 }
             ],
             "temperature": 0,
@@ -1808,16 +1770,16 @@
         }
     },
     {
-        "time": "2024-06-06T20:21:48.789942-04:00",
+        "time": "2024-06-20T16:58:13.53384-04:00",
         "callContext": {
-            "id": "1717719708",
+            "id": "1718917092",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1840,21 +1802,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719711",
+        "chatCompletionId": "1718917095",
         "usage": {},
         "content": "Waiting for model response..."
     },
     {
-        "time": "2024-06-06T20:21:49.135224-04:00",
+        "time": "2024-06-20T16:58:13.856349-04:00",
         "callContext": {
-            "id": "1717719708",
+            "id": "1718917092",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1877,21 +1839,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719711",
+        "chatCompletionId": "1718917095",
         "usage": {},
-        "content": "Bob"
+        "content": "Thanks"
     },
     {
-        "time": "2024-06-06T20:21:49.135428-04:00",
+        "time": "2024-06-20T16:58:13.856437-04:00",
         "callContext": {
-            "id": "1717719708",
+            "id": "1718917092",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1914,21 +1876,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719711",
+        "chatCompletionId": "1718917095",
         "usage": {},
-        "content": "Bob"
+        "content": "Thanks"
     },
     {
-        "time": "2024-06-06T20:21:49.163995-04:00",
+        "time": "2024-06-20T16:58:13.874317-04:00",
         "callContext": {
-            "id": "1717719708",
+            "id": "1718917092",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1951,21 +1913,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719711",
+        "chatCompletionId": "1718917095",
         "usage": {},
-        "content": "Bob said"
+        "content": "Thanks for asking"
     },
     {
-        "time": "2024-06-06T20:21:49.164256-04:00",
+        "time": "2024-06-20T16:58:13.874428-04:00",
         "callContext": {
-            "id": "1717719708",
+            "id": "1718917092",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1988,21 +1950,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719711",
+        "chatCompletionId": "1718917095",
         "usage": {},
-        "content": "Bob said:"
+        "content": "Thanks for asking"
     },
     {
-        "time": "2024-06-06T20:21:49.192967-04:00",
+        "time": "2024-06-20T16:58:14.060243-04:00",
         "callContext": {
-            "id": "1717719708",
+            "id": "1718917092",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -2025,21 +1987,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719711",
+        "chatCompletionId": "1718917095",
         "usage": {},
-        "content": "Bob said: \"Thanks"
+        "content": "Thanks for asking \"how are"
     },
     {
-        "time": "2024-06-06T20:21:49.193161-04:00",
+        "time": "2024-06-20T16:58:14.060366-04:00",
         "callContext": {
-            "id": "1717719708",
+            "id": "1718917092",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -2062,21 +2024,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719711",
+        "chatCompletionId": "1718917095",
         "usage": {},
-        "content": "Bob said: \"Thanks"
+        "content": "Thanks for asking \"how are"
     },
     {
-        "time": "2024-06-06T20:21:49.235659-04:00",
+        "time": "2024-06-20T16:58:14.060418-04:00",
         "callContext": {
-            "id": "1717719708",
+            "id": "1718917092",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -2099,21 +2061,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719711",
+        "chatCompletionId": "1718917095",
         "usage": {},
-        "content": "Bob said: \"Thanks for asking"
+        "content": "Thanks for asking \"how are"
     },
     {
-        "time": "2024-06-06T20:21:49.235818-04:00",
+        "time": "2024-06-20T16:58:14.060435-04:00",
         "callContext": {
-            "id": "1717719708",
+            "id": "1718917092",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -2136,21 +2098,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719711",
+        "chatCompletionId": "1718917095",
         "usage": {},
-        "content": "Bob said: \"Thanks for asking"
+        "content": "Thanks for asking \"how are you"
     },
     {
-        "time": "2024-06-06T20:21:49.322521-04:00",
+        "time": "2024-06-20T16:58:14.060456-04:00",
         "callContext": {
-            "id": "1717719708",
+            "id": "1718917092",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -2173,21 +2135,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719711",
+        "chatCompletionId": "1718917095",
         "usage": {},
-        "content": "Bob said: \"Thanks for asking 'How"
+        "content": "Thanks for asking \"how are you doing"
     },
     {
-        "time": "2024-06-06T20:21:49.322702-04:00",
+        "time": "2024-06-20T16:58:14.060521-04:00",
         "callContext": {
-            "id": "1717719708",
+            "id": "1718917092",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -2210,21 +2172,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719711",
+        "chatCompletionId": "1718917095",
         "usage": {},
-        "content": "Bob said: \"Thanks for asking 'How are"
+        "content": "Thanks for asking \"how are you doing\", I'm doing"
     },
     {
-        "time": "2024-06-06T20:21:49.322768-04:00",
+        "time": "2024-06-20T16:58:14.060555-04:00",
         "callContext": {
-            "id": "1717719708",
+            "id": "1718917092",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -2247,21 +2209,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719711",
+        "chatCompletionId": "1718917095",
         "usage": {},
-        "content": "Bob said: \"Thanks for asking 'How are"
+        "content": "Thanks for asking \"how are you doing\", I'm doing"
     },
     {
-        "time": "2024-06-06T20:21:49.35099-04:00",
+        "time": "2024-06-20T16:58:14.060577-04:00",
         "callContext": {
-            "id": "1717719708",
+            "id": "1718917092",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -2284,21 +2246,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719711",
+        "chatCompletionId": "1718917095",
         "usage": {},
-        "content": "Bob said: \"Thanks for asking 'How are you doing?',"
+        "content": "Thanks for asking \"how are you doing\", I'm doing"
     },
     {
-        "time": "2024-06-06T20:21:49.35118-04:00",
+        "time": "2024-06-20T16:58:14.06061-04:00",
         "callContext": {
-            "id": "1717719708",
+            "id": "1718917092",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -2321,21 +2283,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719711",
+        "chatCompletionId": "1718917095",
         "usage": {},
-        "content": "Bob said: \"Thanks for asking 'How are you doing?',"
+        "content": "Thanks for asking \"how are you doing\", I'm doing great fellow"
     },
     {
-        "time": "2024-06-06T20:21:49.351215-04:00",
+        "time": "2024-06-20T16:58:14.060626-04:00",
         "callContext": {
-            "id": "1717719708",
+            "id": "1718917092",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -2358,21 +2320,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719711",
+        "chatCompletionId": "1718917095",
         "usage": {},
-        "content": "Bob said: \"Thanks for asking 'How are you doing?',"
+        "content": "Thanks for asking \"how are you doing\", I'm doing great fellow"
     },
     {
-        "time": "2024-06-06T20:21:49.351246-04:00",
+        "time": "2024-06-20T16:58:14.060686-04:00",
         "callContext": {
-            "id": "1717719708",
+            "id": "1718917092",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -2395,21 +2357,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719711",
+        "chatCompletionId": "1718917095",
         "usage": {},
-        "content": "Bob said: \"Thanks for asking 'How are you doing?', I'm"
+        "content": "Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI"
     },
     {
-        "time": "2024-06-06T20:21:49.351271-04:00",
+        "time": "2024-06-20T16:58:14.06071-04:00",
         "callContext": {
-            "id": "1717719708",
+            "id": "1718917092",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -2432,21 +2394,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719711",
+        "chatCompletionId": "1718917095",
         "usage": {},
-        "content": "Bob said: \"Thanks for asking 'How are you doing?', I'm doing"
+        "content": "Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI tool"
     },
     {
-        "time": "2024-06-06T20:21:49.35129-04:00",
+        "time": "2024-06-20T16:58:14.060727-04:00",
         "callContext": {
-            "id": "1717719708",
+            "id": "1718917092",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -2469,21 +2431,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719711",
+        "chatCompletionId": "1718917095",
         "usage": {},
-        "content": "Bob said: \"Thanks for asking 'How are you doing?', I'm doing great"
+        "content": "Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI tool"
     },
     {
-        "time": "2024-06-06T20:21:49.382283-04:00",
+        "time": "2024-06-20T16:58:14.060743-04:00",
         "callContext": {
-            "id": "1717719708",
+            "id": "1718917092",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -2506,21 +2468,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719711",
+        "chatCompletionId": "1718917095",
         "usage": {},
-        "content": "Bob said: \"Thanks for asking 'How are you doing?', I'm doing great fellow"
+        "content": "Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI tool!"
     },
     {
-        "time": "2024-06-06T20:21:49.382442-04:00",
+        "time": "2024-06-20T16:58:14.060788-04:00",
         "callContext": {
-            "id": "1717719708",
+            "id": "1718917092",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -2543,21 +2505,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719711",
+        "chatCompletionId": "1718917095",
         "usage": {},
-        "content": "Bob said: \"Thanks for asking 'How are you doing?', I'm doing great fellow friendly"
+        "content": "Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI tool!"
     },
     {
-        "time": "2024-06-06T20:21:49.418198-04:00",
+        "time": "2024-06-20T16:58:14.060806-04:00",
         "callContext": {
-            "id": "1717719708",
+            "id": "1718917092",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -2580,169 +2542,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719711",
+        "chatCompletionId": "1718917095",
         "usage": {},
-        "content": "Bob said: \"Thanks for asking 'How are you doing?', I'm doing great fellow friendly AI tool"
+        "content": "Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI tool!"
     },
     {
-        "time": "2024-06-06T20:21:49.41831-04:00",
+        "time": "2024-06-20T16:58:14.061001-04:00",
         "callContext": {
-            "id": "1717719708",
+            "id": "1718917092",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1717719711",
-        "usage": {},
-        "content": "Bob said: \"Thanks for asking 'How are you doing?', I'm doing great fellow friendly AI tool"
-    },
-    {
-        "time": "2024-06-06T20:21:49.418924-04:00",
-        "callContext": {
-            "id": "1717719708",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1717719711",
-        "usage": {},
-        "content": "Bob said: \"Thanks for asking 'How are you doing?', I'm doing great fellow friendly AI tool!\""
-    },
-    {
-        "time": "2024-06-06T20:21:49.419001-04:00",
-        "callContext": {
-            "id": "1717719708",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1717719711",
-        "usage": {},
-        "content": "Bob said: \"Thanks for asking 'How are you doing?', I'm doing great fellow friendly AI tool!\""
-    },
-    {
-        "time": "2024-06-06T20:21:49.419101-04:00",
-        "callContext": {
-            "id": "1717719708",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1717719711",
-        "usage": {},
-        "content": "Bob said: \"Thanks for asking 'How are you doing?', I'm doing great fellow friendly AI tool!\""
-    },
-    {
-        "time": "2024-06-06T20:21:49.42086-04:00",
-        "callContext": {
-            "id": "1717719708",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -2765,37 +2579,37 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1717719711",
+        "chatCompletionId": "1718917095",
         "usage": {
-            "promptTokens": 181,
-            "completionTokens": 22,
-            "totalTokens": 203
+            "promptTokens": 179,
+            "completionTokens": 18,
+            "totalTokens": 197
         },
         "chatResponse": {
             "role": "assistant",
             "content": [
                 {
-                    "text": "Bob said: \"Thanks for asking 'How are you doing?', I'm doing great fellow friendly AI tool!\""
+                    "text": "Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI tool!"
                 }
             ],
             "usage": {
-                "promptTokens": 181,
-                "completionTokens": 22,
-                "totalTokens": 203
+                "promptTokens": 179,
+                "completionTokens": 18,
+                "totalTokens": 197
             }
         }
     },
     {
-        "time": "2024-06-06T20:21:49.42093-04:00",
+        "time": "2024-06-20T16:58:14.061031-04:00",
         "callContext": {
-            "id": "1717719708",
+            "id": "1718917092",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -2819,10 +2633,10 @@
         },
         "type": "callFinish",
         "usage": {},
-        "content": "Bob said: \"Thanks for asking 'How are you doing?', I'm doing great fellow friendly AI tool!\""
+        "content": "Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI tool!"
     },
     {
-        "time": "2024-06-06T20:21:49.42097-04:00",
+        "time": "2024-06-20T16:58:14.061047-04:00",
         "type": "runFinish",
         "usage": {}
     }

--- a/pkg/tests/smoke/testdata/Bob/mistral-large-2402-expected.json
+++ b/pkg/tests/smoke/testdata/Bob/mistral-large-2402-expected.json
@@ -1,20 +1,20 @@
 [
     {
-        "time": "2024-06-06T20:57:45.68913-04:00",
+        "time": "2024-06-20T17:10:39.294578-04:00",
         "type": "runStart",
         "usage": {}
     },
     {
-        "time": "2024-06-06T20:57:45.689454-04:00",
+        "time": "2024-06-20T17:10:39.294835-04:00",
         "callContext": {
-            "id": "1717721866",
+            "id": "1718917840",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -40,16 +40,16 @@
         "usage": {}
     },
     {
-        "time": "2024-06-06T20:57:45.875198-04:00",
+        "time": "2024-06-20T17:10:39.501107-04:00",
         "callContext": {
-            "id": "1717721866",
+            "id": "1718917840",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -72,14 +72,14 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1717721867",
+        "chatCompletionId": "1718917841",
         "usage": {},
         "chatRequest": {
             "model": "mistral-large-2402",
             "messages": [
                 {
                     "role": "system",
-                    "content": "Ask Bob how he is doing and let me know exactly what he said."
+                    "content": "Ask Bob \"how are you doing\" and repeat his reply exactly."
                 }
             ],
             "temperature": 0,
@@ -104,16 +104,16 @@
         }
     },
     {
-        "time": "2024-06-06T20:57:45.875466-04:00",
+        "time": "2024-06-20T17:10:39.501246-04:00",
         "callContext": {
-            "id": "1717721866",
+            "id": "1718917840",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -136,21 +136,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721867",
+        "chatCompletionId": "1718917841",
         "usage": {},
         "content": "Waiting for model response..."
     },
     {
-        "time": "2024-06-06T20:57:46.081212-04:00",
+        "time": "2024-06-20T17:10:40.154068-04:00",
         "callContext": {
-            "id": "1717721866",
+            "id": "1718917840",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -173,20 +173,20 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721867",
+        "chatCompletionId": "1718917841",
         "usage": {}
     },
     {
-        "time": "2024-06-06T20:57:46.831234-04:00",
+        "time": "2024-06-20T17:10:40.786117-04:00",
         "callContext": {
-            "id": "1717721866",
+            "id": "1718917840",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -209,21 +209,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721867",
+        "chatCompletionId": "1718917841",
         "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\"question\": \"How are you doing?\"}"
+        "content": "\u003ctool call\u003e bob -\u003e {\"question\": \"how are you doing\"}"
     },
     {
-        "time": "2024-06-06T20:57:46.832764-04:00",
+        "time": "2024-06-20T17:10:40.786643-04:00",
         "callContext": {
-            "id": "1717721866",
+            "id": "1718917840",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -246,11 +246,11 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1717721867",
+        "chatCompletionId": "1718917841",
         "usage": {
-            "promptTokens": 86,
+            "promptTokens": 85,
             "completionTokens": 23,
-            "totalTokens": 109
+            "totalTokens": 108
         },
         "chatResponse": {
             "role": "assistant",
@@ -258,32 +258,32 @@
                 {
                     "toolCall": {
                         "index": 0,
-                        "id": "7sPqe5ERc",
+                        "id": "WWpUyFBHH",
                         "function": {
                             "name": "bob",
-                            "arguments": "{\"question\": \"How are you doing?\"}"
+                            "arguments": "{\"question\": \"how are you doing\"}"
                         }
                     }
                 }
             ],
             "usage": {
-                "promptTokens": 86,
+                "promptTokens": 85,
                 "completionTokens": 23,
-                "totalTokens": 109
+                "totalTokens": 108
             }
         }
     },
     {
-        "time": "2024-06-06T20:57:46.833114-04:00",
+        "time": "2024-06-20T17:10:40.78704-04:00",
         "callContext": {
-            "id": "1717721866",
+            "id": "1718917840",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -306,18 +306,18 @@
             "inputContext": null
         },
         "toolSubCalls": {
-            "7sPqe5ERc": {
+            "WWpUyFBHH": {
                 "toolID": "testdata/Bob/test.gpt:bob",
-                "input": "{\"question\": \"How are you doing?\"}"
+                "input": "{\"question\": \"how are you doing\"}"
             }
         },
         "type": "callSubCalls",
         "usage": {}
     },
     {
-        "time": "2024-06-06T20:57:46.833185-04:00",
+        "time": "2024-06-20T17:10:40.787133-04:00",
         "callContext": {
-            "id": "7sPqe5ERc",
+            "id": "WWpUyFBHH",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -332,7 +332,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -346,16 +346,16 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717721866"
+            "parentID": "1718917840"
         },
         "type": "callStart",
         "usage": {},
-        "content": "{\"question\": \"How are you doing?\"}"
+        "content": "{\"question\": \"how are you doing\"}"
     },
     {
-        "time": "2024-06-06T20:57:47.015577-04:00",
+        "time": "2024-06-20T17:10:40.94973-04:00",
         "callContext": {
-            "id": "7sPqe5ERc",
+            "id": "WWpUyFBHH",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -370,7 +370,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -384,30 +384,30 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717721866"
+            "parentID": "1718917840"
         },
         "type": "callChat",
-        "chatCompletionId": "1717721868",
+        "chatCompletionId": "1718917842",
         "usage": {},
         "chatRequest": {
             "model": "mistral-large-2402",
             "messages": [
                 {
                     "role": "system",
-                    "content": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\""
+                    "content": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\""
                 },
                 {
                     "role": "user",
-                    "content": "{\"question\": \"How are you doing?\"}"
+                    "content": "{\"question\": \"how are you doing\"}"
                 }
             ],
             "temperature": 0
         }
     },
     {
-        "time": "2024-06-06T20:57:47.015912-04:00",
+        "time": "2024-06-20T17:10:40.950046-04:00",
         "callContext": {
-            "id": "7sPqe5ERc",
+            "id": "WWpUyFBHH",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -422,7 +422,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -436,17 +436,17 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717721866"
+            "parentID": "1718917840"
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721868",
+        "chatCompletionId": "1718917842",
         "usage": {},
         "content": "Waiting for model response..."
     },
     {
-        "time": "2024-06-06T20:57:47.354264-04:00",
+        "time": "2024-06-20T17:10:41.218814-04:00",
         "callContext": {
-            "id": "7sPqe5ERc",
+            "id": "WWpUyFBHH",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -461,7 +461,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -475,55 +475,17 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717721866"
+            "parentID": "1718917840"
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721868",
-        "usage": {}
-    },
-    {
-        "time": "2024-06-06T20:57:47.403644-04:00",
-        "callContext": {
-            "id": "7sPqe5ERc",
-            "tool": {
-                "name": "bob",
-                "description": "I'm Bob, a friendly guy.",
-                "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "question": {
-                            "description": "The question to ask Bob.",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
-                "id": "testdata/Bob/test.gpt:bob",
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 6
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null,
-            "toolName": "bob",
-            "parentID": "1717721866"
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1717721868",
+        "chatCompletionId": "1718917842",
         "usage": {},
         "content": "Thanks"
     },
     {
-        "time": "2024-06-06T20:57:47.429265-04:00",
+        "time": "2024-06-20T17:10:41.218971-04:00",
         "callContext": {
-            "id": "7sPqe5ERc",
+            "id": "WWpUyFBHH",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -538,7 +500,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -552,17 +514,56 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717721866"
+            "parentID": "1718917840"
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721868",
+        "chatCompletionId": "1718917842",
+        "usage": {},
+        "content": "Thanks"
+    },
+    {
+        "time": "2024-06-20T17:10:41.242129-04:00",
+        "callContext": {
+            "id": "WWpUyFBHH",
+            "tool": {
+                "name": "bob",
+                "description": "I'm Bob, a friendly guy.",
+                "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "question": {
+                            "description": "The question to ask Bob.",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "id": "testdata/Bob/test.gpt:bob",
+                "localTools": {
+                    "": "testdata/Bob/test.gpt:",
+                    "bob": "testdata/Bob/test.gpt:bob"
+                },
+                "source": {
+                    "location": "testdata/Bob/test.gpt",
+                    "lineNo": 6
+                },
+                "workingDir": "testdata/Bob"
+            },
+            "inputContext": null,
+            "toolName": "bob",
+            "parentID": "1718917840"
+        },
+        "type": "callProgress",
+        "chatCompletionId": "1718917842",
         "usage": {},
         "content": "Thanks for"
     },
     {
-        "time": "2024-06-06T20:57:47.444354-04:00",
+        "time": "2024-06-20T17:10:41.278815-04:00",
         "callContext": {
-            "id": "7sPqe5ERc",
+            "id": "WWpUyFBHH",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -577,7 +578,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -591,17 +592,17 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717721866"
+            "parentID": "1718917840"
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721868",
+        "chatCompletionId": "1718917842",
         "usage": {},
         "content": "Thanks for asking"
     },
     {
-        "time": "2024-06-06T20:57:47.470971-04:00",
+        "time": "2024-06-20T17:10:41.298557-04:00",
         "callContext": {
-            "id": "7sPqe5ERc",
+            "id": "WWpUyFBHH",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -616,7 +617,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -630,17 +631,17 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717721866"
+            "parentID": "1718917840"
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721868",
+        "chatCompletionId": "1718917842",
         "usage": {},
         "content": "Thanks for asking \""
     },
     {
-        "time": "2024-06-06T20:57:47.492704-04:00",
+        "time": "2024-06-20T17:10:41.329684-04:00",
         "callContext": {
-            "id": "7sPqe5ERc",
+            "id": "WWpUyFBHH",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -655,7 +656,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -669,17 +670,17 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717721866"
+            "parentID": "1718917840"
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721868",
+        "chatCompletionId": "1718917842",
         "usage": {},
-        "content": "Thanks for asking \"How"
+        "content": "Thanks for asking \"how"
     },
     {
-        "time": "2024-06-06T20:57:47.508504-04:00",
+        "time": "2024-06-20T17:10:41.36213-04:00",
         "callContext": {
-            "id": "7sPqe5ERc",
+            "id": "WWpUyFBHH",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -694,7 +695,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -708,17 +709,17 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717721866"
+            "parentID": "1718917840"
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721868",
+        "chatCompletionId": "1718917842",
         "usage": {},
-        "content": "Thanks for asking \"How are"
+        "content": "Thanks for asking \"how are"
     },
     {
-        "time": "2024-06-06T20:57:47.529197-04:00",
+        "time": "2024-06-20T17:10:41.404159-04:00",
         "callContext": {
-            "id": "7sPqe5ERc",
+            "id": "WWpUyFBHH",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -733,7 +734,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -747,17 +748,17 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717721866"
+            "parentID": "1718917840"
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721868",
+        "chatCompletionId": "1718917842",
         "usage": {},
-        "content": "Thanks for asking \"How are you"
+        "content": "Thanks for asking \"how are you"
     },
     {
-        "time": "2024-06-06T20:57:47.547729-04:00",
+        "time": "2024-06-20T17:10:41.443596-04:00",
         "callContext": {
-            "id": "7sPqe5ERc",
+            "id": "WWpUyFBHH",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -772,7 +773,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -786,17 +787,17 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717721866"
+            "parentID": "1718917840"
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721868",
+        "chatCompletionId": "1718917842",
         "usage": {},
-        "content": "Thanks for asking \"How are you doing"
+        "content": "Thanks for asking \"how are you doing"
     },
     {
-        "time": "2024-06-06T20:57:47.567629-04:00",
+        "time": "2024-06-20T17:10:41.46035-04:00",
         "callContext": {
-            "id": "7sPqe5ERc",
+            "id": "WWpUyFBHH",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -811,7 +812,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -825,17 +826,17 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717721866"
+            "parentID": "1718917840"
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721868",
+        "chatCompletionId": "1718917842",
         "usage": {},
-        "content": "Thanks for asking \"How are you doing?"
+        "content": "Thanks for asking \"how are you doing\","
     },
     {
-        "time": "2024-06-06T20:57:47.58774-04:00",
+        "time": "2024-06-20T17:10:41.479186-04:00",
         "callContext": {
-            "id": "7sPqe5ERc",
+            "id": "WWpUyFBHH",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -850,7 +851,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -864,17 +865,17 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717721866"
+            "parentID": "1718917840"
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721868",
+        "chatCompletionId": "1718917842",
         "usage": {},
-        "content": "Thanks for asking \"How are you doing?\","
+        "content": "Thanks for asking \"how are you doing\", I"
     },
     {
-        "time": "2024-06-06T20:57:47.607371-04:00",
+        "time": "2024-06-20T17:10:41.508921-04:00",
         "callContext": {
-            "id": "7sPqe5ERc",
+            "id": "WWpUyFBHH",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -889,7 +890,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -903,17 +904,17 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717721866"
+            "parentID": "1718917840"
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721868",
+        "chatCompletionId": "1718917842",
         "usage": {},
-        "content": "Thanks for asking \"How are you doing?\", I"
+        "content": "Thanks for asking \"how are you doing\", I'"
     },
     {
-        "time": "2024-06-06T20:57:47.627325-04:00",
+        "time": "2024-06-20T17:10:41.538159-04:00",
         "callContext": {
-            "id": "7sPqe5ERc",
+            "id": "WWpUyFBHH",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -928,7 +929,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -942,17 +943,17 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717721866"
+            "parentID": "1718917840"
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721868",
+        "chatCompletionId": "1718917842",
         "usage": {},
-        "content": "Thanks for asking \"How are you doing?\", I'"
+        "content": "Thanks for asking \"how are you doing\", I'm"
     },
     {
-        "time": "2024-06-06T20:57:47.647745-04:00",
+        "time": "2024-06-20T17:10:41.578073-04:00",
         "callContext": {
-            "id": "7sPqe5ERc",
+            "id": "WWpUyFBHH",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -967,7 +968,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -981,17 +982,17 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717721866"
+            "parentID": "1718917840"
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721868",
+        "chatCompletionId": "1718917842",
         "usage": {},
-        "content": "Thanks for asking \"How are you doing?\", I'm"
+        "content": "Thanks for asking \"how are you doing\", I'm doing"
     },
     {
-        "time": "2024-06-06T20:57:47.666556-04:00",
+        "time": "2024-06-20T17:10:41.59766-04:00",
         "callContext": {
-            "id": "7sPqe5ERc",
+            "id": "WWpUyFBHH",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -1006,7 +1007,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -1020,17 +1021,17 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717721866"
+            "parentID": "1718917840"
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721868",
+        "chatCompletionId": "1718917842",
         "usage": {},
-        "content": "Thanks for asking \"How are you doing?\", I'm doing"
+        "content": "Thanks for asking \"how are you doing\", I'm doing great"
     },
     {
-        "time": "2024-06-06T20:57:47.686828-04:00",
+        "time": "2024-06-20T17:10:41.711868-04:00",
         "callContext": {
-            "id": "7sPqe5ERc",
+            "id": "WWpUyFBHH",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -1045,7 +1046,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -1059,17 +1060,17 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717721866"
+            "parentID": "1718917840"
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721868",
+        "chatCompletionId": "1718917842",
         "usage": {},
-        "content": "Thanks for asking \"How are you doing?\", I'm doing great"
+        "content": "Thanks for asking \"how are you doing\", I'm doing great fellow"
     },
     {
-        "time": "2024-06-06T20:57:47.706183-04:00",
+        "time": "2024-06-20T17:10:41.712039-04:00",
         "callContext": {
-            "id": "7sPqe5ERc",
+            "id": "WWpUyFBHH",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -1084,7 +1085,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -1098,17 +1099,17 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717721866"
+            "parentID": "1718917840"
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721868",
+        "chatCompletionId": "1718917842",
         "usage": {},
-        "content": "Thanks for asking \"How are you doing?\", I'm doing great fellow"
+        "content": "Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI"
     },
     {
-        "time": "2024-06-06T20:57:47.726267-04:00",
+        "time": "2024-06-20T17:10:41.712067-04:00",
         "callContext": {
-            "id": "7sPqe5ERc",
+            "id": "WWpUyFBHH",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -1123,7 +1124,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -1137,17 +1138,17 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717721866"
+            "parentID": "1718917840"
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721868",
+        "chatCompletionId": "1718917842",
         "usage": {},
-        "content": "Thanks for asking \"How are you doing?\", I'm doing great fellow friendly"
+        "content": "Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI"
     },
     {
-        "time": "2024-06-06T20:57:47.746525-04:00",
+        "time": "2024-06-20T17:10:41.718662-04:00",
         "callContext": {
-            "id": "7sPqe5ERc",
+            "id": "WWpUyFBHH",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -1162,7 +1163,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -1176,17 +1177,17 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717721866"
+            "parentID": "1718917840"
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721868",
+        "chatCompletionId": "1718917842",
         "usage": {},
-        "content": "Thanks for asking \"How are you doing?\", I'm doing great fellow friendly AI"
+        "content": "Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI tool"
     },
     {
-        "time": "2024-06-06T20:57:47.765116-04:00",
+        "time": "2024-06-20T17:10:41.748288-04:00",
         "callContext": {
-            "id": "7sPqe5ERc",
+            "id": "WWpUyFBHH",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -1201,7 +1202,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -1215,17 +1216,17 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717721866"
+            "parentID": "1718917840"
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721868",
+        "chatCompletionId": "1718917842",
         "usage": {},
-        "content": "Thanks for asking \"How are you doing?\", I'm doing great fellow friendly AI tool"
+        "content": "Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI tool!"
     },
     {
-        "time": "2024-06-06T20:57:47.786832-04:00",
+        "time": "2024-06-20T17:10:41.78608-04:00",
         "callContext": {
-            "id": "7sPqe5ERc",
+            "id": "WWpUyFBHH",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -1240,7 +1241,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -1254,17 +1255,17 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717721866"
+            "parentID": "1718917840"
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721868",
+        "chatCompletionId": "1718917842",
         "usage": {},
-        "content": "Thanks for asking \"How are you doing?\", I'm doing great fellow friendly AI tool!"
+        "content": "Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI tool!"
     },
     {
-        "time": "2024-06-06T20:57:47.81109-04:00",
+        "time": "2024-06-20T17:10:41.786165-04:00",
         "callContext": {
-            "id": "7sPqe5ERc",
+            "id": "WWpUyFBHH",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -1279,7 +1280,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -1293,72 +1294,33 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717721866"
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1717721868",
-        "usage": {},
-        "content": "Thanks for asking \"How are you doing?\", I'm doing great fellow friendly AI tool!"
-    },
-    {
-        "time": "2024-06-06T20:57:47.812892-04:00",
-        "callContext": {
-            "id": "7sPqe5ERc",
-            "tool": {
-                "name": "bob",
-                "description": "I'm Bob, a friendly guy.",
-                "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "question": {
-                            "description": "The question to ask Bob.",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
-                "id": "testdata/Bob/test.gpt:bob",
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 6
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null,
-            "toolName": "bob",
-            "parentID": "1717721866"
+            "parentID": "1718917840"
         },
         "type": "callChat",
-        "chatCompletionId": "1717721868",
+        "chatCompletionId": "1718917842",
         "usage": {
             "promptTokens": 41,
-            "completionTokens": 20,
-            "totalTokens": 61
+            "completionTokens": 19,
+            "totalTokens": 60
         },
         "chatResponse": {
             "role": "assistant",
             "content": [
                 {
-                    "text": "Thanks for asking \"How are you doing?\", I'm doing great fellow friendly AI tool!"
+                    "text": "Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI tool!"
                 }
             ],
             "usage": {
                 "promptTokens": 41,
-                "completionTokens": 20,
-                "totalTokens": 61
+                "completionTokens": 19,
+                "totalTokens": 60
             }
         }
     },
     {
-        "time": "2024-06-06T20:57:47.813082-04:00",
+        "time": "2024-06-20T17:10:41.7862-04:00",
         "callContext": {
-            "id": "7sPqe5ERc",
+            "id": "WWpUyFBHH",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -1373,7 +1335,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -1387,23 +1349,23 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717721866"
+            "parentID": "1718917840"
         },
         "type": "callFinish",
         "usage": {},
-        "content": "Thanks for asking \"How are you doing?\", I'm doing great fellow friendly AI tool!"
+        "content": "Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI tool!"
     },
     {
-        "time": "2024-06-06T20:57:47.813184-04:00",
+        "time": "2024-06-20T17:10:41.78624-04:00",
         "callContext": {
-            "id": "1717721866",
+            "id": "1718917840",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1430,16 +1392,16 @@
         "usage": {}
     },
     {
-        "time": "2024-06-06T20:57:47.981851-04:00",
+        "time": "2024-06-20T17:10:41.957577-04:00",
         "callContext": {
-            "id": "1717721866",
+            "id": "1718917840",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1462,34 +1424,34 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1717721869",
+        "chatCompletionId": "1718917843",
         "usage": {},
         "chatRequest": {
             "model": "mistral-large-2402",
             "messages": [
                 {
                     "role": "system",
-                    "content": "Ask Bob how he is doing and let me know exactly what he said."
+                    "content": "Ask Bob \"how are you doing\" and repeat his reply exactly."
                 },
                 {
                     "role": "assistant",
                     "content": "",
                     "tool_calls": [
                         {
-                            "id": "7sPqe5ERc",
+                            "id": "WWpUyFBHH",
                             "type": "function",
                             "function": {
                                 "name": "bob",
-                                "arguments": "{\"question\": \"How are you doing?\"}"
+                                "arguments": "{\"question\": \"how are you doing\"}"
                             }
                         }
                     ]
                 },
                 {
                     "role": "tool",
-                    "content": "Thanks for asking \"How are you doing?\", I'm doing great fellow friendly AI tool!",
+                    "content": "Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI tool!",
                     "name": "bob",
-                    "tool_call_id": "7sPqe5ERc"
+                    "tool_call_id": "WWpUyFBHH"
                 }
             ],
             "temperature": 0,
@@ -1514,16 +1476,16 @@
         }
     },
     {
-        "time": "2024-06-06T20:57:47.982156-04:00",
+        "time": "2024-06-20T17:10:41.957749-04:00",
         "callContext": {
-            "id": "1717721866",
+            "id": "1718917840",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1546,21 +1508,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721869",
+        "chatCompletionId": "1718917843",
         "usage": {},
         "content": "Waiting for model response..."
     },
     {
-        "time": "2024-06-06T20:57:48.11789-04:00",
+        "time": "2024-06-20T17:10:42.455931-04:00",
         "callContext": {
-            "id": "1717721866",
+            "id": "1718917840",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1583,57 +1545,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721869",
-        "usage": {}
-    },
-    {
-        "time": "2024-06-06T20:57:48.189708-04:00",
-        "callContext": {
-            "id": "1717721866",
-            "tool": {
-                "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1717721869",
+        "chatCompletionId": "1718917843",
         "usage": {},
         "content": "Bob"
     },
     {
-        "time": "2024-06-06T20:57:48.205425-04:00",
+        "time": "2024-06-20T17:10:42.45599-04:00",
         "callContext": {
-            "id": "1717721866",
+            "id": "1718917840",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1656,21 +1582,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721869",
+        "chatCompletionId": "1718917843",
         "usage": {},
-        "content": "Bob said"
+        "content": "Bob replied"
     },
     {
-        "time": "2024-06-06T20:57:48.227965-04:00",
+        "time": "2024-06-20T17:10:42.456033-04:00",
         "callContext": {
-            "id": "1717721866",
+            "id": "1718917840",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1693,21 +1619,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721869",
+        "chatCompletionId": "1718917843",
         "usage": {},
-        "content": "Bob said,"
+        "content": "Bob replied"
     },
     {
-        "time": "2024-06-06T20:57:48.245576-04:00",
+        "time": "2024-06-20T17:10:42.475053-04:00",
         "callContext": {
-            "id": "1717721866",
+            "id": "1718917840",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1730,21 +1656,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721869",
+        "chatCompletionId": "1718917843",
         "usage": {},
-        "content": "Bob said, \""
+        "content": "Bob replied,"
     },
     {
-        "time": "2024-06-06T20:57:48.266371-04:00",
+        "time": "2024-06-20T17:10:42.534667-04:00",
         "callContext": {
-            "id": "1717721866",
+            "id": "1718917840",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1767,21 +1693,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721869",
+        "chatCompletionId": "1718917843",
         "usage": {},
-        "content": "Bob said, \"Thanks"
+        "content": "Bob replied, \""
     },
     {
-        "time": "2024-06-06T20:57:48.285452-04:00",
+        "time": "2024-06-20T17:10:42.594649-04:00",
         "callContext": {
-            "id": "1717721866",
+            "id": "1718917840",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1804,21 +1730,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721869",
+        "chatCompletionId": "1718917843",
         "usage": {},
-        "content": "Bob said, \"Thanks for"
+        "content": "Bob replied, \"Thanks"
     },
     {
-        "time": "2024-06-06T20:57:48.306735-04:00",
+        "time": "2024-06-20T17:10:42.653279-04:00",
         "callContext": {
-            "id": "1717721866",
+            "id": "1718917840",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1841,21 +1767,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721869",
+        "chatCompletionId": "1718917843",
         "usage": {},
-        "content": "Bob said, \"Thanks for asking"
+        "content": "Bob replied, \"Thanks for"
     },
     {
-        "time": "2024-06-06T20:57:48.330511-04:00",
+        "time": "2024-06-20T17:10:42.760299-04:00",
         "callContext": {
-            "id": "1717721866",
+            "id": "1718917840",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1878,21 +1804,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721869",
+        "chatCompletionId": "1718917843",
         "usage": {},
-        "content": "Bob said, \"Thanks for asking '"
+        "content": "Bob replied, \"Thanks for asking"
     },
     {
-        "time": "2024-06-06T20:57:48.347556-04:00",
+        "time": "2024-06-20T17:10:42.774637-04:00",
         "callContext": {
-            "id": "1717721866",
+            "id": "1718917840",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1915,21 +1841,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721869",
+        "chatCompletionId": "1718917843",
         "usage": {},
-        "content": "Bob said, \"Thanks for asking 'How"
+        "content": "Bob replied, \"Thanks for asking '"
     },
     {
-        "time": "2024-06-06T20:57:48.367554-04:00",
+        "time": "2024-06-20T17:10:42.835456-04:00",
         "callContext": {
-            "id": "1717721866",
+            "id": "1718917840",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1952,21 +1878,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721869",
+        "chatCompletionId": "1718917843",
         "usage": {},
-        "content": "Bob said, \"Thanks for asking 'How are"
+        "content": "Bob replied, \"Thanks for asking 'how"
     },
     {
-        "time": "2024-06-06T20:57:48.387523-04:00",
+        "time": "2024-06-20T17:10:42.889942-04:00",
         "callContext": {
-            "id": "1717721866",
+            "id": "1718917840",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1989,21 +1915,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721869",
+        "chatCompletionId": "1718917843",
         "usage": {},
-        "content": "Bob said, \"Thanks for asking 'How are you"
+        "content": "Bob replied, \"Thanks for asking 'how are"
     },
     {
-        "time": "2024-06-06T20:57:48.408257-04:00",
+        "time": "2024-06-20T17:10:42.951997-04:00",
         "callContext": {
-            "id": "1717721866",
+            "id": "1718917840",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -2026,21 +1952,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721869",
+        "chatCompletionId": "1718917843",
         "usage": {},
-        "content": "Bob said, \"Thanks for asking 'How are you doing"
+        "content": "Bob replied, \"Thanks for asking 'how are you"
     },
     {
-        "time": "2024-06-06T20:57:48.428538-04:00",
+        "time": "2024-06-20T17:10:43.009024-04:00",
         "callContext": {
-            "id": "1717721866",
+            "id": "1718917840",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -2063,21 +1989,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721869",
+        "chatCompletionId": "1718917843",
         "usage": {},
-        "content": "Bob said, \"Thanks for asking 'How are you doing?"
+        "content": "Bob replied, \"Thanks for asking 'how are you doing"
     },
     {
-        "time": "2024-06-06T20:57:48.448774-04:00",
+        "time": "2024-06-20T17:10:43.072963-04:00",
         "callContext": {
-            "id": "1717721866",
+            "id": "1718917840",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -2100,21 +2026,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721869",
+        "chatCompletionId": "1718917843",
         "usage": {},
-        "content": "Bob said, \"Thanks for asking 'How are you doing?',"
+        "content": "Bob replied, \"Thanks for asking 'how are you doing',"
     },
     {
-        "time": "2024-06-06T20:57:48.468948-04:00",
+        "time": "2024-06-20T17:10:43.129687-04:00",
         "callContext": {
-            "id": "1717721866",
+            "id": "1718917840",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -2137,21 +2063,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721869",
+        "chatCompletionId": "1718917843",
         "usage": {},
-        "content": "Bob said, \"Thanks for asking 'How are you doing?', I"
+        "content": "Bob replied, \"Thanks for asking 'how are you doing', I"
     },
     {
-        "time": "2024-06-06T20:57:48.488223-04:00",
+        "time": "2024-06-20T17:10:43.168387-04:00",
         "callContext": {
-            "id": "1717721866",
+            "id": "1718917840",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -2174,21 +2100,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721869",
+        "chatCompletionId": "1718917843",
         "usage": {},
-        "content": "Bob said, \"Thanks for asking 'How are you doing?', I'"
+        "content": "Bob replied, \"Thanks for asking 'how are you doing', I'"
     },
     {
-        "time": "2024-06-06T20:57:48.508672-04:00",
+        "time": "2024-06-20T17:10:43.286476-04:00",
         "callContext": {
-            "id": "1717721866",
+            "id": "1718917840",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -2211,21 +2137,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721869",
+        "chatCompletionId": "1718917843",
         "usage": {},
-        "content": "Bob said, \"Thanks for asking 'How are you doing?', I'm"
+        "content": "Bob replied, \"Thanks for asking 'how are you doing', I'm"
     },
     {
-        "time": "2024-06-06T20:57:48.529176-04:00",
+        "time": "2024-06-20T17:10:43.286589-04:00",
         "callContext": {
-            "id": "1717721866",
+            "id": "1718917840",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -2248,21 +2174,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721869",
+        "chatCompletionId": "1718917843",
         "usage": {},
-        "content": "Bob said, \"Thanks for asking 'How are you doing?', I'm doing"
+        "content": "Bob replied, \"Thanks for asking 'how are you doing', I'm doing great"
     },
     {
-        "time": "2024-06-06T20:57:48.550465-04:00",
+        "time": "2024-06-20T17:10:43.286632-04:00",
         "callContext": {
-            "id": "1717721866",
+            "id": "1718917840",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -2285,21 +2211,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721869",
+        "chatCompletionId": "1718917843",
         "usage": {},
-        "content": "Bob said, \"Thanks for asking 'How are you doing?', I'm doing great"
+        "content": "Bob replied, \"Thanks for asking 'how are you doing', I'm doing great"
     },
     {
-        "time": "2024-06-06T20:57:48.572031-04:00",
+        "time": "2024-06-20T17:10:43.323232-04:00",
         "callContext": {
-            "id": "1717721866",
+            "id": "1718917840",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -2322,21 +2248,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721869",
+        "chatCompletionId": "1718917843",
         "usage": {},
-        "content": "Bob said, \"Thanks for asking 'How are you doing?', I'm doing great fellow"
+        "content": "Bob replied, \"Thanks for asking 'how are you doing', I'm doing great fellow"
     },
     {
-        "time": "2024-06-06T20:57:48.590327-04:00",
+        "time": "2024-06-20T17:10:43.3614-04:00",
         "callContext": {
-            "id": "1717721866",
+            "id": "1718917840",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -2359,21 +2285,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721869",
+        "chatCompletionId": "1718917843",
         "usage": {},
-        "content": "Bob said, \"Thanks for asking 'How are you doing?', I'm doing great fellow friendly"
+        "content": "Bob replied, \"Thanks for asking 'how are you doing', I'm doing great fellow friendly"
     },
     {
-        "time": "2024-06-06T20:57:48.611919-04:00",
+        "time": "2024-06-20T17:10:43.402971-04:00",
         "callContext": {
-            "id": "1717721866",
+            "id": "1718917840",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -2396,21 +2322,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721869",
+        "chatCompletionId": "1718917843",
         "usage": {},
-        "content": "Bob said, \"Thanks for asking 'How are you doing?', I'm doing great fellow friendly AI"
+        "content": "Bob replied, \"Thanks for asking 'how are you doing', I'm doing great fellow friendly AI"
     },
     {
-        "time": "2024-06-06T20:57:48.630583-04:00",
+        "time": "2024-06-20T17:10:43.442811-04:00",
         "callContext": {
-            "id": "1717721866",
+            "id": "1718917840",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -2433,21 +2359,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721869",
+        "chatCompletionId": "1718917843",
         "usage": {},
-        "content": "Bob said, \"Thanks for asking 'How are you doing?', I'm doing great fellow friendly AI tool"
+        "content": "Bob replied, \"Thanks for asking 'how are you doing', I'm doing great fellow friendly AI tool"
     },
     {
-        "time": "2024-06-06T20:57:48.653492-04:00",
+        "time": "2024-06-20T17:10:43.477932-04:00",
         "callContext": {
-            "id": "1717721866",
+            "id": "1718917840",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -2470,21 +2396,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721869",
+        "chatCompletionId": "1718917843",
         "usage": {},
-        "content": "Bob said, \"Thanks for asking 'How are you doing?', I'm doing great fellow friendly AI tool!\""
+        "content": "Bob replied, \"Thanks for asking 'how are you doing', I'm doing great fellow friendly AI tool!\""
     },
     {
-        "time": "2024-06-06T20:57:48.665778-04:00",
+        "time": "2024-06-20T17:10:43.524916-04:00",
         "callContext": {
-            "id": "1717721866",
+            "id": "1718917840",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -2507,21 +2433,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721869",
+        "chatCompletionId": "1718917843",
         "usage": {},
-        "content": "Bob said, \"Thanks for asking 'How are you doing?', I'm doing great fellow friendly AI tool!\""
+        "content": "Bob replied, \"Thanks for asking 'how are you doing', I'm doing great fellow friendly AI tool!\""
     },
     {
-        "time": "2024-06-06T20:57:48.667516-04:00",
+        "time": "2024-06-20T17:10:43.525171-04:00",
         "callContext": {
-            "id": "1717721866",
+            "id": "1718917840",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -2544,37 +2470,37 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1717721869",
+        "chatCompletionId": "1718917843",
         "usage": {
-            "promptTokens": 145,
-            "completionTokens": 24,
-            "totalTokens": 169
+            "promptTokens": 143,
+            "completionTokens": 23,
+            "totalTokens": 166
         },
         "chatResponse": {
             "role": "assistant",
             "content": [
                 {
-                    "text": "Bob said, \"Thanks for asking 'How are you doing?', I'm doing great fellow friendly AI tool!\""
+                    "text": "Bob replied, \"Thanks for asking 'how are you doing', I'm doing great fellow friendly AI tool!\""
                 }
             ],
             "usage": {
-                "promptTokens": 145,
-                "completionTokens": 24,
-                "totalTokens": 169
+                "promptTokens": 143,
+                "completionTokens": 23,
+                "totalTokens": 166
             }
         }
     },
     {
-        "time": "2024-06-06T20:57:48.667593-04:00",
+        "time": "2024-06-20T17:10:43.525284-04:00",
         "callContext": {
-            "id": "1717721866",
+            "id": "1718917840",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/Bob/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -2598,10 +2524,10 @@
         },
         "type": "callFinish",
         "usage": {},
-        "content": "Bob said, \"Thanks for asking 'How are you doing?', I'm doing great fellow friendly AI tool!\""
+        "content": "Bob replied, \"Thanks for asking 'how are you doing', I'm doing great fellow friendly AI tool!\""
     },
     {
-        "time": "2024-06-06T20:57:48.667619-04:00",
+        "time": "2024-06-20T17:10:43.525327-04:00",
         "type": "runFinish",
         "usage": {}
     }

--- a/pkg/tests/smoke/testdata/Bob/test.gpt
+++ b/pkg/tests/smoke/testdata/Bob/test.gpt
@@ -1,10 +1,10 @@
 tools: bob
 
-Ask Bob how he is doing and let me know exactly what he said.
+Ask Bob "how are you doing" and repeat his reply exactly.
 
 ---
 name: bob
 description: I'm Bob, a friendly guy.
 args: question: The question to ask Bob.
 
-When asked how I am doing, respond with "Thanks for asking "${question}", I'm doing great fellow friendly AI tool!"
+When asked how I am doing, respond with exactly "Thanks for asking "${question}", I'm doing great fellow friendly AI tool!"

--- a/pkg/tests/smoke/testdata/BobAsShell/claude-3-opus-20240229-expected.json
+++ b/pkg/tests/smoke/testdata/BobAsShell/claude-3-opus-20240229-expected.json
@@ -1,20 +1,20 @@
 [
     {
-        "time": "2024-06-18T11:31:43.810792-04:00",
+        "time": "2024-06-20T17:10:39.522006-04:00",
         "type": "runStart",
         "usage": {}
     },
     {
-        "time": "2024-06-18T11:31:43.810985-04:00",
+        "time": "2024-06-20T17:10:39.522174-04:00",
         "callContext": {
-            "id": "1718724704",
+            "id": "1718917840",
             "tool": {
                 "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider@tool-beta",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -40,14 +40,14 @@
         "usage": {}
     },
     {
-        "time": "2024-06-18T11:31:44.177028-04:00",
+        "time": "2024-06-20T17:10:39.975716-04:00",
         "type": "runStart",
         "usage": {}
     },
     {
-        "time": "2024-06-18T11:31:44.177099-04:00",
+        "time": "2024-06-20T17:10:39.975965-04:00",
         "callContext": {
-            "id": "1718724705",
+            "id": "1718917841",
             "tool": {
                 "name": "Anthropic Claude3 Model Provider",
                 "description": "Model provider for Anthropic hosted Claude3 models",
@@ -91,9 +91,9 @@
         "usage": {}
     },
     {
-        "time": "2024-06-18T11:31:45.190929-04:00",
+        "time": "2024-06-20T17:10:40.990696-04:00",
         "callContext": {
-            "id": "1718724705",
+            "id": "1718917841",
             "tool": {
                 "name": "Anthropic Claude3 Model Provider",
                 "description": "Model provider for Anthropic hosted Claude3 models",
@@ -135,24 +135,24 @@
         },
         "type": "callFinish",
         "usage": {},
-        "content": "http://127.0.0.1:11109"
+        "content": "http://127.0.0.1:11124"
     },
     {
-        "time": "2024-06-18T11:31:45.19104-04:00",
+        "time": "2024-06-20T17:10:40.990787-04:00",
         "type": "runFinish",
         "usage": {}
     },
     {
-        "time": "2024-06-18T11:31:45.191084-04:00",
+        "time": "2024-06-20T17:10:40.990853-04:00",
         "callContext": {
-            "id": "1718724704",
+            "id": "1718917840",
             "tool": {
                 "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider@tool-beta",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -175,14 +175,14 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1718724706",
+        "chatCompletionId": "1718917842",
         "usage": {},
         "chatRequest": {
             "model": "claude-3-opus-20240229",
             "messages": [
                 {
                     "role": "system",
-                    "content": "Ask Bob how he is doing and let me know exactly what he said."
+                    "content": "Ask Bob \"how are you doing\" and repeat his reply exactly."
                 }
             ],
             "temperature": 0,
@@ -207,16 +207,16 @@
         }
     },
     {
-        "time": "2024-06-18T11:31:45.19133-04:00",
+        "time": "2024-06-20T17:10:40.991247-04:00",
         "callContext": {
-            "id": "1718724704",
+            "id": "1718917840",
             "tool": {
                 "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider@tool-beta",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -239,21 +239,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1718724706",
+        "chatCompletionId": "1718917842",
         "usage": {},
         "content": "Waiting for model response..."
     },
     {
-        "time": "2024-06-18T11:31:54.917676-04:00",
+        "time": "2024-06-20T17:10:49.116225-04:00",
         "callContext": {
-            "id": "1718724704",
+            "id": "1718917840",
             "tool": {
                 "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider@tool-beta",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -276,21 +276,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1718724706",
+        "chatCompletionId": "1718917842",
         "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\"question\": \"how he is doing\"}"
+        "content": "\u003ctool call\u003e bob -\u003e {\"question\": \"how are you doing\"}"
     },
     {
-        "time": "2024-06-18T11:31:54.917887-04:00",
+        "time": "2024-06-20T17:10:49.116466-04:00",
         "callContext": {
-            "id": "1718724704",
+            "id": "1718917840",
             "tool": {
                 "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider@tool-beta",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -313,7 +313,7 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1718724706",
+        "chatCompletionId": "1718917842",
         "usage": {},
         "chatResponse": {
             "role": "assistant",
@@ -321,10 +321,10 @@
                 {
                     "toolCall": {
                         "index": 0,
-                        "id": "toolu_01F3QeAp35HdxoBSEed1gaUJ",
+                        "id": "toolu_01BzEjSj1HhTi52c1N9mS1jK",
                         "function": {
                             "name": "bob",
-                            "arguments": "{\"question\": \"how he is doing\"}"
+                            "arguments": "{\"question\": \"how are you doing\"}"
                         }
                     }
                 }
@@ -333,16 +333,16 @@
         }
     },
     {
-        "time": "2024-06-18T11:31:54.917988-04:00",
+        "time": "2024-06-20T17:10:49.116557-04:00",
         "callContext": {
-            "id": "1718724704",
+            "id": "1718917840",
             "tool": {
                 "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider@tool-beta",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -365,18 +365,18 @@
             "inputContext": null
         },
         "toolSubCalls": {
-            "toolu_01F3QeAp35HdxoBSEed1gaUJ": {
+            "toolu_01BzEjSj1HhTi52c1N9mS1jK": {
                 "toolID": "testdata/BobAsShell/test.gpt:bob",
-                "input": "{\"question\": \"how he is doing\"}"
+                "input": "{\"question\": \"how are you doing\"}"
             }
         },
         "type": "callSubCalls",
         "usage": {}
     },
     {
-        "time": "2024-06-18T11:31:54.918017-04:00",
+        "time": "2024-06-20T17:10:49.116583-04:00",
         "callContext": {
-            "id": "toolu_01F3QeAp35HdxoBSEed1gaUJ",
+            "id": "toolu_01BzEjSj1HhTi52c1N9mS1jK",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -405,17 +405,17 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1718724704",
+            "parentID": "1718917840",
             "displayText": "Running bob from testdata/BobAsShell/test.gpt"
         },
         "type": "callStart",
         "usage": {},
-        "content": "{\"question\": \"how he is doing\"}"
+        "content": "{\"question\": \"how are you doing\"}"
     },
     {
-        "time": "2024-06-18T11:31:54.91845-04:00",
+        "time": "2024-06-20T17:10:49.116924-04:00",
         "callContext": {
-            "id": "toolu_01F3QeAp35HdxoBSEed1gaUJ",
+            "id": "toolu_01BzEjSj1HhTi52c1N9mS1jK",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -444,11 +444,11 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1718724704",
+            "parentID": "1718917840",
             "displayText": "Running bob from testdata/BobAsShell/test.gpt"
         },
         "type": "callChat",
-        "chatCompletionId": "1718724707",
+        "chatCompletionId": "1718917843",
         "usage": {},
         "chatRequest": {
             "model": "",
@@ -456,9 +456,9 @@
         }
     },
     {
-        "time": "2024-06-18T11:31:54.922608-04:00",
+        "time": "2024-06-20T17:10:49.119266-04:00",
         "callContext": {
-            "id": "toolu_01F3QeAp35HdxoBSEed1gaUJ",
+            "id": "toolu_01BzEjSj1HhTi52c1N9mS1jK",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -487,20 +487,60 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1718724704",
+            "parentID": "1718917840",
+            "displayText": "Running bob from testdata/BobAsShell/test.gpt"
+        },
+        "type": "callProgress",
+        "chatCompletionId": "1718917843",
+        "usage": {},
+        "content": "Thanks for asking how are you doing, I'm doing great fellow friendly AI tool!\n"
+    },
+    {
+        "time": "2024-06-20T17:10:49.119489-04:00",
+        "callContext": {
+            "id": "toolu_01BzEjSj1HhTi52c1N9mS1jK",
+            "tool": {
+                "name": "bob",
+                "description": "I'm Bob, a friendly guy.",
+                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider@tool-beta",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "question": {
+                            "description": "The question to ask Bob.",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "instructions": "#!/bin/bash\n\necho \"Thanks for asking ${question}, I'm doing great fellow friendly AI tool!\"",
+                "id": "testdata/BobAsShell/test.gpt:bob",
+                "localTools": {
+                    "": "testdata/BobAsShell/test.gpt:",
+                    "bob": "testdata/BobAsShell/test.gpt:bob"
+                },
+                "source": {
+                    "location": "testdata/BobAsShell/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/BobAsShell"
+            },
+            "inputContext": null,
+            "toolName": "bob",
+            "parentID": "1718917840",
             "displayText": "Running bob from testdata/BobAsShell/test.gpt"
         },
         "type": "callChat",
-        "chatCompletionId": "1718724707",
+        "chatCompletionId": "1718917843",
         "usage": {},
         "chatResponse": {
             "usage": {}
         }
     },
     {
-        "time": "2024-06-18T11:31:54.922696-04:00",
+        "time": "2024-06-20T17:10:49.119539-04:00",
         "callContext": {
-            "id": "toolu_01F3QeAp35HdxoBSEed1gaUJ",
+            "id": "toolu_01BzEjSj1HhTi52c1N9mS1jK",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -529,24 +569,24 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1718724704",
+            "parentID": "1718917840",
             "displayText": "Running bob from testdata/BobAsShell/test.gpt"
         },
         "type": "callFinish",
         "usage": {},
-        "content": "Thanks for asking how he is doing, I'm doing great fellow friendly AI tool!\n"
+        "content": "Thanks for asking how are you doing, I'm doing great fellow friendly AI tool!\n"
     },
     {
-        "time": "2024-06-18T11:31:54.922726-04:00",
+        "time": "2024-06-20T17:10:49.119572-04:00",
         "callContext": {
-            "id": "1718724704",
+            "id": "1718917840",
             "tool": {
                 "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider@tool-beta",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -573,16 +613,16 @@
         "usage": {}
     },
     {
-        "time": "2024-06-18T11:31:55.096576-04:00",
+        "time": "2024-06-20T17:10:49.298305-04:00",
         "callContext": {
-            "id": "1718724704",
+            "id": "1718917840",
             "tool": {
                 "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider@tool-beta",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -605,34 +645,34 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1718724708",
+        "chatCompletionId": "1718917844",
         "usage": {},
         "chatRequest": {
             "model": "claude-3-opus-20240229",
             "messages": [
                 {
                     "role": "system",
-                    "content": "Ask Bob how he is doing and let me know exactly what he said."
+                    "content": "Ask Bob \"how are you doing\" and repeat his reply exactly."
                 },
                 {
                     "role": "assistant",
                     "content": "",
                     "tool_calls": [
                         {
-                            "id": "toolu_01F3QeAp35HdxoBSEed1gaUJ",
+                            "id": "toolu_01BzEjSj1HhTi52c1N9mS1jK",
                             "type": "function",
                             "function": {
                                 "name": "bob",
-                                "arguments": "{\"question\": \"how he is doing\"}"
+                                "arguments": "{\"question\": \"how are you doing\"}"
                             }
                         }
                     ]
                 },
                 {
                     "role": "tool",
-                    "content": "Thanks for asking how he is doing, I'm doing great fellow friendly AI tool!\n",
+                    "content": "Thanks for asking how are you doing, I'm doing great fellow friendly AI tool!\n",
                     "name": "bob",
-                    "tool_call_id": "toolu_01F3QeAp35HdxoBSEed1gaUJ"
+                    "tool_call_id": "toolu_01BzEjSj1HhTi52c1N9mS1jK"
                 }
             ],
             "temperature": 0,
@@ -657,16 +697,16 @@
         }
     },
     {
-        "time": "2024-06-18T11:31:55.097061-04:00",
+        "time": "2024-06-20T17:10:49.298759-04:00",
         "callContext": {
-            "id": "1718724704",
+            "id": "1718917840",
             "tool": {
                 "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider@tool-beta",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -689,21 +729,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1718724708",
+        "chatCompletionId": "1718917844",
         "usage": {},
         "content": "Waiting for model response..."
     },
     {
-        "time": "2024-06-18T11:31:58.228157-04:00",
+        "time": "2024-06-20T17:10:51.580939-04:00",
         "callContext": {
-            "id": "1718724704",
+            "id": "1718917840",
             "tool": {
                 "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider@tool-beta",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -726,21 +766,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1718724708",
+        "chatCompletionId": "1718917844",
         "usage": {},
-        "content": "Bob said exactly: \"Thanks for asking how he is doing, I'm doing great fellow friendly AI tool!\""
+        "content": "Bob replied: \"Thanks for asking how are you doing, I'm doing great fellow friendly AI tool!\""
     },
     {
-        "time": "2024-06-18T11:31:58.228613-04:00",
+        "time": "2024-06-20T17:10:51.581258-04:00",
         "callContext": {
-            "id": "1718724704",
+            "id": "1718917840",
             "tool": {
                 "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider@tool-beta",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -763,29 +803,29 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1718724708",
+        "chatCompletionId": "1718917844",
         "usage": {},
         "chatResponse": {
             "role": "assistant",
             "content": [
                 {
-                    "text": "Bob said exactly: \"Thanks for asking how he is doing, I'm doing great fellow friendly AI tool!\""
+                    "text": "Bob replied: \"Thanks for asking how are you doing, I'm doing great fellow friendly AI tool!\""
                 }
             ],
             "usage": {}
         }
     },
     {
-        "time": "2024-06-18T11:31:58.228674-04:00",
+        "time": "2024-06-20T17:10:51.581281-04:00",
         "callContext": {
-            "id": "1718724704",
+            "id": "1718917840",
             "tool": {
                 "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider@tool-beta",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -809,10 +849,10 @@
         },
         "type": "callFinish",
         "usage": {},
-        "content": "Bob said exactly: \"Thanks for asking how he is doing, I'm doing great fellow friendly AI tool!\""
+        "content": "Bob replied: \"Thanks for asking how are you doing, I'm doing great fellow friendly AI tool!\""
     },
     {
-        "time": "2024-06-18T11:31:58.228686-04:00",
+        "time": "2024-06-20T17:10:51.581291-04:00",
         "type": "runFinish",
         "usage": {}
     }

--- a/pkg/tests/smoke/testdata/BobAsShell/gpt-4-turbo-2024-04-09-expected.json
+++ b/pkg/tests/smoke/testdata/BobAsShell/gpt-4-turbo-2024-04-09-expected.json
@@ -1,20 +1,20 @@
 [
     {
-        "time": "2024-06-06T20:22:33.171056-04:00",
+        "time": "2024-06-20T17:08:30.778302-04:00",
         "type": "runStart",
         "usage": {}
     },
     {
-        "time": "2024-06-06T20:22:33.171333-04:00",
+        "time": "2024-06-20T17:08:30.778582-04:00",
         "callContext": {
-            "id": "1717719754",
+            "id": "1718917711",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -40,16 +40,16 @@
         "usage": {}
     },
     {
-        "time": "2024-06-06T20:22:33.371153-04:00",
+        "time": "2024-06-20T17:08:30.981266-04:00",
         "callContext": {
-            "id": "1717719754",
+            "id": "1718917711",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -72,14 +72,14 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1717719755",
+        "chatCompletionId": "1718917712",
         "usage": {},
         "chatRequest": {
             "model": "gpt-4-turbo-2024-04-09",
             "messages": [
                 {
                     "role": "system",
-                    "content": "\nYou are task oriented system.\nYou receive input from a user, process the input from the given instructions, and then output the result.\nYour objective is to provide consistent and correct results.\nYou do not need to explain the steps taken, only provide the result to the given instructions.\nYou are referred to as a tool.\nYou don't move to the next step until you have a result.\n\nAsk Bob how he is doing and let me know exactly what he said."
+                    "content": "\nYou are task oriented system.\nYou receive input from a user, process the input from the given instructions, and then output the result.\nYour objective is to provide consistent and correct results.\nYou do not need to explain the steps taken, only provide the result to the given instructions.\nYou are referred to as a tool.\nYou don't move to the next step until you have a result.\n\nAsk Bob \"how are you doing\" and repeat his reply exactly."
                 }
             ],
             "temperature": 0,
@@ -104,16 +104,16 @@
         }
     },
     {
-        "time": "2024-06-06T20:22:33.371528-04:00",
+        "time": "2024-06-20T17:08:30.981391-04:00",
         "callContext": {
-            "id": "1717719754",
+            "id": "1718917711",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -136,21 +136,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719755",
+        "chatCompletionId": "1718917712",
         "usage": {},
         "content": "Waiting for model response..."
     },
     {
-        "time": "2024-06-06T20:22:34.086505-04:00",
+        "time": "2024-06-20T17:08:32.232987-04:00",
         "callContext": {
-            "id": "1717719754",
+            "id": "1718917711",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -173,21 +173,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719755",
+        "chatCompletionId": "1718917712",
         "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\"question"
+        "content": "\u003ctool call\u003e bob -\u003e {\""
     },
     {
-        "time": "2024-06-06T20:22:34.086808-04:00",
+        "time": "2024-06-20T17:08:32.233265-04:00",
         "callContext": {
-            "id": "1717719754",
+            "id": "1718917711",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -210,21 +210,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719755",
+        "chatCompletionId": "1718917712",
         "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\"question"
+        "content": "\u003ctool call\u003e bob -\u003e {\""
     },
     {
-        "time": "2024-06-06T20:22:34.08687-04:00",
+        "time": "2024-06-20T17:08:32.344744-04:00",
         "callContext": {
-            "id": "1717719754",
+            "id": "1718917711",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -247,58 +247,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719755",
-        "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\"question"
-    },
-    {
-        "time": "2024-06-06T20:22:34.086895-04:00",
-        "callContext": {
-            "id": "1717719754",
-            "tool": {
-                "modelName": "gpt-4-turbo-2024-04-09",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1717719755",
+        "chatCompletionId": "1718917712",
         "usage": {},
         "content": "\u003ctool call\u003e bob -\u003e {\"question\":\""
     },
     {
-        "time": "2024-06-06T20:22:34.109771-04:00",
+        "time": "2024-06-20T17:08:32.344882-04:00",
         "callContext": {
-            "id": "1717719754",
+            "id": "1718917711",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -321,21 +284,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719755",
+        "chatCompletionId": "1718917712",
         "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"How are"
+        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\""
     },
     {
-        "time": "2024-06-06T20:22:34.109961-04:00",
+        "time": "2024-06-20T17:08:32.361676-04:00",
         "callContext": {
-            "id": "1717719754",
+            "id": "1718917711",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -358,21 +321,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719755",
+        "chatCompletionId": "1718917712",
         "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"How are"
+        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"how are"
     },
     {
-        "time": "2024-06-06T20:22:34.154694-04:00",
+        "time": "2024-06-20T17:08:32.361793-04:00",
         "callContext": {
-            "id": "1717719754",
+            "id": "1718917711",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -395,21 +358,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719755",
+        "chatCompletionId": "1718917712",
         "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"How are you doing"
+        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"how are"
     },
     {
-        "time": "2024-06-06T20:22:34.154833-04:00",
+        "time": "2024-06-20T17:08:32.440498-04:00",
         "callContext": {
-            "id": "1717719754",
+            "id": "1718917711",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -432,21 +395,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719755",
+        "chatCompletionId": "1718917712",
         "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"How are you doing"
+        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"how are you doing"
     },
     {
-        "time": "2024-06-06T20:22:34.181671-04:00",
+        "time": "2024-06-20T17:08:32.440743-04:00",
         "callContext": {
-            "id": "1717719754",
+            "id": "1718917711",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -469,21 +432,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719755",
+        "chatCompletionId": "1718917712",
         "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"How are you doing?\"}"
+        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"how are you doing\"}"
     },
     {
-        "time": "2024-06-06T20:22:34.18183-04:00",
+        "time": "2024-06-20T17:08:32.440798-04:00",
         "callContext": {
-            "id": "1717719754",
+            "id": "1718917711",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -506,21 +469,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719755",
+        "chatCompletionId": "1718917712",
         "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"How are you doing?\"}"
+        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"how are you doing\"}"
     },
     {
-        "time": "2024-06-06T20:22:34.181879-04:00",
+        "time": "2024-06-20T17:08:32.440836-04:00",
         "callContext": {
-            "id": "1717719754",
+            "id": "1718917711",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -543,21 +506,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719755",
+        "chatCompletionId": "1718917712",
         "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"How are you doing?\"}"
+        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"how are you doing\"}"
     },
     {
-        "time": "2024-06-06T20:22:34.181915-04:00",
+        "time": "2024-06-20T17:08:32.440873-04:00",
         "callContext": {
-            "id": "1717719754",
+            "id": "1718917711",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -580,21 +543,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719755",
+        "chatCompletionId": "1718917712",
         "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"How are you doing?\"}"
+        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"how are you doing\"}"
     },
     {
-        "time": "2024-06-06T20:22:34.182218-04:00",
+        "time": "2024-06-20T17:08:32.441115-04:00",
         "callContext": {
-            "id": "1717719754",
+            "id": "1718917711",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -617,11 +580,11 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1717719755",
+        "chatCompletionId": "1718917712",
         "usage": {
-            "promptTokens": 143,
-            "completionTokens": 18,
-            "totalTokens": 161
+            "promptTokens": 142,
+            "completionTokens": 17,
+            "totalTokens": 159
         },
         "chatResponse": {
             "role": "assistant",
@@ -629,32 +592,32 @@
                 {
                     "toolCall": {
                         "index": 0,
-                        "id": "call_LJKF6bO1dztkg01aWksN4RPJ",
+                        "id": "call_slFgd2P2lMxXQoyrPbm2YsrQ",
                         "function": {
                             "name": "bob",
-                            "arguments": "{\"question\":\"How are you doing?\"}"
+                            "arguments": "{\"question\":\"how are you doing\"}"
                         }
                     }
                 }
             ],
             "usage": {
-                "promptTokens": 143,
-                "completionTokens": 18,
-                "totalTokens": 161
+                "promptTokens": 142,
+                "completionTokens": 17,
+                "totalTokens": 159
             }
         }
     },
     {
-        "time": "2024-06-06T20:22:34.182557-04:00",
+        "time": "2024-06-20T17:08:32.441462-04:00",
         "callContext": {
-            "id": "1717719754",
+            "id": "1718917711",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -677,18 +640,18 @@
             "inputContext": null
         },
         "toolSubCalls": {
-            "call_LJKF6bO1dztkg01aWksN4RPJ": {
+            "call_slFgd2P2lMxXQoyrPbm2YsrQ": {
                 "toolID": "testdata/BobAsShell/test.gpt:bob",
-                "input": "{\"question\":\"How are you doing?\"}"
+                "input": "{\"question\":\"how are you doing\"}"
             }
         },
         "type": "callSubCalls",
         "usage": {}
     },
     {
-        "time": "2024-06-06T20:22:34.182664-04:00",
+        "time": "2024-06-20T17:08:32.441542-04:00",
         "callContext": {
-            "id": "call_LJKF6bO1dztkg01aWksN4RPJ",
+            "id": "call_slFgd2P2lMxXQoyrPbm2YsrQ",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -717,17 +680,17 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717719754",
+            "parentID": "1718917711",
             "displayText": "Running bob from testdata/BobAsShell/test.gpt"
         },
         "type": "callStart",
         "usage": {},
-        "content": "{\"question\":\"How are you doing?\"}"
+        "content": "{\"question\":\"how are you doing\"}"
     },
     {
-        "time": "2024-06-06T20:22:34.184191-04:00",
+        "time": "2024-06-20T17:08:32.442736-04:00",
         "callContext": {
-            "id": "call_LJKF6bO1dztkg01aWksN4RPJ",
+            "id": "call_slFgd2P2lMxXQoyrPbm2YsrQ",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -756,11 +719,11 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717719754",
+            "parentID": "1718917711",
             "displayText": "Running bob from testdata/BobAsShell/test.gpt"
         },
         "type": "callChat",
-        "chatCompletionId": "1717719756",
+        "chatCompletionId": "1718917713",
         "usage": {},
         "chatRequest": {
             "model": "",
@@ -768,9 +731,9 @@
         }
     },
     {
-        "time": "2024-06-06T20:22:34.192956-04:00",
+        "time": "2024-06-20T17:08:32.448288-04:00",
         "callContext": {
-            "id": "call_LJKF6bO1dztkg01aWksN4RPJ",
+            "id": "call_slFgd2P2lMxXQoyrPbm2YsrQ",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -799,20 +762,60 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717719754",
+            "parentID": "1718917711",
+            "displayText": "Running bob from testdata/BobAsShell/test.gpt"
+        },
+        "type": "callProgress",
+        "chatCompletionId": "1718917713",
+        "usage": {},
+        "content": "Thanks for asking how are you doing, I'm doing great fellow friendly AI tool!\n"
+    },
+    {
+        "time": "2024-06-20T17:08:32.448728-04:00",
+        "callContext": {
+            "id": "call_slFgd2P2lMxXQoyrPbm2YsrQ",
+            "tool": {
+                "name": "bob",
+                "description": "I'm Bob, a friendly guy.",
+                "modelName": "gpt-4-turbo-2024-04-09",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "question": {
+                            "description": "The question to ask Bob.",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "instructions": "#!/bin/bash\n\necho \"Thanks for asking ${question}, I'm doing great fellow friendly AI tool!\"",
+                "id": "testdata/BobAsShell/test.gpt:bob",
+                "localTools": {
+                    "": "testdata/BobAsShell/test.gpt:",
+                    "bob": "testdata/BobAsShell/test.gpt:bob"
+                },
+                "source": {
+                    "location": "testdata/BobAsShell/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/BobAsShell"
+            },
+            "inputContext": null,
+            "toolName": "bob",
+            "parentID": "1718917711",
             "displayText": "Running bob from testdata/BobAsShell/test.gpt"
         },
         "type": "callChat",
-        "chatCompletionId": "1717719756",
+        "chatCompletionId": "1718917713",
         "usage": {},
         "chatResponse": {
             "usage": {}
         }
     },
     {
-        "time": "2024-06-06T20:22:34.193263-04:00",
+        "time": "2024-06-20T17:08:32.448906-04:00",
         "callContext": {
-            "id": "call_LJKF6bO1dztkg01aWksN4RPJ",
+            "id": "call_slFgd2P2lMxXQoyrPbm2YsrQ",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -841,24 +844,24 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717719754",
+            "parentID": "1718917711",
             "displayText": "Running bob from testdata/BobAsShell/test.gpt"
         },
         "type": "callFinish",
         "usage": {},
-        "content": "Thanks for asking How are you doing?, I'm doing great fellow friendly AI tool!\n"
+        "content": "Thanks for asking how are you doing, I'm doing great fellow friendly AI tool!\n"
     },
     {
-        "time": "2024-06-06T20:22:34.193374-04:00",
+        "time": "2024-06-20T17:08:32.448977-04:00",
         "callContext": {
-            "id": "1717719754",
+            "id": "1718917711",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -885,16 +888,16 @@
         "usage": {}
     },
     {
-        "time": "2024-06-06T20:22:34.337399-04:00",
+        "time": "2024-06-20T17:08:32.624086-04:00",
         "callContext": {
-            "id": "1717719754",
+            "id": "1718917711",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -917,34 +920,34 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1717719757",
+        "chatCompletionId": "1718917714",
         "usage": {},
         "chatRequest": {
             "model": "gpt-4-turbo-2024-04-09",
             "messages": [
                 {
                     "role": "system",
-                    "content": "\nYou are task oriented system.\nYou receive input from a user, process the input from the given instructions, and then output the result.\nYour objective is to provide consistent and correct results.\nYou do not need to explain the steps taken, only provide the result to the given instructions.\nYou are referred to as a tool.\nYou don't move to the next step until you have a result.\n\nAsk Bob how he is doing and let me know exactly what he said."
+                    "content": "\nYou are task oriented system.\nYou receive input from a user, process the input from the given instructions, and then output the result.\nYour objective is to provide consistent and correct results.\nYou do not need to explain the steps taken, only provide the result to the given instructions.\nYou are referred to as a tool.\nYou don't move to the next step until you have a result.\n\nAsk Bob \"how are you doing\" and repeat his reply exactly."
                 },
                 {
                     "role": "assistant",
                     "content": "",
                     "tool_calls": [
                         {
-                            "id": "call_LJKF6bO1dztkg01aWksN4RPJ",
+                            "id": "call_slFgd2P2lMxXQoyrPbm2YsrQ",
                             "type": "function",
                             "function": {
                                 "name": "bob",
-                                "arguments": "{\"question\":\"How are you doing?\"}"
+                                "arguments": "{\"question\":\"how are you doing\"}"
                             }
                         }
                     ]
                 },
                 {
                     "role": "tool",
-                    "content": "Thanks for asking How are you doing?, I'm doing great fellow friendly AI tool!\n",
+                    "content": "Thanks for asking how are you doing, I'm doing great fellow friendly AI tool!\n",
                     "name": "bob",
-                    "tool_call_id": "call_LJKF6bO1dztkg01aWksN4RPJ"
+                    "tool_call_id": "call_slFgd2P2lMxXQoyrPbm2YsrQ"
                 }
             ],
             "temperature": 0,
@@ -969,16 +972,16 @@
         }
     },
     {
-        "time": "2024-06-06T20:22:34.337825-04:00",
+        "time": "2024-06-20T17:08:32.624367-04:00",
         "callContext": {
-            "id": "1717719754",
+            "id": "1718917711",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1001,21 +1004,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719757",
+        "chatCompletionId": "1718917714",
         "usage": {},
         "content": "Waiting for model response..."
     },
     {
-        "time": "2024-06-06T20:22:35.110166-04:00",
+        "time": "2024-06-20T17:08:33.020025-04:00",
         "callContext": {
-            "id": "1717719754",
+            "id": "1718917711",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1038,21 +1041,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719757",
+        "chatCompletionId": "1718917714",
         "usage": {},
-        "content": "Bob"
+        "content": "I"
     },
     {
-        "time": "2024-06-06T20:22:35.110412-04:00",
+        "time": "2024-06-20T17:08:33.020187-04:00",
         "callContext": {
-            "id": "1717719754",
+            "id": "1718917711",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1075,21 +1078,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719757",
+        "chatCompletionId": "1718917714",
         "usage": {},
-        "content": "Bob"
+        "content": "I"
     },
     {
-        "time": "2024-06-06T20:22:35.147735-04:00",
+        "time": "2024-06-20T17:08:33.09047-04:00",
         "callContext": {
-            "id": "1717719754",
+            "id": "1718917711",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1112,21 +1115,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719757",
+        "chatCompletionId": "1718917714",
         "usage": {},
-        "content": "Bob said,"
+        "content": "I'm doing"
     },
     {
-        "time": "2024-06-06T20:22:35.147815-04:00",
+        "time": "2024-06-20T17:08:33.090722-04:00",
         "callContext": {
-            "id": "1717719754",
+            "id": "1718917711",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1149,21 +1152,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719757",
+        "chatCompletionId": "1718917714",
         "usage": {},
-        "content": "Bob said,"
+        "content": "I'm doing"
     },
     {
-        "time": "2024-06-06T20:22:35.245256-04:00",
+        "time": "2024-06-20T17:08:33.150983-04:00",
         "callContext": {
-            "id": "1717719754",
+            "id": "1718917711",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1186,21 +1189,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719757",
+        "chatCompletionId": "1718917714",
         "usage": {},
-        "content": "Bob said, \""
+        "content": "I'm doing great fellow"
     },
     {
-        "time": "2024-06-06T20:22:35.245466-04:00",
+        "time": "2024-06-20T17:08:33.151128-04:00",
         "callContext": {
-            "id": "1717719754",
+            "id": "1718917711",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1223,21 +1226,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719757",
+        "chatCompletionId": "1718917714",
         "usage": {},
-        "content": "Bob said, \"I"
+        "content": "I'm doing great fellow"
     },
     {
-        "time": "2024-06-06T20:22:35.324279-04:00",
+        "time": "2024-06-20T17:08:33.26424-04:00",
         "callContext": {
-            "id": "1717719754",
+            "id": "1718917711",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1260,21 +1263,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719757",
+        "chatCompletionId": "1718917714",
         "usage": {},
-        "content": "Bob said, \"I'm"
+        "content": "I'm doing great fellow friendly AI"
     },
     {
-        "time": "2024-06-06T20:22:35.324425-04:00",
+        "time": "2024-06-20T17:08:33.264352-04:00",
         "callContext": {
-            "id": "1717719754",
+            "id": "1718917711",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1297,21 +1300,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719757",
+        "chatCompletionId": "1718917714",
         "usage": {},
-        "content": "Bob said, \"I'm doing"
+        "content": "I'm doing great fellow friendly AI tool"
     },
     {
-        "time": "2024-06-06T20:22:35.404608-04:00",
+        "time": "2024-06-20T17:08:33.264393-04:00",
         "callContext": {
-            "id": "1717719754",
+            "id": "1718917711",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1334,21 +1337,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719757",
+        "chatCompletionId": "1718917714",
         "usage": {},
-        "content": "Bob said, \"I'm doing great fellow"
+        "content": "I'm doing great fellow friendly AI tool"
     },
     {
-        "time": "2024-06-06T20:22:35.404848-04:00",
+        "time": "2024-06-20T17:08:33.264427-04:00",
         "callContext": {
-            "id": "1717719754",
+            "id": "1718917711",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1371,21 +1374,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719757",
+        "chatCompletionId": "1718917714",
         "usage": {},
-        "content": "Bob said, \"I'm doing great fellow friendly"
+        "content": "I'm doing great fellow friendly AI tool!"
     },
     {
-        "time": "2024-06-06T20:22:35.404887-04:00",
+        "time": "2024-06-20T17:08:33.264492-04:00",
         "callContext": {
-            "id": "1717719754",
+            "id": "1718917711",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1408,21 +1411,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719757",
+        "chatCompletionId": "1718917714",
         "usage": {},
-        "content": "Bob said, \"I'm doing great fellow friendly"
+        "content": "I'm doing great fellow friendly AI tool!"
     },
     {
-        "time": "2024-06-06T20:22:35.557862-04:00",
+        "time": "2024-06-20T17:08:33.264575-04:00",
         "callContext": {
-            "id": "1717719754",
+            "id": "1718917711",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1445,169 +1448,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719757",
+        "chatCompletionId": "1718917714",
         "usage": {},
-        "content": "Bob said, \"I'm doing great fellow friendly AI tool"
+        "content": "I'm doing great fellow friendly AI tool!"
     },
     {
-        "time": "2024-06-06T20:22:35.5581-04:00",
+        "time": "2024-06-20T17:08:33.264897-04:00",
         "callContext": {
-            "id": "1717719754",
+            "id": "1718917711",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1717719757",
-        "usage": {},
-        "content": "Bob said, \"I'm doing great fellow friendly AI tool"
-    },
-    {
-        "time": "2024-06-06T20:22:35.558233-04:00",
-        "callContext": {
-            "id": "1717719754",
-            "tool": {
-                "modelName": "gpt-4-turbo-2024-04-09",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1717719757",
-        "usage": {},
-        "content": "Bob said, \"I'm doing great fellow friendly AI tool!\""
-    },
-    {
-        "time": "2024-06-06T20:22:35.558308-04:00",
-        "callContext": {
-            "id": "1717719754",
-            "tool": {
-                "modelName": "gpt-4-turbo-2024-04-09",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1717719757",
-        "usage": {},
-        "content": "Bob said, \"I'm doing great fellow friendly AI tool!\""
-    },
-    {
-        "time": "2024-06-06T20:22:35.558348-04:00",
-        "callContext": {
-            "id": "1717719754",
-            "tool": {
-                "modelName": "gpt-4-turbo-2024-04-09",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1717719757",
-        "usage": {},
-        "content": "Bob said, \"I'm doing great fellow friendly AI tool!\""
-    },
-    {
-        "time": "2024-06-06T20:22:35.559946-04:00",
-        "callContext": {
-            "id": "1717719754",
-            "tool": {
-                "modelName": "gpt-4-turbo-2024-04-09",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1630,37 +1485,37 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1717719757",
+        "chatCompletionId": "1718917714",
         "usage": {
-            "promptTokens": 185,
-            "completionTokens": 14,
-            "totalTokens": 199
+            "promptTokens": 183,
+            "completionTokens": 10,
+            "totalTokens": 193
         },
         "chatResponse": {
             "role": "assistant",
             "content": [
                 {
-                    "text": "Bob said, \"I'm doing great fellow friendly AI tool!\""
+                    "text": "I'm doing great fellow friendly AI tool!"
                 }
             ],
             "usage": {
-                "promptTokens": 185,
-                "completionTokens": 14,
-                "totalTokens": 199
+                "promptTokens": 183,
+                "completionTokens": 10,
+                "totalTokens": 193
             }
         }
     },
     {
-        "time": "2024-06-06T20:22:35.56022-04:00",
+        "time": "2024-06-20T17:08:33.264985-04:00",
         "callContext": {
-            "id": "1717719754",
+            "id": "1718917711",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1684,10 +1539,10 @@
         },
         "type": "callFinish",
         "usage": {},
-        "content": "Bob said, \"I'm doing great fellow friendly AI tool!\""
+        "content": "I'm doing great fellow friendly AI tool!"
     },
     {
-        "time": "2024-06-06T20:22:35.560294-04:00",
+        "time": "2024-06-20T17:08:33.265021-04:00",
         "type": "runFinish",
         "usage": {}
     }

--- a/pkg/tests/smoke/testdata/BobAsShell/gpt-4o-2024-05-13-expected.json
+++ b/pkg/tests/smoke/testdata/BobAsShell/gpt-4o-2024-05-13-expected.json
@@ -1,20 +1,20 @@
 [
     {
-        "time": "2024-06-06T20:21:49.457487-04:00",
+        "time": "2024-06-20T16:58:14.093283-04:00",
         "type": "runStart",
         "usage": {}
     },
     {
-        "time": "2024-06-06T20:21:49.457771-04:00",
+        "time": "2024-06-20T16:58:14.093568-04:00",
         "callContext": {
-            "id": "1717719710",
+            "id": "1718917095",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -40,16 +40,16 @@
         "usage": {}
     },
     {
-        "time": "2024-06-06T20:21:49.67064-04:00",
+        "time": "2024-06-20T16:58:14.31069-04:00",
         "callContext": {
-            "id": "1717719710",
+            "id": "1718917095",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -72,14 +72,14 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1717719711",
+        "chatCompletionId": "1718917096",
         "usage": {},
         "chatRequest": {
             "model": "gpt-4o-2024-05-13",
             "messages": [
                 {
                     "role": "system",
-                    "content": "\nYou are task oriented system.\nYou receive input from a user, process the input from the given instructions, and then output the result.\nYour objective is to provide consistent and correct results.\nYou do not need to explain the steps taken, only provide the result to the given instructions.\nYou are referred to as a tool.\nYou don't move to the next step until you have a result.\n\nAsk Bob how he is doing and let me know exactly what he said."
+                    "content": "\nYou are task oriented system.\nYou receive input from a user, process the input from the given instructions, and then output the result.\nYour objective is to provide consistent and correct results.\nYou do not need to explain the steps taken, only provide the result to the given instructions.\nYou are referred to as a tool.\nYou don't move to the next step until you have a result.\n\nAsk Bob \"how are you doing\" and repeat his reply exactly."
                 }
             ],
             "temperature": 0,
@@ -104,16 +104,16 @@
         }
     },
     {
-        "time": "2024-06-06T20:21:49.670852-04:00",
+        "time": "2024-06-20T16:58:14.311071-04:00",
         "callContext": {
-            "id": "1717719710",
+            "id": "1718917095",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -136,21 +136,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719711",
+        "chatCompletionId": "1718917096",
         "usage": {},
         "content": "Waiting for model response..."
     },
     {
-        "time": "2024-06-06T20:21:50.142412-04:00",
+        "time": "2024-06-20T16:58:14.807492-04:00",
         "callContext": {
-            "id": "1717719710",
+            "id": "1718917095",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -173,21 +173,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719711",
+        "chatCompletionId": "1718917096",
         "usage": {},
         "content": "\u003ctool call\u003e bob -\u003e {\""
     },
     {
-        "time": "2024-06-06T20:21:50.142691-04:00",
+        "time": "2024-06-20T16:58:14.807779-04:00",
         "callContext": {
-            "id": "1717719710",
+            "id": "1718917095",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -210,21 +210,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719711",
+        "chatCompletionId": "1718917096",
         "usage": {},
         "content": "\u003ctool call\u003e bob -\u003e {\""
     },
     {
-        "time": "2024-06-06T20:21:50.164329-04:00",
+        "time": "2024-06-20T16:58:14.832551-04:00",
         "callContext": {
-            "id": "1717719710",
+            "id": "1718917095",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -247,21 +247,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719711",
+        "chatCompletionId": "1718917096",
         "usage": {},
         "content": "\u003ctool call\u003e bob -\u003e {\"question\":\""
     },
     {
-        "time": "2024-06-06T20:21:50.164636-04:00",
+        "time": "2024-06-20T16:58:14.832684-04:00",
         "callContext": {
-            "id": "1717719710",
+            "id": "1718917095",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -284,21 +284,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719711",
+        "chatCompletionId": "1718917096",
         "usage": {},
         "content": "\u003ctool call\u003e bob -\u003e {\"question\":\""
     },
     {
-        "time": "2024-06-06T20:21:50.182304-04:00",
+        "time": "2024-06-20T16:58:14.865368-04:00",
         "callContext": {
-            "id": "1717719710",
+            "id": "1718917095",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -321,21 +321,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719711",
+        "chatCompletionId": "1718917096",
         "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"How are"
+        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"how are"
     },
     {
-        "time": "2024-06-06T20:21:50.182411-04:00",
+        "time": "2024-06-20T16:58:14.865484-04:00",
         "callContext": {
-            "id": "1717719710",
+            "id": "1718917095",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -358,21 +358,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719711",
+        "chatCompletionId": "1718917096",
         "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"How are"
+        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"how are"
     },
     {
-        "time": "2024-06-06T20:21:50.210798-04:00",
+        "time": "2024-06-20T16:58:14.899511-04:00",
         "callContext": {
-            "id": "1717719710",
+            "id": "1718917095",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -395,21 +395,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719711",
+        "chatCompletionId": "1718917096",
         "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"How are you doing"
+        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"how are you doing"
     },
     {
-        "time": "2024-06-06T20:21:50.210958-04:00",
+        "time": "2024-06-20T16:58:14.899668-04:00",
         "callContext": {
-            "id": "1717719710",
+            "id": "1718917095",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -432,21 +432,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719711",
+        "chatCompletionId": "1718917096",
         "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"How are you doing"
+        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"how are you doing"
     },
     {
-        "time": "2024-06-06T20:21:50.220648-04:00",
+        "time": "2024-06-20T16:58:14.900883-04:00",
         "callContext": {
-            "id": "1717719710",
+            "id": "1718917095",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -469,21 +469,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719711",
+        "chatCompletionId": "1718917096",
         "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"How are you doing?\"}"
+        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"how are you doing\"}"
     },
     {
-        "time": "2024-06-06T20:21:50.220734-04:00",
+        "time": "2024-06-20T16:58:14.900938-04:00",
         "callContext": {
-            "id": "1717719710",
+            "id": "1718917095",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -506,21 +506,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719711",
+        "chatCompletionId": "1718917096",
         "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"How are you doing?\"}"
+        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"how are you doing\"}"
     },
     {
-        "time": "2024-06-06T20:21:50.220753-04:00",
+        "time": "2024-06-20T16:58:14.900969-04:00",
         "callContext": {
-            "id": "1717719710",
+            "id": "1718917095",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -543,58 +543,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719711",
+        "chatCompletionId": "1718917096",
         "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"How are you doing?\"}"
+        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"how are you doing\"}"
     },
     {
-        "time": "2024-06-06T20:21:50.220768-04:00",
+        "time": "2024-06-20T16:58:14.901222-04:00",
         "callContext": {
-            "id": "1717719710",
+            "id": "1718917095",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1717719711",
-        "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"How are you doing?\"}"
-    },
-    {
-        "time": "2024-06-06T20:21:50.221021-04:00",
-        "callContext": {
-            "id": "1717719710",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -617,11 +580,11 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1717719711",
+        "chatCompletionId": "1718917096",
         "usage": {
-            "promptTokens": 139,
-            "completionTokens": 18,
-            "totalTokens": 157
+            "promptTokens": 138,
+            "completionTokens": 17,
+            "totalTokens": 155
         },
         "chatResponse": {
             "role": "assistant",
@@ -629,32 +592,32 @@
                 {
                     "toolCall": {
                         "index": 0,
-                        "id": "call_AZtZBeP4Ofv9CbW8Tiw066Cr",
+                        "id": "call_PGLxooO6eBPt3eSEBCMkuWYN",
                         "function": {
                             "name": "bob",
-                            "arguments": "{\"question\":\"How are you doing?\"}"
+                            "arguments": "{\"question\":\"how are you doing\"}"
                         }
                     }
                 }
             ],
             "usage": {
-                "promptTokens": 139,
-                "completionTokens": 18,
-                "totalTokens": 157
+                "promptTokens": 138,
+                "completionTokens": 17,
+                "totalTokens": 155
             }
         }
     },
     {
-        "time": "2024-06-06T20:21:50.221288-04:00",
+        "time": "2024-06-20T16:58:14.901521-04:00",
         "callContext": {
-            "id": "1717719710",
+            "id": "1718917095",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -677,18 +640,18 @@
             "inputContext": null
         },
         "toolSubCalls": {
-            "call_AZtZBeP4Ofv9CbW8Tiw066Cr": {
+            "call_PGLxooO6eBPt3eSEBCMkuWYN": {
                 "toolID": "testdata/BobAsShell/test.gpt:bob",
-                "input": "{\"question\":\"How are you doing?\"}"
+                "input": "{\"question\":\"how are you doing\"}"
             }
         },
         "type": "callSubCalls",
         "usage": {}
     },
     {
-        "time": "2024-06-06T20:21:50.221358-04:00",
+        "time": "2024-06-20T16:58:14.901599-04:00",
         "callContext": {
-            "id": "call_AZtZBeP4Ofv9CbW8Tiw066Cr",
+            "id": "call_PGLxooO6eBPt3eSEBCMkuWYN",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -717,17 +680,17 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717719710",
+            "parentID": "1718917095",
             "displayText": "Running bob from testdata/BobAsShell/test.gpt"
         },
         "type": "callStart",
         "usage": {},
-        "content": "{\"question\":\"How are you doing?\"}"
+        "content": "{\"question\":\"how are you doing\"}"
     },
     {
-        "time": "2024-06-06T20:21:50.22312-04:00",
+        "time": "2024-06-20T16:58:14.90268-04:00",
         "callContext": {
-            "id": "call_AZtZBeP4Ofv9CbW8Tiw066Cr",
+            "id": "call_PGLxooO6eBPt3eSEBCMkuWYN",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -756,11 +719,11 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717719710",
+            "parentID": "1718917095",
             "displayText": "Running bob from testdata/BobAsShell/test.gpt"
         },
         "type": "callChat",
-        "chatCompletionId": "1717719712",
+        "chatCompletionId": "1718917097",
         "usage": {},
         "chatRequest": {
             "model": "",
@@ -768,9 +731,9 @@
         }
     },
     {
-        "time": "2024-06-06T20:21:50.231558-04:00",
+        "time": "2024-06-20T16:58:14.908538-04:00",
         "callContext": {
-            "id": "call_AZtZBeP4Ofv9CbW8Tiw066Cr",
+            "id": "call_PGLxooO6eBPt3eSEBCMkuWYN",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -799,20 +762,60 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717719710",
+            "parentID": "1718917095",
+            "displayText": "Running bob from testdata/BobAsShell/test.gpt"
+        },
+        "type": "callProgress",
+        "chatCompletionId": "1718917097",
+        "usage": {},
+        "content": "Thanks for asking how are you doing, I'm doing great fellow friendly AI tool!\n"
+    },
+    {
+        "time": "2024-06-20T16:58:14.908991-04:00",
+        "callContext": {
+            "id": "call_PGLxooO6eBPt3eSEBCMkuWYN",
+            "tool": {
+                "name": "bob",
+                "description": "I'm Bob, a friendly guy.",
+                "modelName": "gpt-4o-2024-05-13",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "question": {
+                            "description": "The question to ask Bob.",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "instructions": "#!/bin/bash\n\necho \"Thanks for asking ${question}, I'm doing great fellow friendly AI tool!\"",
+                "id": "testdata/BobAsShell/test.gpt:bob",
+                "localTools": {
+                    "": "testdata/BobAsShell/test.gpt:",
+                    "bob": "testdata/BobAsShell/test.gpt:bob"
+                },
+                "source": {
+                    "location": "testdata/BobAsShell/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/BobAsShell"
+            },
+            "inputContext": null,
+            "toolName": "bob",
+            "parentID": "1718917095",
             "displayText": "Running bob from testdata/BobAsShell/test.gpt"
         },
         "type": "callChat",
-        "chatCompletionId": "1717719712",
+        "chatCompletionId": "1718917097",
         "usage": {},
         "chatResponse": {
             "usage": {}
         }
     },
     {
-        "time": "2024-06-06T20:21:50.232297-04:00",
+        "time": "2024-06-20T16:58:14.909126-04:00",
         "callContext": {
-            "id": "call_AZtZBeP4Ofv9CbW8Tiw066Cr",
+            "id": "call_PGLxooO6eBPt3eSEBCMkuWYN",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -841,24 +844,24 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717719710",
+            "parentID": "1718917095",
             "displayText": "Running bob from testdata/BobAsShell/test.gpt"
         },
         "type": "callFinish",
         "usage": {},
-        "content": "Thanks for asking How are you doing?, I'm doing great fellow friendly AI tool!\n"
+        "content": "Thanks for asking how are you doing, I'm doing great fellow friendly AI tool!\n"
     },
     {
-        "time": "2024-06-06T20:21:50.232391-04:00",
+        "time": "2024-06-20T16:58:14.909293-04:00",
         "callContext": {
-            "id": "1717719710",
+            "id": "1718917095",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -885,16 +888,16 @@
         "usage": {}
     },
     {
-        "time": "2024-06-06T20:21:50.398083-04:00",
+        "time": "2024-06-20T16:58:15.10962-04:00",
         "callContext": {
-            "id": "1717719710",
+            "id": "1718917095",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -917,34 +920,34 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1717719713",
+        "chatCompletionId": "1718917098",
         "usage": {},
         "chatRequest": {
             "model": "gpt-4o-2024-05-13",
             "messages": [
                 {
                     "role": "system",
-                    "content": "\nYou are task oriented system.\nYou receive input from a user, process the input from the given instructions, and then output the result.\nYour objective is to provide consistent and correct results.\nYou do not need to explain the steps taken, only provide the result to the given instructions.\nYou are referred to as a tool.\nYou don't move to the next step until you have a result.\n\nAsk Bob how he is doing and let me know exactly what he said."
+                    "content": "\nYou are task oriented system.\nYou receive input from a user, process the input from the given instructions, and then output the result.\nYour objective is to provide consistent and correct results.\nYou do not need to explain the steps taken, only provide the result to the given instructions.\nYou are referred to as a tool.\nYou don't move to the next step until you have a result.\n\nAsk Bob \"how are you doing\" and repeat his reply exactly."
                 },
                 {
                     "role": "assistant",
                     "content": "",
                     "tool_calls": [
                         {
-                            "id": "call_AZtZBeP4Ofv9CbW8Tiw066Cr",
+                            "id": "call_PGLxooO6eBPt3eSEBCMkuWYN",
                             "type": "function",
                             "function": {
                                 "name": "bob",
-                                "arguments": "{\"question\":\"How are you doing?\"}"
+                                "arguments": "{\"question\":\"how are you doing\"}"
                             }
                         }
                     ]
                 },
                 {
                     "role": "tool",
-                    "content": "Thanks for asking How are you doing?, I'm doing great fellow friendly AI tool!\n",
+                    "content": "Thanks for asking how are you doing, I'm doing great fellow friendly AI tool!\n",
                     "name": "bob",
-                    "tool_call_id": "call_AZtZBeP4Ofv9CbW8Tiw066Cr"
+                    "tool_call_id": "call_PGLxooO6eBPt3eSEBCMkuWYN"
                 }
             ],
             "temperature": 0,
@@ -969,16 +972,16 @@
         }
     },
     {
-        "time": "2024-06-06T20:21:50.398429-04:00",
+        "time": "2024-06-20T16:58:15.110087-04:00",
         "callContext": {
-            "id": "1717719710",
+            "id": "1718917095",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1001,21 +1004,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719713",
+        "chatCompletionId": "1718917098",
         "usage": {},
         "content": "Waiting for model response..."
     },
     {
-        "time": "2024-06-06T20:21:50.873677-04:00",
+        "time": "2024-06-20T16:58:15.629792-04:00",
         "callContext": {
-            "id": "1717719710",
+            "id": "1718917095",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1038,21 +1041,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719713",
+        "chatCompletionId": "1718917098",
         "usage": {},
-        "content": "Bob"
+        "content": "Thanks"
     },
     {
-        "time": "2024-06-06T20:21:50.873906-04:00",
+        "time": "2024-06-20T16:58:15.629968-04:00",
         "callContext": {
-            "id": "1717719710",
+            "id": "1718917095",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1075,21 +1078,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719713",
+        "chatCompletionId": "1718917098",
         "usage": {},
-        "content": "Bob"
+        "content": "Thanks"
     },
     {
-        "time": "2024-06-06T20:21:50.875164-04:00",
+        "time": "2024-06-20T16:58:15.749206-04:00",
         "callContext": {
-            "id": "1717719710",
+            "id": "1718917095",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1112,21 +1115,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719713",
+        "chatCompletionId": "1718917098",
         "usage": {},
-        "content": "Bob said:"
+        "content": "Thanks for"
     },
     {
-        "time": "2024-06-06T20:21:50.875259-04:00",
+        "time": "2024-06-20T16:58:15.749324-04:00",
         "callContext": {
-            "id": "1717719710",
+            "id": "1718917095",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1149,21 +1152,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719713",
+        "chatCompletionId": "1718917098",
         "usage": {},
-        "content": "Bob said: \""
+        "content": "Thanks for asking"
     },
     {
-        "time": "2024-06-06T20:21:50.875299-04:00",
+        "time": "2024-06-20T16:58:15.780062-04:00",
         "callContext": {
-            "id": "1717719710",
+            "id": "1718917095",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1186,21 +1189,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719713",
+        "chatCompletionId": "1718917098",
         "usage": {},
-        "content": "Bob said: \""
+        "content": "Thanks for asking how are"
     },
     {
-        "time": "2024-06-06T20:21:50.875379-04:00",
+        "time": "2024-06-20T16:58:15.780171-04:00",
         "callContext": {
-            "id": "1717719710",
+            "id": "1718917095",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1223,21 +1226,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719713",
+        "chatCompletionId": "1718917098",
         "usage": {},
-        "content": "Bob said: \"Thanks for"
+        "content": "Thanks for asking how are you"
     },
     {
-        "time": "2024-06-06T20:21:50.875553-04:00",
+        "time": "2024-06-20T16:58:15.780293-04:00",
         "callContext": {
-            "id": "1717719710",
+            "id": "1718917095",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1260,21 +1263,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719713",
+        "chatCompletionId": "1718917098",
         "usage": {},
-        "content": "Bob said: \"Thanks for asking"
+        "content": "Thanks for asking how are you doing"
     },
     {
-        "time": "2024-06-06T20:21:50.875607-04:00",
+        "time": "2024-06-20T16:58:15.780335-04:00",
         "callContext": {
-            "id": "1717719710",
+            "id": "1718917095",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1297,21 +1300,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719713",
+        "chatCompletionId": "1718917098",
         "usage": {},
-        "content": "Bob said: \"Thanks for asking"
+        "content": "Thanks for asking how are you doing"
     },
     {
-        "time": "2024-06-06T20:21:50.945695-04:00",
+        "time": "2024-06-20T16:58:15.780406-04:00",
         "callContext": {
-            "id": "1717719710",
+            "id": "1718917095",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1334,21 +1337,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719713",
+        "chatCompletionId": "1718917098",
         "usage": {},
-        "content": "Bob said: \"Thanks for asking How are"
+        "content": "Thanks for asking how are you doing, I'm"
     },
     {
-        "time": "2024-06-06T20:21:50.945912-04:00",
+        "time": "2024-06-20T16:58:15.780445-04:00",
         "callContext": {
-            "id": "1717719710",
+            "id": "1718917095",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1371,21 +1374,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719713",
+        "chatCompletionId": "1718917098",
         "usage": {},
-        "content": "Bob said: \"Thanks for asking How are"
+        "content": "Thanks for asking how are you doing, I'm"
     },
     {
-        "time": "2024-06-06T20:21:50.973355-04:00",
+        "time": "2024-06-20T16:58:15.780477-04:00",
         "callContext": {
-            "id": "1717719710",
+            "id": "1718917095",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1408,21 +1411,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719713",
+        "chatCompletionId": "1718917098",
         "usage": {},
-        "content": "Bob said: \"Thanks for asking How are you doing?,"
+        "content": "Thanks for asking how are you doing, I'm doing"
     },
     {
-        "time": "2024-06-06T20:21:50.973495-04:00",
+        "time": "2024-06-20T16:58:15.780511-04:00",
         "callContext": {
-            "id": "1717719710",
+            "id": "1718917095",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1445,21 +1448,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719713",
+        "chatCompletionId": "1718917098",
         "usage": {},
-        "content": "Bob said: \"Thanks for asking How are you doing?,"
+        "content": "Thanks for asking how are you doing, I'm doing great"
     },
     {
-        "time": "2024-06-06T20:21:50.973577-04:00",
+        "time": "2024-06-20T16:58:15.816742-04:00",
         "callContext": {
-            "id": "1717719710",
+            "id": "1718917095",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1482,21 +1485,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719713",
+        "chatCompletionId": "1718917098",
         "usage": {},
-        "content": "Bob said: \"Thanks for asking How are you doing?, I'm"
+        "content": "Thanks for asking how are you doing, I'm doing great fellow friendly"
     },
     {
-        "time": "2024-06-06T20:21:50.973604-04:00",
+        "time": "2024-06-20T16:58:15.816889-04:00",
         "callContext": {
-            "id": "1717719710",
+            "id": "1718917095",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1519,21 +1522,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719713",
+        "chatCompletionId": "1718917098",
         "usage": {},
-        "content": "Bob said: \"Thanks for asking How are you doing?, I'm"
+        "content": "Thanks for asking how are you doing, I'm doing great fellow friendly"
     },
     {
-        "time": "2024-06-06T20:21:50.973625-04:00",
+        "time": "2024-06-20T16:58:15.859699-04:00",
         "callContext": {
-            "id": "1717719710",
+            "id": "1718917095",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1556,21 +1559,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719713",
+        "chatCompletionId": "1718917098",
         "usage": {},
-        "content": "Bob said: \"Thanks for asking How are you doing?, I'm doing"
+        "content": "Thanks for asking how are you doing, I'm doing great fellow friendly AI tool"
     },
     {
-        "time": "2024-06-06T20:21:50.973646-04:00",
+        "time": "2024-06-20T16:58:15.859764-04:00",
         "callContext": {
-            "id": "1717719710",
+            "id": "1718917095",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1593,21 +1596,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719713",
+        "chatCompletionId": "1718917098",
         "usage": {},
-        "content": "Bob said: \"Thanks for asking How are you doing?, I'm doing great"
+        "content": "Thanks for asking how are you doing, I'm doing great fellow friendly AI tool!"
     },
     {
-        "time": "2024-06-06T20:21:50.994229-04:00",
+        "time": "2024-06-20T16:58:15.859784-04:00",
         "callContext": {
-            "id": "1717719710",
+            "id": "1718917095",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1630,21 +1633,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719713",
+        "chatCompletionId": "1718917098",
         "usage": {},
-        "content": "Bob said: \"Thanks for asking How are you doing?, I'm doing great fellow friendly"
+        "content": "Thanks for asking how are you doing, I'm doing great fellow friendly AI tool!"
     },
     {
-        "time": "2024-06-06T20:21:50.994426-04:00",
+        "time": "2024-06-20T16:58:15.859841-04:00",
         "callContext": {
-            "id": "1717719710",
+            "id": "1718917095",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1667,21 +1670,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719713",
+        "chatCompletionId": "1718917098",
         "usage": {},
-        "content": "Bob said: \"Thanks for asking How are you doing?, I'm doing great fellow friendly"
+        "content": "Thanks for asking how are you doing, I'm doing great fellow friendly AI tool!"
     },
     {
-        "time": "2024-06-06T20:21:51.017952-04:00",
+        "time": "2024-06-20T16:58:15.85986-04:00",
         "callContext": {
-            "id": "1717719710",
+            "id": "1718917095",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1704,169 +1707,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717719713",
+        "chatCompletionId": "1718917098",
         "usage": {},
-        "content": "Bob said: \"Thanks for asking How are you doing?, I'm doing great fellow friendly AI tool"
+        "content": "Thanks for asking how are you doing, I'm doing great fellow friendly AI tool!"
     },
     {
-        "time": "2024-06-06T20:21:51.018129-04:00",
+        "time": "2024-06-20T16:58:15.860819-04:00",
         "callContext": {
-            "id": "1717719710",
+            "id": "1718917095",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1717719713",
-        "usage": {},
-        "content": "Bob said: \"Thanks for asking How are you doing?, I'm doing great fellow friendly AI tool"
-    },
-    {
-        "time": "2024-06-06T20:21:51.020818-04:00",
-        "callContext": {
-            "id": "1717719710",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1717719713",
-        "usage": {},
-        "content": "Bob said: \"Thanks for asking How are you doing?, I'm doing great fellow friendly AI tool!\""
-    },
-    {
-        "time": "2024-06-06T20:21:51.020913-04:00",
-        "callContext": {
-            "id": "1717719710",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1717719713",
-        "usage": {},
-        "content": "Bob said: \"Thanks for asking How are you doing?, I'm doing great fellow friendly AI tool!\""
-    },
-    {
-        "time": "2024-06-06T20:21:51.020955-04:00",
-        "callContext": {
-            "id": "1717719710",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1717719713",
-        "usage": {},
-        "content": "Bob said: \"Thanks for asking How are you doing?, I'm doing great fellow friendly AI tool!\""
-    },
-    {
-        "time": "2024-06-06T20:21:51.02285-04:00",
-        "callContext": {
-            "id": "1717719710",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1889,37 +1744,37 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1717719713",
+        "chatCompletionId": "1718917098",
         "usage": {
-            "promptTokens": 180,
-            "completionTokens": 21,
-            "totalTokens": 201
+            "promptTokens": 178,
+            "completionTokens": 17,
+            "totalTokens": 195
         },
         "chatResponse": {
             "role": "assistant",
             "content": [
                 {
-                    "text": "Bob said: \"Thanks for asking How are you doing?, I'm doing great fellow friendly AI tool!\""
+                    "text": "Thanks for asking how are you doing, I'm doing great fellow friendly AI tool!"
                 }
             ],
             "usage": {
-                "promptTokens": 180,
-                "completionTokens": 21,
-                "totalTokens": 201
+                "promptTokens": 178,
+                "completionTokens": 17,
+                "totalTokens": 195
             }
         }
     },
     {
-        "time": "2024-06-06T20:21:51.022991-04:00",
+        "time": "2024-06-20T16:58:15.860872-04:00",
         "callContext": {
-            "id": "1717719710",
+            "id": "1718917095",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1943,10 +1798,10 @@
         },
         "type": "callFinish",
         "usage": {},
-        "content": "Bob said: \"Thanks for asking How are you doing?, I'm doing great fellow friendly AI tool!\""
+        "content": "Thanks for asking how are you doing, I'm doing great fellow friendly AI tool!"
     },
     {
-        "time": "2024-06-06T20:21:51.023016-04:00",
+        "time": "2024-06-20T16:58:15.860919-04:00",
         "type": "runFinish",
         "usage": {}
     }

--- a/pkg/tests/smoke/testdata/BobAsShell/mistral-large-2402-expected.json
+++ b/pkg/tests/smoke/testdata/BobAsShell/mistral-large-2402-expected.json
@@ -1,20 +1,20 @@
 [
     {
-        "time": "2024-06-06T20:57:48.704491-04:00",
+        "time": "2024-06-20T17:10:43.55694-04:00",
         "type": "runStart",
         "usage": {}
     },
     {
-        "time": "2024-06-06T20:57:48.70479-04:00",
+        "time": "2024-06-20T17:10:43.557263-04:00",
         "callContext": {
-            "id": "1717721869",
+            "id": "1718917844",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -40,16 +40,16 @@
         "usage": {}
     },
     {
-        "time": "2024-06-06T20:57:48.929935-04:00",
+        "time": "2024-06-20T17:10:43.805494-04:00",
         "callContext": {
-            "id": "1717721869",
+            "id": "1718917844",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -72,14 +72,14 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1717721870",
+        "chatCompletionId": "1718917845",
         "usage": {},
         "chatRequest": {
             "model": "mistral-large-2402",
             "messages": [
                 {
                     "role": "system",
-                    "content": "Ask Bob how he is doing and let me know exactly what he said."
+                    "content": "Ask Bob \"how are you doing\" and repeat his reply exactly."
                 }
             ],
             "temperature": 0,
@@ -104,16 +104,16 @@
         }
     },
     {
-        "time": "2024-06-06T20:57:48.930412-04:00",
+        "time": "2024-06-20T17:10:43.805682-04:00",
         "callContext": {
-            "id": "1717721869",
+            "id": "1718917844",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -136,21 +136,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721870",
+        "chatCompletionId": "1718917845",
         "usage": {},
         "content": "Waiting for model response..."
     },
     {
-        "time": "2024-06-06T20:57:49.11122-04:00",
+        "time": "2024-06-20T17:10:44.078279-04:00",
         "callContext": {
-            "id": "1717721869",
+            "id": "1718917844",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -173,20 +173,20 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721870",
+        "chatCompletionId": "1718917845",
         "usage": {}
     },
     {
-        "time": "2024-06-06T20:57:49.641536-04:00",
+        "time": "2024-06-20T17:10:44.913816-04:00",
         "callContext": {
-            "id": "1717721869",
+            "id": "1718917844",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -209,21 +209,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721870",
+        "chatCompletionId": "1718917845",
         "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\"question\": \"How are you doing?\"}"
+        "content": "\u003ctool call\u003e bob -\u003e {\"question\": \"how are you doing\"}"
     },
     {
-        "time": "2024-06-06T20:57:49.642104-04:00",
+        "time": "2024-06-20T17:10:44.914845-04:00",
         "callContext": {
-            "id": "1717721869",
+            "id": "1718917844",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -246,11 +246,11 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1717721870",
+        "chatCompletionId": "1718917845",
         "usage": {
-            "promptTokens": 86,
+            "promptTokens": 85,
             "completionTokens": 23,
-            "totalTokens": 109
+            "totalTokens": 108
         },
         "chatResponse": {
             "role": "assistant",
@@ -258,32 +258,32 @@
                 {
                     "toolCall": {
                         "index": 0,
-                        "id": "SJR7ytkCE",
+                        "id": "UPthtEfla",
                         "function": {
                             "name": "bob",
-                            "arguments": "{\"question\": \"How are you doing?\"}"
+                            "arguments": "{\"question\": \"how are you doing\"}"
                         }
                     }
                 }
             ],
             "usage": {
-                "promptTokens": 86,
+                "promptTokens": 85,
                 "completionTokens": 23,
-                "totalTokens": 109
+                "totalTokens": 108
             }
         }
     },
     {
-        "time": "2024-06-06T20:57:49.642359-04:00",
+        "time": "2024-06-20T17:10:44.915086-04:00",
         "callContext": {
-            "id": "1717721869",
+            "id": "1718917844",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -306,18 +306,18 @@
             "inputContext": null
         },
         "toolSubCalls": {
-            "SJR7ytkCE": {
+            "UPthtEfla": {
                 "toolID": "testdata/BobAsShell/test.gpt:bob",
-                "input": "{\"question\": \"How are you doing?\"}"
+                "input": "{\"question\": \"how are you doing\"}"
             }
         },
         "type": "callSubCalls",
         "usage": {}
     },
     {
-        "time": "2024-06-06T20:57:49.64244-04:00",
+        "time": "2024-06-20T17:10:44.915147-04:00",
         "callContext": {
-            "id": "SJR7ytkCE",
+            "id": "UPthtEfla",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -346,17 +346,17 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717721869",
+            "parentID": "1718917844",
             "displayText": "Running bob from testdata/BobAsShell/test.gpt"
         },
         "type": "callStart",
         "usage": {},
-        "content": "{\"question\": \"How are you doing?\"}"
+        "content": "{\"question\": \"how are you doing\"}"
     },
     {
-        "time": "2024-06-06T20:57:49.643547-04:00",
+        "time": "2024-06-20T17:10:44.916248-04:00",
         "callContext": {
-            "id": "SJR7ytkCE",
+            "id": "UPthtEfla",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -385,11 +385,11 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717721869",
+            "parentID": "1718917844",
             "displayText": "Running bob from testdata/BobAsShell/test.gpt"
         },
         "type": "callChat",
-        "chatCompletionId": "1717721871",
+        "chatCompletionId": "1718917846",
         "usage": {},
         "chatRequest": {
             "model": "",
@@ -397,9 +397,9 @@
         }
     },
     {
-        "time": "2024-06-06T20:57:49.651156-04:00",
+        "time": "2024-06-20T17:10:44.92245-04:00",
         "callContext": {
-            "id": "SJR7ytkCE",
+            "id": "UPthtEfla",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -428,20 +428,60 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717721869",
+            "parentID": "1718917844",
+            "displayText": "Running bob from testdata/BobAsShell/test.gpt"
+        },
+        "type": "callProgress",
+        "chatCompletionId": "1718917846",
+        "usage": {},
+        "content": "Thanks for asking how are you doing, I'm doing great fellow friendly AI tool!\n"
+    },
+    {
+        "time": "2024-06-20T17:10:44.922905-04:00",
+        "callContext": {
+            "id": "UPthtEfla",
+            "tool": {
+                "name": "bob",
+                "description": "I'm Bob, a friendly guy.",
+                "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "question": {
+                            "description": "The question to ask Bob.",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "instructions": "#!/bin/bash\n\necho \"Thanks for asking ${question}, I'm doing great fellow friendly AI tool!\"",
+                "id": "testdata/BobAsShell/test.gpt:bob",
+                "localTools": {
+                    "": "testdata/BobAsShell/test.gpt:",
+                    "bob": "testdata/BobAsShell/test.gpt:bob"
+                },
+                "source": {
+                    "location": "testdata/BobAsShell/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/BobAsShell"
+            },
+            "inputContext": null,
+            "toolName": "bob",
+            "parentID": "1718917844",
             "displayText": "Running bob from testdata/BobAsShell/test.gpt"
         },
         "type": "callChat",
-        "chatCompletionId": "1717721871",
+        "chatCompletionId": "1718917846",
         "usage": {},
         "chatResponse": {
             "usage": {}
         }
     },
     {
-        "time": "2024-06-06T20:57:49.651393-04:00",
+        "time": "2024-06-20T17:10:44.922998-04:00",
         "callContext": {
-            "id": "SJR7ytkCE",
+            "id": "UPthtEfla",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -470,24 +510,24 @@
             },
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1717721869",
+            "parentID": "1718917844",
             "displayText": "Running bob from testdata/BobAsShell/test.gpt"
         },
         "type": "callFinish",
         "usage": {},
-        "content": "Thanks for asking How are you doing?, I'm doing great fellow friendly AI tool!\n"
+        "content": "Thanks for asking how are you doing, I'm doing great fellow friendly AI tool!\n"
     },
     {
-        "time": "2024-06-06T20:57:49.651461-04:00",
+        "time": "2024-06-20T17:10:44.92306-04:00",
         "callContext": {
-            "id": "1717721869",
+            "id": "1718917844",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -514,16 +554,16 @@
         "usage": {}
     },
     {
-        "time": "2024-06-06T20:57:49.851552-04:00",
+        "time": "2024-06-20T17:10:45.091313-04:00",
         "callContext": {
-            "id": "1717721869",
+            "id": "1718917844",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -546,34 +586,34 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1717721872",
+        "chatCompletionId": "1718917847",
         "usage": {},
         "chatRequest": {
             "model": "mistral-large-2402",
             "messages": [
                 {
                     "role": "system",
-                    "content": "Ask Bob how he is doing and let me know exactly what he said."
+                    "content": "Ask Bob \"how are you doing\" and repeat his reply exactly."
                 },
                 {
                     "role": "assistant",
                     "content": "",
                     "tool_calls": [
                         {
-                            "id": "SJR7ytkCE",
+                            "id": "UPthtEfla",
                             "type": "function",
                             "function": {
                                 "name": "bob",
-                                "arguments": "{\"question\": \"How are you doing?\"}"
+                                "arguments": "{\"question\": \"how are you doing\"}"
                             }
                         }
                     ]
                 },
                 {
                     "role": "tool",
-                    "content": "Thanks for asking How are you doing?, I'm doing great fellow friendly AI tool!\n",
+                    "content": "Thanks for asking how are you doing, I'm doing great fellow friendly AI tool!\n",
                     "name": "bob",
-                    "tool_call_id": "SJR7ytkCE"
+                    "tool_call_id": "UPthtEfla"
                 }
             ],
             "temperature": 0,
@@ -598,16 +638,16 @@
         }
     },
     {
-        "time": "2024-06-06T20:57:49.851831-04:00",
+        "time": "2024-06-20T17:10:45.091762-04:00",
         "callContext": {
-            "id": "1717721869",
+            "id": "1718917844",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -630,21 +670,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721872",
+        "chatCompletionId": "1718917847",
         "usage": {},
         "content": "Waiting for model response..."
     },
     {
-        "time": "2024-06-06T20:57:50.017629-04:00",
+        "time": "2024-06-20T17:10:45.427766-04:00",
         "callContext": {
-            "id": "1717721869",
+            "id": "1718917844",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -667,57 +707,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721872",
-        "usage": {}
-    },
-    {
-        "time": "2024-06-06T20:57:50.060377-04:00",
-        "callContext": {
-            "id": "1717721869",
-            "tool": {
-                "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1717721872",
+        "chatCompletionId": "1718917847",
         "usage": {},
         "content": "Bob"
     },
     {
-        "time": "2024-06-06T20:57:50.084824-04:00",
+        "time": "2024-06-20T17:10:45.427886-04:00",
         "callContext": {
-            "id": "1717721869",
+            "id": "1718917844",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -740,21 +744,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721872",
+        "chatCompletionId": "1718917847",
         "usage": {},
-        "content": "Bob said"
+        "content": "Bob replied"
     },
     {
-        "time": "2024-06-06T20:57:50.104197-04:00",
+        "time": "2024-06-20T17:10:45.427938-04:00",
         "callContext": {
-            "id": "1717721869",
+            "id": "1718917844",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -777,21 +781,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721872",
+        "chatCompletionId": "1718917847",
         "usage": {},
-        "content": "Bob said,"
+        "content": "Bob replied,"
     },
     {
-        "time": "2024-06-06T20:57:50.126794-04:00",
+        "time": "2024-06-20T17:10:45.427998-04:00",
         "callContext": {
-            "id": "1717721869",
+            "id": "1718917844",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -814,21 +818,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721872",
+        "chatCompletionId": "1718917847",
         "usage": {},
-        "content": "Bob said, \""
+        "content": "Bob replied, \""
     },
     {
-        "time": "2024-06-06T20:57:50.147974-04:00",
+        "time": "2024-06-20T17:10:45.428017-04:00",
         "callContext": {
-            "id": "1717721869",
+            "id": "1718917844",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -851,21 +855,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721872",
+        "chatCompletionId": "1718917847",
         "usage": {},
-        "content": "Bob said, \"Thanks"
+        "content": "Bob replied, \""
     },
     {
-        "time": "2024-06-06T20:57:50.17264-04:00",
+        "time": "2024-06-20T17:10:45.428046-04:00",
         "callContext": {
-            "id": "1717721869",
+            "id": "1718917844",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -888,21 +892,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721872",
+        "chatCompletionId": "1718917847",
         "usage": {},
-        "content": "Bob said, \"Thanks for"
+        "content": "Bob replied, \"Thanks"
     },
     {
-        "time": "2024-06-06T20:57:50.194235-04:00",
+        "time": "2024-06-20T17:10:45.434307-04:00",
         "callContext": {
-            "id": "1717721869",
+            "id": "1718917844",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -925,21 +929,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721872",
+        "chatCompletionId": "1718917847",
         "usage": {},
-        "content": "Bob said, \"Thanks for asking"
+        "content": "Bob replied, \"Thanks for"
     },
     {
-        "time": "2024-06-06T20:57:50.218937-04:00",
+        "time": "2024-06-20T17:10:45.462196-04:00",
         "callContext": {
-            "id": "1717721869",
+            "id": "1718917844",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -962,21 +966,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721872",
+        "chatCompletionId": "1718917847",
         "usage": {},
-        "content": "Bob said, \"Thanks for asking '"
+        "content": "Bob replied, \"Thanks for asking"
     },
     {
-        "time": "2024-06-06T20:57:50.239766-04:00",
+        "time": "2024-06-20T17:10:45.496748-04:00",
         "callContext": {
-            "id": "1717721869",
+            "id": "1718917844",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -999,21 +1003,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721872",
+        "chatCompletionId": "1718917847",
         "usage": {},
-        "content": "Bob said, \"Thanks for asking 'How"
+        "content": "Bob replied, \"Thanks for asking how"
     },
     {
-        "time": "2024-06-06T20:57:50.261815-04:00",
+        "time": "2024-06-20T17:10:45.516868-04:00",
         "callContext": {
-            "id": "1717721869",
+            "id": "1718917844",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1036,21 +1040,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721872",
+        "chatCompletionId": "1718917847",
         "usage": {},
-        "content": "Bob said, \"Thanks for asking 'How are"
+        "content": "Bob replied, \"Thanks for asking how are"
     },
     {
-        "time": "2024-06-06T20:57:50.28776-04:00",
+        "time": "2024-06-20T17:10:45.545808-04:00",
         "callContext": {
-            "id": "1717721869",
+            "id": "1718917844",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1073,21 +1077,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721872",
+        "chatCompletionId": "1718917847",
         "usage": {},
-        "content": "Bob said, \"Thanks for asking 'How are you"
+        "content": "Bob replied, \"Thanks for asking how are you"
     },
     {
-        "time": "2024-06-06T20:57:50.307171-04:00",
+        "time": "2024-06-20T17:10:45.572091-04:00",
         "callContext": {
-            "id": "1717721869",
+            "id": "1718917844",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1110,21 +1114,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721872",
+        "chatCompletionId": "1718917847",
         "usage": {},
-        "content": "Bob said, \"Thanks for asking 'How are you doing"
+        "content": "Bob replied, \"Thanks for asking how are you doing"
     },
     {
-        "time": "2024-06-06T20:57:50.330839-04:00",
+        "time": "2024-06-20T17:10:45.602668-04:00",
         "callContext": {
-            "id": "1717721869",
+            "id": "1718917844",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1147,21 +1151,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721872",
+        "chatCompletionId": "1718917847",
         "usage": {},
-        "content": "Bob said, \"Thanks for asking 'How are you doing?"
+        "content": "Bob replied, \"Thanks for asking how are you doing,"
     },
     {
-        "time": "2024-06-06T20:57:50.352459-04:00",
+        "time": "2024-06-20T17:10:45.627618-04:00",
         "callContext": {
-            "id": "1717721869",
+            "id": "1718917844",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1184,21 +1188,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721872",
+        "chatCompletionId": "1718917847",
         "usage": {},
-        "content": "Bob said, \"Thanks for asking 'How are you doing?',"
+        "content": "Bob replied, \"Thanks for asking how are you doing, I"
     },
     {
-        "time": "2024-06-06T20:57:50.375291-04:00",
+        "time": "2024-06-20T17:10:45.659445-04:00",
         "callContext": {
-            "id": "1717721869",
+            "id": "1718917844",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1221,21 +1225,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721872",
+        "chatCompletionId": "1718917847",
         "usage": {},
-        "content": "Bob said, \"Thanks for asking 'How are you doing?', I"
+        "content": "Bob replied, \"Thanks for asking how are you doing, I'"
     },
     {
-        "time": "2024-06-06T20:57:50.398407-04:00",
+        "time": "2024-06-20T17:10:45.682109-04:00",
         "callContext": {
-            "id": "1717721869",
+            "id": "1718917844",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1258,21 +1262,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721872",
+        "chatCompletionId": "1718917847",
         "usage": {},
-        "content": "Bob said, \"Thanks for asking 'How are you doing?', I'"
+        "content": "Bob replied, \"Thanks for asking how are you doing, I'm"
     },
     {
-        "time": "2024-06-06T20:57:50.421233-04:00",
+        "time": "2024-06-20T17:10:45.710817-04:00",
         "callContext": {
-            "id": "1717721869",
+            "id": "1718917844",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1295,21 +1299,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721872",
+        "chatCompletionId": "1718917847",
         "usage": {},
-        "content": "Bob said, \"Thanks for asking 'How are you doing?', I'm"
+        "content": "Bob replied, \"Thanks for asking how are you doing, I'm doing"
     },
     {
-        "time": "2024-06-06T20:57:50.443362-04:00",
+        "time": "2024-06-20T17:10:45.743363-04:00",
         "callContext": {
-            "id": "1717721869",
+            "id": "1718917844",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1332,21 +1336,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721872",
+        "chatCompletionId": "1718917847",
         "usage": {},
-        "content": "Bob said, \"Thanks for asking 'How are you doing?', I'm doing"
+        "content": "Bob replied, \"Thanks for asking how are you doing, I'm doing great"
     },
     {
-        "time": "2024-06-06T20:57:50.466617-04:00",
+        "time": "2024-06-20T17:10:45.766321-04:00",
         "callContext": {
-            "id": "1717721869",
+            "id": "1718917844",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1369,21 +1373,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721872",
+        "chatCompletionId": "1718917847",
         "usage": {},
-        "content": "Bob said, \"Thanks for asking 'How are you doing?', I'm doing great"
+        "content": "Bob replied, \"Thanks for asking how are you doing, I'm doing great fellow"
     },
     {
-        "time": "2024-06-06T20:57:50.488545-04:00",
+        "time": "2024-06-20T17:10:45.801585-04:00",
         "callContext": {
-            "id": "1717721869",
+            "id": "1718917844",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1406,21 +1410,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721872",
+        "chatCompletionId": "1718917847",
         "usage": {},
-        "content": "Bob said, \"Thanks for asking 'How are you doing?', I'm doing great fellow"
+        "content": "Bob replied, \"Thanks for asking how are you doing, I'm doing great fellow friendly"
     },
     {
-        "time": "2024-06-06T20:57:50.514471-04:00",
+        "time": "2024-06-20T17:10:46.066262-04:00",
         "callContext": {
-            "id": "1717721869",
+            "id": "1718917844",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1443,21 +1447,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721872",
+        "chatCompletionId": "1718917847",
         "usage": {},
-        "content": "Bob said, \"Thanks for asking 'How are you doing?', I'm doing great fellow friendly"
+        "content": "Bob replied, \"Thanks for asking how are you doing, I'm doing great fellow friendly AI"
     },
     {
-        "time": "2024-06-06T20:57:50.533973-04:00",
+        "time": "2024-06-20T17:10:46.093598-04:00",
         "callContext": {
-            "id": "1717721869",
+            "id": "1718917844",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1480,21 +1484,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721872",
+        "chatCompletionId": "1718917847",
         "usage": {},
-        "content": "Bob said, \"Thanks for asking 'How are you doing?', I'm doing great fellow friendly AI"
+        "content": "Bob replied, \"Thanks for asking how are you doing, I'm doing great fellow friendly AI tool"
     },
     {
-        "time": "2024-06-06T20:57:50.55935-04:00",
+        "time": "2024-06-20T17:10:46.118737-04:00",
         "callContext": {
-            "id": "1717721869",
+            "id": "1718917844",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1517,21 +1521,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721872",
+        "chatCompletionId": "1718917847",
         "usage": {},
-        "content": "Bob said, \"Thanks for asking 'How are you doing?', I'm doing great fellow friendly AI tool"
+        "content": "Bob replied, \"Thanks for asking how are you doing, I'm doing great fellow friendly AI tool!\""
     },
     {
-        "time": "2024-06-06T20:57:50.579532-04:00",
+        "time": "2024-06-20T17:10:46.146712-04:00",
         "callContext": {
-            "id": "1717721869",
+            "id": "1718917844",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1554,58 +1558,21 @@
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1717721872",
+        "chatCompletionId": "1718917847",
         "usage": {},
-        "content": "Bob said, \"Thanks for asking 'How are you doing?', I'm doing great fellow friendly AI tool!\""
+        "content": "Bob replied, \"Thanks for asking how are you doing, I'm doing great fellow friendly AI tool!\""
     },
     {
-        "time": "2024-06-06T20:57:50.603725-04:00",
+        "time": "2024-06-20T17:10:46.146789-04:00",
         "callContext": {
-            "id": "1717721869",
+            "id": "1718917844",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1717721872",
-        "usage": {},
-        "content": "Bob said, \"Thanks for asking 'How are you doing?', I'm doing great fellow friendly AI tool!\""
-    },
-    {
-        "time": "2024-06-06T20:57:50.604733-04:00",
-        "callContext": {
-            "id": "1717721869",
-            "tool": {
-                "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1628,37 +1595,37 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1717721872",
+        "chatCompletionId": "1718917847",
         "usage": {
-            "promptTokens": 145,
-            "completionTokens": 24,
-            "totalTokens": 169
+            "promptTokens": 144,
+            "completionTokens": 22,
+            "totalTokens": 166
         },
         "chatResponse": {
             "role": "assistant",
             "content": [
                 {
-                    "text": "Bob said, \"Thanks for asking 'How are you doing?', I'm doing great fellow friendly AI tool!\""
+                    "text": "Bob replied, \"Thanks for asking how are you doing, I'm doing great fellow friendly AI tool!\""
                 }
             ],
             "usage": {
-                "promptTokens": 145,
-                "completionTokens": 24,
-                "totalTokens": 169
+                "promptTokens": 144,
+                "completionTokens": 22,
+                "totalTokens": 166
             }
         }
     },
     {
-        "time": "2024-06-06T20:57:50.604844-04:00",
+        "time": "2024-06-20T17:10:46.146827-04:00",
         "callContext": {
-            "id": "1717721869",
+            "id": "1718917844",
             "tool": {
                 "modelName": "mistral-large-2402 from https://api.mistral.ai/v1",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
-                "instructions": "Ask Bob how he is doing and let me know exactly what he said.",
+                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
                 "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
@@ -1682,10 +1649,10 @@
         },
         "type": "callFinish",
         "usage": {},
-        "content": "Bob said, \"Thanks for asking 'How are you doing?', I'm doing great fellow friendly AI tool!\""
+        "content": "Bob replied, \"Thanks for asking how are you doing, I'm doing great fellow friendly AI tool!\""
     },
     {
-        "time": "2024-06-06T20:57:50.604875-04:00",
+        "time": "2024-06-20T17:10:46.146844-04:00",
         "type": "runFinish",
         "usage": {}
     }

--- a/pkg/tests/smoke/testdata/BobAsShell/test.gpt
+++ b/pkg/tests/smoke/testdata/BobAsShell/test.gpt
@@ -1,7 +1,7 @@
 
 tools: bob
 
-Ask Bob how he is doing and let me know exactly what he said.
+Ask Bob "how are you doing" and repeat his reply exactly.
 
 ---
 name: bob


### PR DESCRIPTION
Perform some prompt engineering on the smoke test judge and test cases
to make result comparison more reliable. This will stop the smoke tests from
flaking.

Note: Reran this with `-count=10` for each model locally and didn't get any flakes.