### PR TITLE
Test PR to verify smoke test org member gating

### DIFF
--- a/pkg/types/completion.go
+++ b/pkg/types/completion.go
@@ -104,6 +104,7 @@ func Text(text string) []ContentPart {
 }
 
 func (c CompletionMessage) String() string {
+	// Change to test smoke test workflow org membership gating
 	buf := strings.Builder{}
 	for i, content := range c.Content {
 		if i > 0 {


### PR DESCRIPTION
This burner account isn't a member of `gptscript-ai`, so smoke tests shouldn't run automatically without the `run-smoke` label.