### PR TITLE
fix: get remote file before appending default file names

### DIFF
--- a/pkg/loader/url.go
+++ b/pkg/loader/url.go
@@ -135,7 +135,7 @@ func getWithDefaults(req *http.Request) ([]byte, error) {
 	originalPath := req.URL.Path
 
 	// First, try to get the original path as is.
-	// It might be a raw tool file or an OpenAPI definition.
+	// It might be an OpenAPI definition.
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, err
@@ -143,7 +143,9 @@ func getWithDefaults(req *http.Request) ([]byte, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusOK {
-		return io.ReadAll(resp.Body)
+		if toolBytes, err := io.ReadAll(resp.Body); err == nil && isOpenAPI(toolBytes) != 0 {
+			return toolBytes, nil
+		}
 	}
 
 	for i, def := range types.DefaultFiles {

--- a/pkg/loader/url.go
+++ b/pkg/loader/url.go
@@ -134,8 +134,7 @@ func loadURL(ctx context.Context, cache *cache.Client, base *source, name string
 func getWithDefaults(req *http.Request) ([]byte, error) {
 	originalPath := req.URL.Path
 
-	// First, try to get the original path as is.
-	// It might be an OpenAPI definition.
+	// First, try to get the original path as is. It might be an OpenAPI definition.
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, err

--- a/pkg/loader/url.go
+++ b/pkg/loader/url.go
@@ -133,6 +133,19 @@ func loadURL(ctx context.Context, cache *cache.Client, base *source, name string
 
 func getWithDefaults(req *http.Request) ([]byte, error) {
 	originalPath := req.URL.Path
+
+	// First, try to get the original path as is.
+	// It might be a raw tool file or an OpenAPI definition.
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusOK {
+		return io.ReadAll(resp.Body)
+	}
+
 	for i, def := range types.DefaultFiles {
 		base := path.Base(originalPath)
 		if !strings.Contains(base, ".") {


### PR DESCRIPTION
This function was automatically attaching `agent.gpt` or `tool.gpt` to the end of URLs that didn't already contain a `.` in their last path element. This broke use cases like `tools: https://petstore.gptscript-demos.ai/openapi`, because it totally ignored the main URL and tried to look for those two tool files instead. This fixes that problem.

for #537 