### PR TITLE
fix: always build credential helper

### DIFF
--- a/pkg/gptscript/gptscript.go
+++ b/pkg/gptscript/gptscript.go
@@ -103,6 +103,9 @@ func New(o ...Options) (*GPTScript, error) {
 	if err := opts.Runner.RuntimeManager.SetUpCredentialHelpers(context.Background(), cliCfg, opts.Env); err != nil {
 		return nil, err
 	}
+	if err := opts.Runner.RuntimeManager.EnsureCredentialHelpers(context.Background()); err != nil {
+		return nil, err
+	}
 
 	oaiClient, err := openai.NewClient(credStore, opts.OpenAI, openai.Options{
 		Cache:   cacheClient,


### PR DESCRIPTION
Previously, we were only building the credential helper right before handling credential tools. But the helper is also needed for looking up model provider keys like `sys.openai`. This leads to crashes on new installations. For now, the solution is to just always build the credential helper. Once Darren is back, we can figure out how to do this in a better way if he is dissatisfied with it.