### PR TITLE
feat: build credential helpers just in time

### DIFF
--- a/pkg/cli/credential_delete.go
+++ b/pkg/cli/credential_delete.go
@@ -6,6 +6,8 @@ import (
 	"github.com/gptscript-ai/gptscript/pkg/cache"
 	"github.com/gptscript-ai/gptscript/pkg/config"
 	"github.com/gptscript-ai/gptscript/pkg/credentials"
+	"github.com/gptscript-ai/gptscript/pkg/repos/runtimes"
+	"github.com/gptscript-ai/gptscript/pkg/runner"
 	"github.com/spf13/cobra"
 )
 
@@ -21,24 +23,33 @@ func (c *Delete) Customize(cmd *cobra.Command) {
 	cmd.Args = cobra.ExactArgs(1)
 }
 
-func (c *Delete) Run(_ *cobra.Command, args []string) error {
+func (c *Delete) Run(cmd *cobra.Command, args []string) error {
 	opts, err := c.root.NewGPTScriptOpts()
 	if err != nil {
 		return err
 	}
-	opts.Cache = cache.Complete(opts.Cache)
 
 	cfg, err := config.ReadCLIConfig(c.root.ConfigFile)
 	if err != nil {
 		return fmt.Errorf("failed to read CLI config: %w", err)
 	}
 
-	store, err := credentials.NewStore(cfg, c.root.CredentialContext, opts.Cache.CacheDir)
+	opts.Cache = cache.Complete(opts.Cache)
+	opts.Runner = runner.Complete(opts.Runner)
+	if opts.Runner.RuntimeManager == nil {
+		opts.Runner.RuntimeManager = runtimes.Default(opts.Cache.CacheDir)
+	}
+
+	if err = opts.Runner.RuntimeManager.SetUpCredentialHelpers(cmd.Context(), cfg, opts.Env); err != nil {
+		return err
+	}
+
+	store, err := credentials.NewStore(cfg, opts.Runner.RuntimeManager, c.root.CredentialContext, opts.Cache.CacheDir)
 	if err != nil {
 		return fmt.Errorf("failed to get credentials store: %w", err)
 	}
 
-	if err = store.Remove(args[0]); err != nil {
+	if err = store.Remove(cmd.Context(), args[0]); err != nil {
 		return fmt.Errorf("failed to remove credential: %w", err)
 	}
 	return nil

--- a/pkg/cli/credential_show.go
+++ b/pkg/cli/credential_show.go
@@ -8,6 +8,8 @@ import (
 	"github.com/gptscript-ai/gptscript/pkg/cache"
 	"github.com/gptscript-ai/gptscript/pkg/config"
 	"github.com/gptscript-ai/gptscript/pkg/credentials"
+	"github.com/gptscript-ai/gptscript/pkg/repos/runtimes"
+	"github.com/gptscript-ai/gptscript/pkg/runner"
 	"github.com/spf13/cobra"
 )
 
@@ -23,24 +25,33 @@ func (c *Show) Customize(cmd *cobra.Command) {
 	cmd.Args = cobra.ExactArgs(1)
 }
 
-func (c *Show) Run(_ *cobra.Command, args []string) error {
+func (c *Show) Run(cmd *cobra.Command, args []string) error {
 	opts, err := c.root.NewGPTScriptOpts()
 	if err != nil {
 		return err
 	}
-	opts.Cache = cache.Complete(opts.Cache)
 
 	cfg, err := config.ReadCLIConfig(c.root.ConfigFile)
 	if err != nil {
 		return fmt.Errorf("failed to read CLI config: %w", err)
 	}
 
-	store, err := credentials.NewStore(cfg, c.root.CredentialContext, opts.Cache.CacheDir)
+	opts.Cache = cache.Complete(opts.Cache)
+	opts.Runner = runner.Complete(opts.Runner)
+	if opts.Runner.RuntimeManager == nil {
+		opts.Runner.RuntimeManager = runtimes.Default(opts.Cache.CacheDir)
+	}
+
+	if err = opts.Runner.RuntimeManager.SetUpCredentialHelpers(cmd.Context(), cfg, opts.Env); err != nil {
+		return err
+	}
+
+	store, err := credentials.NewStore(cfg, opts.Runner.RuntimeManager, c.root.CredentialContext, opts.Cache.CacheDir)
 	if err != nil {
 		return fmt.Errorf("failed to get credentials store: %w", err)
 	}
 
-	cred, exists, err := store.Get(args[0])
+	cred, exists, err := store.Get(cmd.Context(), args[0])
 	if err != nil {
 		return fmt.Errorf("failed to get credential: %w", err)
 	}

--- a/pkg/cli/eval.go
+++ b/pkg/cli/eval.go
@@ -56,7 +56,7 @@ func (e *Eval) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	runner, err := gptscript.New(opts)
+	runner, err := gptscript.New(cmd.Context(), opts)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/gptscript.go
+++ b/pkg/cli/gptscript.go
@@ -380,7 +380,7 @@ func (r *GPTScript) Run(cmd *cobra.Command, args []string) (retErr error) {
 
 	ctx := cmd.Context()
 
-	gptScript, err := gptscript.New(gptOpt)
+	gptScript, err := gptscript.New(ctx, gptOpt)
 	if err != nil {
 		return err
 	}

--- a/pkg/credentials/noop.go
+++ b/pkg/credentials/noop.go
@@ -1,19 +1,21 @@
 package credentials
 
+import "context"
+
 type NoopStore struct{}
 
-func (s NoopStore) Get(_ string) (*Credential, bool, error) {
+func (s NoopStore) Get(context.Context, string) (*Credential, bool, error) {
 	return nil, false, nil
 }
 
-func (s NoopStore) Add(_ Credential) error {
+func (s NoopStore) Add(context.Context, Credential) error {
 	return nil
 }
 
-func (s NoopStore) Remove(_ string) error {
+func (s NoopStore) Remove(context.Context, string) error {
 	return nil
 }
 
-func (s NoopStore) List() ([]Credential, error) {
+func (s NoopStore) List(context.Context) ([]Credential, error) {
 	return nil, nil
 }

--- a/pkg/openai/client.go
+++ b/pkg/openai/client.go
@@ -93,7 +93,7 @@ func complete(opts ...Options) (Options, error) {
 	return result, err
 }
 
-func NewClient(credStore credentials.CredentialStore, opts ...Options) (*Client, error) {
+func NewClient(ctx context.Context, credStore credentials.CredentialStore, opts ...Options) (*Client, error) {
 	opt, err := complete(opts...)
 	if err != nil {
 		return nil, err
@@ -101,7 +101,7 @@ func NewClient(credStore credentials.CredentialStore, opts ...Options) (*Client,
 
 	// If the API key is not set, try to get it from the cred store
 	if opt.APIKey == "" && opt.BaseURL == "" {
-		cred, exists, err := credStore.Get(BuiltinCredName)
+		cred, exists, err := credStore.Get(ctx, BuiltinCredName)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/prompt/credential.go
+++ b/pkg/prompt/credential.go
@@ -9,7 +9,7 @@ import (
 )
 
 func GetModelProviderCredential(ctx context.Context, credStore credentials.CredentialStore, credName, env, message string, envs []string) (string, error) {
-	cred, exists, err := credStore.Get(credName)
+	cred, exists, err := credStore.Get(ctx, credName)
 	if err != nil {
 		return "", err
 	}
@@ -25,7 +25,7 @@ func GetModelProviderCredential(ctx context.Context, credStore credentials.Crede
 		}
 
 		k = gjson.Get(result, "key").String()
-		if err := credStore.Add(credentials.Credential{
+		if err := credStore.Add(ctx, credentials.Credential{
 			ToolName: credName,
 			Type:     credentials.CredentialTypeModelProvider,
 			Env: map[string]string{

--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -116,7 +116,7 @@ func (c *Client) clientFromURL(ctx context.Context, apiURL string) (*openai.Clie
 		}
 	}
 
-	return openai.NewClient(c.credStore, openai.Options{
+	return openai.NewClient(ctx, c.credStore, openai.Options{
 		BaseURL: apiURL,
 		Cache:   c.cache,
 		APIKey:  key,
@@ -163,7 +163,7 @@ func (c *Client) load(ctx context.Context, toolName string) (*openai.Client, err
 		url += "/v1"
 	}
 
-	client, err = openai.NewClient(c.credStore, openai.Options{
+	client, err = openai.NewClient(ctx, c.credStore, openai.Options{
 		BaseURL:  url,
 		Cache:    c.cache,
 		CacheKey: prg.EntryToolID,

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -873,12 +873,12 @@ func (r *Runner) handleCredentials(callCtx engine.Context, monitor Monitor, env 
 		// Only try to look up the cred if the tool is on GitHub or has an alias.
 		// If it is a GitHub tool and has an alias, the alias overrides the tool name, so we use it as the credential name.
 		if isGitHubTool(toolName) && credentialAlias == "" {
-			c, exists, err = r.credStore.Get(toolName)
+			c, exists, err = r.credStore.Get(callCtx.Ctx, toolName)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get credentials for tool %s: %w", toolName, err)
 			}
 		} else if credentialAlias != "" {
-			c, exists, err = r.credStore.Get(credentialAlias)
+			c, exists, err = r.credStore.Get(callCtx.Ctx, credentialAlias)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get credentials for tool %s: %w", credentialAlias, err)
 			}
@@ -942,7 +942,7 @@ func (r *Runner) handleCredentials(callCtx engine.Context, monitor Monitor, env 
 			if (isGitHubTool(toolName) && callCtx.Program.ToolSet[credToolRefs[0].ToolID].Source.Repo != nil) || credentialAlias != "" {
 				if isEmpty {
 					log.Warnf("Not saving empty credential for tool %s", toolName)
-				} else if err := r.credStore.Add(*c); err != nil {
+				} else if err := r.credStore.Add(callCtx.Ctx, *c); err != nil {
 					return nil, fmt.Errorf("failed to add credential for tool %s: %w", toolName, err)
 				}
 			} else {

--- a/pkg/sdkserver/run.go
+++ b/pkg/sdkserver/run.go
@@ -17,7 +17,7 @@ import (
 type loaderFunc func(context.Context, string, string, ...loader.Options) (types.Program, error)
 
 func (s *server) execAndStream(ctx context.Context, programLoader loaderFunc, logger mvl.Logger, w http.ResponseWriter, opts gptscript.Options, chatState, input, subTool string, toolDef fmt.Stringer) {
-	g, err := gptscript.New(s.gptscriptOpts, opts)
+	g, err := gptscript.New(ctx, s.gptscriptOpts, opts)
 	if err != nil {
 		writeError(logger, w, http.StatusInternalServerError, fmt.Errorf("failed to initialize gptscript: %w", err))
 		return

--- a/pkg/sdkserver/server.go
+++ b/pkg/sdkserver/server.go
@@ -53,7 +53,7 @@ func Start(ctx context.Context, opts Options) error {
 	// prompt server because it is only used for fmt, parse, etc.
 	opts.Env = append(opts.Env, fmt.Sprintf("%s=%s", types.PromptTokenEnvVar, token))
 
-	g, err := gptscript.New(opts.Options)
+	g, err := gptscript.New(ctx, opts.Options)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Instead of building the credential helpers on startup, this change builds them when they are needed. This speeds up start time for the SDK.