### PR TITLE
enhance: plumb credential context into run/eval requests

### DIFF
--- a/pkg/sdkserver/routes.go
+++ b/pkg/sdkserver/routes.go
@@ -200,7 +200,8 @@ func (s *server) execHandler(w http.ResponseWriter, r *http.Request) {
 		CredentialContext: reqObject.CredentialContext,
 		Runner: runner.Options{
 			// Set the monitor factory so that we can get events from the server.
-			MonitorFactory: NewSessionFactory(s.events),
+			MonitorFactory:     NewSessionFactory(s.events),
+			CredentialOverride: reqObject.CredentialOverride,
 		},
 	}
 

--- a/pkg/sdkserver/types.go
+++ b/pkg/sdkserver/types.go
@@ -52,14 +52,15 @@ type toolOrFileRequest struct {
 	cacheOptions  `json:",inline"`
 	openAIOptions `json:",inline"`
 
-	ToolDefs          toolDefs `json:"toolDefs,inline"`
-	SubTool           string   `json:"subTool"`
-	Input             string   `json:"input"`
-	ChatState         string   `json:"chatState"`
-	Workspace         string   `json:"workspace"`
-	Env               []string `json:"env"`
-	CredentialContext string   `json:"credentialContext"`
-	Confirm           bool     `json:"confirm"`
+	ToolDefs           toolDefs `json:"toolDefs,inline"`
+	SubTool            string   `json:"subTool"`
+	Input              string   `json:"input"`
+	ChatState          string   `json:"chatState"`
+	Workspace          string   `json:"workspace"`
+	Env                []string `json:"env"`
+	CredentialContext  string   `json:"credentialContext"`
+	CredentialOverride string   `json:"credentialOverride"`
+	Confirm            bool     `json:"confirm"`
 }
 
 type content struct {


### PR DESCRIPTION
Expose the `credentialOverride` field in the request payload for the run/eval sdkserver
endpoints. This will enable credential override support to be implemented by the SDKs.

Related issue: https://github.com/gptscript-ai/gptscript/issues/553

