### PR TITLE
bug: go back to old behavior of dropping {} for tools

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/gptscript-ai/broadcaster v0.0.0-20240625175512-c43682019b86
 	github.com/gptscript-ai/chat-completion-client v0.0.0-20240531200700-af8e7ecf0379
 	github.com/gptscript-ai/cmd v0.0.0-20240625175447-4250b42feb7d
-	github.com/gptscript-ai/tui v0.0.0-20240627001757-8b452fa47eb5
+	github.com/gptscript-ai/tui v0.0.0-20240627044440-d416df63c10d
 	github.com/hexops/autogold/v2 v2.2.1
 	github.com/hexops/valast v1.4.4
 	github.com/jaytaylor/html2text v0.0.0-20230321000545-74c2419ad056

--- a/go.sum
+++ b/go.sum
@@ -173,8 +173,8 @@ github.com/gptscript-ai/cmd v0.0.0-20240625175447-4250b42feb7d h1:sKf7T7twhGXs6A
 github.com/gptscript-ai/cmd v0.0.0-20240625175447-4250b42feb7d/go.mod h1:DJAo1xTht1LDkNYFNydVjTHd576TC7MlpsVRl3oloVw=
 github.com/gptscript-ai/go-gptscript v0.0.0-20240625134437-4b83849794cc h1:ABV7VAK65YBkqL7VlNp5ryVXnRqkKQ+U/NZfUO3ypqA=
 github.com/gptscript-ai/go-gptscript v0.0.0-20240625134437-4b83849794cc/go.mod h1:Dh6vYRAiVcyC3ElZIGzTvNF1FxtYwA07BHfSiFKQY7s=
-github.com/gptscript-ai/tui v0.0.0-20240627001757-8b452fa47eb5 h1:knDhTTJNqaZB1XMudXJuVVnTqj9USrXzNfsl1nTqKXA=
-github.com/gptscript-ai/tui v0.0.0-20240627001757-8b452fa47eb5/go.mod h1:NwFdBDmGQvjLFFDnSRBRakkhw0MIO1sSdRnWNk4cCQ0=
+github.com/gptscript-ai/tui v0.0.0-20240627044440-d416df63c10d h1:hbJ5rkwMDDntqbvHMbsEoP8Nsa5nqTOzF+ktkw3uDQQ=
+github.com/gptscript-ai/tui v0.0.0-20240627044440-d416df63c10d/go.mod h1:NwFdBDmGQvjLFFDnSRBRakkhw0MIO1sSdRnWNk4cCQ0=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=

--- a/pkg/openai/client.go
+++ b/pkg/openai/client.go
@@ -276,6 +276,9 @@ func toMessages(request types.CompletionRequest, compat bool) (result []openai.C
 		}
 
 		if len(chatMessage.MultiContent) == 1 && chatMessage.MultiContent[0].Type == openai.ChatMessagePartTypeText {
+			if !request.Chat && strings.TrimSpace(chatMessage.MultiContent[0].Text) == "{}" {
+				continue
+			}
 			chatMessage.Content = chatMessage.MultiContent[0].Text
 			chatMessage.MultiContent = nil
 

--- a/pkg/system/prompt.go
+++ b/pkg/system/prompt.go
@@ -24,7 +24,7 @@ You don't move to the next step until you have a result.
 
 // DefaultPromptParameter is used as the key in a json map to indication that we really wanted
 // to just send pure text but the interface required JSON (as that is the fundamental interface of tools in OpenAI)
-var DefaultPromptParameter = "prompt"
+var DefaultPromptParameter = "defaultPromptParameter"
 
 var DefaultToolSchema = openapi3.Schema{
 	Type: &openapi3.Types{"object"},

--- a/pkg/tests/runner_test.go
+++ b/pkg/tests/runner_test.go
@@ -322,7 +322,7 @@ func TestSubChat(t *testing.T) {
                 "name": "chatbot",
                 "parameters": {
                   "properties": {
-                    "prompt": {
+                    "defaultPromptParameter": {
                       "description": "Prompt to send to the assistant. This may be an instruction or question.",
                       "type": "string"
                     }
@@ -447,7 +447,7 @@ func TestSubChat(t *testing.T) {
                 "name": "chatbot",
                 "parameters": {
                   "properties": {
-                    "prompt": {
+                    "defaultPromptParameter": {
                       "description": "Prompt to send to the assistant. This may be an instruction or question.",
                       "type": "string"
                     }

--- a/pkg/tests/testdata/TestAgents/call1.golden
+++ b/pkg/tests/testdata/TestAgents/call1.golden
@@ -8,7 +8,7 @@
         "name": "agent1",
         "parameters": {
           "properties": {
-            "prompt": {
+            "defaultPromptParameter": {
               "description": "Prompt to send to the assistant. This may be an instruction or question.",
               "type": "string"
             }
@@ -23,7 +23,7 @@
         "name": "agent2",
         "parameters": {
           "properties": {
-            "prompt": {
+            "defaultPromptParameter": {
               "description": "Prompt to send to the assistant. This may be an instruction or question.",
               "type": "string"
             }

--- a/pkg/tests/testdata/TestAgents/call2.golden
+++ b/pkg/tests/testdata/TestAgents/call2.golden
@@ -8,7 +8,7 @@
         "name": "agent2",
         "parameters": {
           "properties": {
-            "prompt": {
+            "defaultPromptParameter": {
               "description": "Prompt to send to the assistant. This may be an instruction or question.",
               "type": "string"
             }

--- a/pkg/tests/testdata/TestAgents/call3.golden
+++ b/pkg/tests/testdata/TestAgents/call3.golden
@@ -8,7 +8,7 @@
         "name": "agent1",
         "parameters": {
           "properties": {
-            "prompt": {
+            "defaultPromptParameter": {
               "description": "Prompt to send to the assistant. This may be an instruction or question.",
               "type": "string"
             }
@@ -23,7 +23,7 @@
         "name": "agent3",
         "parameters": {
           "properties": {
-            "prompt": {
+            "defaultPromptParameter": {
               "description": "Prompt to send to the assistant. This may be an instruction or question.",
               "type": "string"
             }

--- a/pkg/tests/testdata/TestAgents/step1.golden
+++ b/pkg/tests/testdata/TestAgents/step1.golden
@@ -16,7 +16,7 @@
                 "name": "agent1",
                 "parameters": {
                   "properties": {
-                    "prompt": {
+                    "defaultPromptParameter": {
                       "description": "Prompt to send to the assistant. This may be an instruction or question.",
                       "type": "string"
                     }
@@ -31,7 +31,7 @@
                 "name": "agent2",
                 "parameters": {
                   "properties": {
-                    "prompt": {
+                    "defaultPromptParameter": {
                       "description": "Prompt to send to the assistant. This may be an instruction or question.",
                       "type": "string"
                     }
@@ -111,7 +111,7 @@
                       "name": "agent2",
                       "parameters": {
                         "properties": {
-                          "prompt": {
+                          "defaultPromptParameter": {
                             "description": "Prompt to send to the assistant. This may be an instruction or question.",
                             "type": "string"
                           }
@@ -182,7 +182,7 @@
                             "name": "agent1",
                             "parameters": {
                               "properties": {
-                                "prompt": {
+                                "defaultPromptParameter": {
                                   "description": "Prompt to send to the assistant. This may be an instruction or question.",
                                   "type": "string"
                                 }
@@ -197,7 +197,7 @@
                             "name": "agent3",
                             "parameters": {
                               "properties": {
-                                "prompt": {
+                                "defaultPromptParameter": {
                                   "description": "Prompt to send to the assistant. This may be an instruction or question.",
                                   "type": "string"
                                 }

--- a/pkg/tests/testdata/TestAsterick/call1.golden
+++ b/pkg/tests/testdata/TestAsterick/call1.golden
@@ -7,7 +7,7 @@
         "name": "afoo",
         "parameters": {
           "properties": {
-            "prompt": {
+            "defaultPromptParameter": {
               "description": "Prompt to send to the tool. This may be an instruction or question.",
               "type": "string"
             }
@@ -22,7 +22,7 @@
         "name": "a",
         "parameters": {
           "properties": {
-            "prompt": {
+            "defaultPromptParameter": {
               "description": "Prompt to send to the tool. This may be an instruction or question.",
               "type": "string"
             }

--- a/pkg/tests/testdata/TestContextSubChat/call1.golden
+++ b/pkg/tests/testdata/TestContextSubChat/call1.golden
@@ -7,7 +7,7 @@
         "name": "chatbot",
         "parameters": {
           "properties": {
-            "prompt": {
+            "defaultPromptParameter": {
               "description": "Prompt to send to the assistant. This may be an instruction or question.",
               "type": "string"
             }

--- a/pkg/tests/testdata/TestContextSubChat/call4.golden
+++ b/pkg/tests/testdata/TestContextSubChat/call4.golden
@@ -7,7 +7,7 @@
         "name": "chatbot",
         "parameters": {
           "properties": {
-            "prompt": {
+            "defaultPromptParameter": {
               "description": "Prompt to send to the assistant. This may be an instruction or question.",
               "type": "string"
             }

--- a/pkg/tests/testdata/TestContextSubChat/call6.golden
+++ b/pkg/tests/testdata/TestContextSubChat/call6.golden
@@ -7,7 +7,7 @@
         "name": "chatbot",
         "parameters": {
           "properties": {
-            "prompt": {
+            "defaultPromptParameter": {
               "description": "Prompt to send to the assistant. This may be an instruction or question.",
               "type": "string"
             }

--- a/pkg/tests/testdata/TestContextSubChat/call9.golden
+++ b/pkg/tests/testdata/TestContextSubChat/call9.golden
@@ -7,7 +7,7 @@
         "name": "chatbot",
         "parameters": {
           "properties": {
-            "prompt": {
+            "defaultPromptParameter": {
               "description": "Prompt to send to the assistant. This may be an instruction or question.",
               "type": "string"
             }

--- a/pkg/tests/testdata/TestContextSubChat/step1.golden
+++ b/pkg/tests/testdata/TestContextSubChat/step1.golden
@@ -15,7 +15,7 @@
                   "name": "chatbot",
                   "parameters": {
                     "properties": {
-                      "prompt": {
+                      "defaultPromptParameter": {
                         "description": "Prompt to send to the assistant. This may be an instruction or question.",
                         "type": "string"
                       }

--- a/pkg/tests/testdata/TestContextSubChat/step3.golden
+++ b/pkg/tests/testdata/TestContextSubChat/step3.golden
@@ -57,7 +57,7 @@
                   "name": "chatbot",
                   "parameters": {
                     "properties": {
-                      "prompt": {
+                      "defaultPromptParameter": {
                         "description": "Prompt to send to the assistant. This may be an instruction or question.",
                         "type": "string"
                       }

--- a/pkg/tests/testdata/TestDualSubChat/call1.golden
+++ b/pkg/tests/testdata/TestDualSubChat/call1.golden
@@ -7,7 +7,7 @@
         "name": "chatbot",
         "parameters": {
           "properties": {
-            "prompt": {
+            "defaultPromptParameter": {
               "description": "Prompt to send to the assistant. This may be an instruction or question.",
               "type": "string"
             }
@@ -22,7 +22,7 @@
         "name": "chatbot2",
         "parameters": {
           "properties": {
-            "prompt": {
+            "defaultPromptParameter": {
               "description": "Prompt to send to the assistant. This may be an instruction or question.",
               "type": "string"
             }

--- a/pkg/tests/testdata/TestDualSubChat/call7.golden
+++ b/pkg/tests/testdata/TestDualSubChat/call7.golden
@@ -7,7 +7,7 @@
         "name": "chatbot",
         "parameters": {
           "properties": {
-            "prompt": {
+            "defaultPromptParameter": {
               "description": "Prompt to send to the assistant. This may be an instruction or question.",
               "type": "string"
             }
@@ -22,7 +22,7 @@
         "name": "chatbot2",
         "parameters": {
           "properties": {
-            "prompt": {
+            "defaultPromptParameter": {
               "description": "Prompt to send to the assistant. This may be an instruction or question.",
               "type": "string"
             }

--- a/pkg/tests/testdata/TestDualSubChat/step1.golden
+++ b/pkg/tests/testdata/TestDualSubChat/step1.golden
@@ -15,7 +15,7 @@
                 "name": "chatbot",
                 "parameters": {
                   "properties": {
-                    "prompt": {
+                    "defaultPromptParameter": {
                       "description": "Prompt to send to the assistant. This may be an instruction or question.",
                       "type": "string"
                     }
@@ -30,7 +30,7 @@
                 "name": "chatbot2",
                 "parameters": {
                   "properties": {
-                    "prompt": {
+                    "defaultPromptParameter": {
                       "description": "Prompt to send to the assistant. This may be an instruction or question.",
                       "type": "string"
                     }

--- a/pkg/tests/testdata/TestDualSubChat/step2.golden
+++ b/pkg/tests/testdata/TestDualSubChat/step2.golden
@@ -15,7 +15,7 @@
                 "name": "chatbot",
                 "parameters": {
                   "properties": {
-                    "prompt": {
+                    "defaultPromptParameter": {
                       "description": "Prompt to send to the assistant. This may be an instruction or question.",
                       "type": "string"
                     }
@@ -30,7 +30,7 @@
                 "name": "chatbot2",
                 "parameters": {
                   "properties": {
-                    "prompt": {
+                    "defaultPromptParameter": {
                       "description": "Prompt to send to the assistant. This may be an instruction or question.",
                       "type": "string"
                     }

--- a/pkg/tests/testdata/TestDualSubChat/step3.golden
+++ b/pkg/tests/testdata/TestDualSubChat/step3.golden
@@ -15,7 +15,7 @@
                 "name": "chatbot",
                 "parameters": {
                   "properties": {
-                    "prompt": {
+                    "defaultPromptParameter": {
                       "description": "Prompt to send to the assistant. This may be an instruction or question.",
                       "type": "string"
                     }
@@ -30,7 +30,7 @@
                 "name": "chatbot2",
                 "parameters": {
                   "properties": {
-                    "prompt": {
+                    "defaultPromptParameter": {
                       "description": "Prompt to send to the assistant. This may be an instruction or question.",
                       "type": "string"
                     }

--- a/pkg/tests/testdata/TestExport/call1.golden
+++ b/pkg/tests/testdata/TestExport/call1.golden
@@ -7,7 +7,7 @@
         "name": "frommain",
         "parameters": {
           "properties": {
-            "prompt": {
+            "defaultPromptParameter": {
               "description": "Prompt to send to the tool. This may be an instruction or question.",
               "type": "string"
             }
@@ -22,7 +22,7 @@
         "name": "parentLocal",
         "parameters": {
           "properties": {
-            "prompt": {
+            "defaultPromptParameter": {
               "description": "Prompt to send to the tool. This may be an instruction or question.",
               "type": "string"
             }
@@ -37,7 +37,7 @@
         "name": "transient",
         "parameters": {
           "properties": {
-            "prompt": {
+            "defaultPromptParameter": {
               "description": "Prompt to send to the tool. This may be an instruction or question.",
               "type": "string"
             }

--- a/pkg/tests/testdata/TestExport/call3.golden
+++ b/pkg/tests/testdata/TestExport/call3.golden
@@ -7,7 +7,7 @@
         "name": "frommain",
         "parameters": {
           "properties": {
-            "prompt": {
+            "defaultPromptParameter": {
               "description": "Prompt to send to the tool. This may be an instruction or question.",
               "type": "string"
             }
@@ -22,7 +22,7 @@
         "name": "parentLocal",
         "parameters": {
           "properties": {
-            "prompt": {
+            "defaultPromptParameter": {
               "description": "Prompt to send to the tool. This may be an instruction or question.",
               "type": "string"
             }
@@ -37,7 +37,7 @@
         "name": "transient",
         "parameters": {
           "properties": {
-            "prompt": {
+            "defaultPromptParameter": {
               "description": "Prompt to send to the tool. This may be an instruction or question.",
               "type": "string"
             }

--- a/pkg/tests/testdata/TestExportContext/call1.golden
+++ b/pkg/tests/testdata/TestExportContext/call1.golden
@@ -7,7 +7,7 @@
         "name": "subtool",
         "parameters": {
           "properties": {
-            "prompt": {
+            "defaultPromptParameter": {
               "description": "Prompt to send to the tool. This may be an instruction or question.",
               "type": "string"
             }

--- a/pkg/tests/testdata/TestSubChat/call1.golden
+++ b/pkg/tests/testdata/TestSubChat/call1.golden
@@ -7,7 +7,7 @@
         "name": "chatbot",
         "parameters": {
           "properties": {
-            "prompt": {
+            "defaultPromptParameter": {
               "description": "Prompt to send to the assistant. This may be an instruction or question.",
               "type": "string"
             }

--- a/pkg/tests/testdata/TestSysContext/call1.golden
+++ b/pkg/tests/testdata/TestSysContext/call1.golden
@@ -8,7 +8,7 @@
         "name": "iAmSuperman",
         "parameters": {
           "properties": {
-            "prompt": {
+            "defaultPromptParameter": {
               "description": "Prompt to send to the tool. This may be an instruction or question.",
               "type": "string"
             }

--- a/pkg/tests/testdata/TestSysContext/step1.golden
+++ b/pkg/tests/testdata/TestSysContext/step1.golden
@@ -16,7 +16,7 @@
                 "name": "iAmSuperman",
                 "parameters": {
                   "properties": {
-                    "prompt": {
+                    "defaultPromptParameter": {
                       "description": "Prompt to send to the tool. This may be an instruction or question.",
                       "type": "string"
                     }

--- a/pkg/tests/testdata/TestToolAs/call1.golden
+++ b/pkg/tests/testdata/TestToolAs/call1.golden
@@ -7,7 +7,7 @@
         "name": "local",
         "parameters": {
           "properties": {
-            "prompt": {
+            "defaultPromptParameter": {
               "description": "Prompt to send to the tool. This may be an instruction or question.",
               "type": "string"
             }
@@ -22,7 +22,7 @@
         "name": "remote",
         "parameters": {
           "properties": {
-            "prompt": {
+            "defaultPromptParameter": {
               "description": "Prompt to send to the tool. This may be an instruction or question.",
               "type": "string"
             }


### PR DESCRIPTION
This is probably the wrong thing to do. We need to differientiate
between empty args and no args. If a tool has no params defined
then {} should be dropped. Right now this logic is in the wrong spot
to do that so we just go back to the old behavior of just always dropping
{} which will cause a problem for tools that would expect an empty object.
