### PR TITLE
fix: only check cred helper repo once per 24h

### DIFF
--- a/pkg/credentials/util.go
+++ b/pkg/credentials/util.go
@@ -5,13 +5,14 @@ import (
 )
 
 type CredentialHelperDirs struct {
-	RevisionFile, BinDir, RepoDir string
+	RevisionFile, LastCheckedFile, BinDir, RepoDir string
 }
 
 func GetCredentialHelperDirs(cacheDir string) CredentialHelperDirs {
 	return CredentialHelperDirs{
-		RevisionFile: filepath.Join(cacheDir, "repos", "gptscript-credential-helpers", "revision"),
-		BinDir:       filepath.Join(cacheDir, "repos", "gptscript-credential-helpers", "bin"),
-		RepoDir:      filepath.Join(cacheDir, "repos", "gptscript-credential-helpers", "repo"),
+		RevisionFile:    filepath.Join(cacheDir, "repos", "gptscript-credential-helpers", "revision"),
+		LastCheckedFile: filepath.Join(cacheDir, "repos", "gptscript-credential-helpers", "last-checked"),
+		BinDir:          filepath.Join(cacheDir, "repos", "gptscript-credential-helpers", "bin"),
+		RepoDir:         filepath.Join(cacheDir, "repos", "gptscript-credential-helpers", "repo"),
 	}
 }

--- a/pkg/repos/get.go
+++ b/pkg/repos/get.go
@@ -119,7 +119,7 @@ func (m *Manager) deferredSetUpCredentialHelpers(ctx context.Context, cliCfg *co
 		if t, err := time.Parse(time.RFC3339, strings.TrimSpace(string(lastChecked))); err == nil && time.Since(t) < 24*time.Hour {
 			// Make sure the binary still exists, and if it does, return.
 			if _, err := os.Stat(filepath.Join(m.credHelperDirs.BinDir, "gptscript-credential-"+helperName+suffix)); err == nil {
-				log.Debugf("Not checking for new version of credential helper %s, last checked %v", helperName, t)
+				log.Debugf("Credential helper %s up-to-date as of %v, checking for updates after %v", helperName, t, lastChecked.Add(24*time.Hour))
 				return nil
 			}
 		}


### PR DESCRIPTION
We used to check the GH repo information for the credential helpers repo every time a cred store operation (get, list, etc.) was called. This is way too many lookups and hits the rate limit. This PR adds a file to hold a timestamp for the last time the repo was checked, and only check again if at least 24 hours have passed.