### PR TITLE
fix: use GH token for VCS lookups

### DIFF
--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -139,7 +139,7 @@ jobs:
           go-version: "1.21"
       - env:
           OPENAI_API_KEY: ${{ secrets.SMOKE_OPENAI_API_KEY }}
-          GPTSCRIPT_DEFAULT_MODEL: claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider@main
+          GPTSCRIPT_DEFAULT_MODEL: claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider
           ANTHROPIC_API_KEY: ${{ secrets.SMOKE_ANTHROPIC_API_KEY }}
           GPTSCRIPT_CREDENTIAL_OVERRIDE: "github.com/gptscript-ai/claude3-anthropic-provider/credential:ANTHROPIC_API_KEY"
         name: Run smoke test for claude-3-opus-20240229

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -139,7 +139,7 @@ jobs:
           go-version: "1.21"
       - env:
           OPENAI_API_KEY: ${{ secrets.SMOKE_OPENAI_API_KEY }}
-          GPTSCRIPT_DEFAULT_MODEL: claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider@tool-beta
+          GPTSCRIPT_DEFAULT_MODEL: claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider
           ANTHROPIC_API_KEY: ${{ secrets.SMOKE_ANTHROPIC_API_KEY }}
         name: Run smoke test for claude-3-opus-20240229
         run: |

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -139,7 +139,7 @@ jobs:
           go-version: "1.21"
       - env:
           OPENAI_API_KEY: ${{ secrets.SMOKE_OPENAI_API_KEY }}
-          GPTSCRIPT_DEFAULT_MODEL: claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider
+          GPTSCRIPT_DEFAULT_MODEL: claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider@main
           ANTHROPIC_API_KEY: ${{ secrets.SMOKE_ANTHROPIC_API_KEY }}
           GPTSCRIPT_CREDENTIAL_OVERRIDE: "github.com/gptscript-ai/claude3-anthropic-provider/credential:ANTHROPIC_API_KEY"
         name: Run smoke test for claude-3-opus-20240229

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -141,6 +141,7 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.SMOKE_OPENAI_API_KEY }}
           GPTSCRIPT_DEFAULT_MODEL: claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider
           ANTHROPIC_API_KEY: ${{ secrets.SMOKE_ANTHROPIC_API_KEY }}
+          GPTSCRIPT_CREDENTIAL_OVERRIDE: "github.com/gptscript-ai/claude3-anthropic-provider/credential:ANTHROPIC_API_KEY"
         name: Run smoke test for claude-3-opus-20240229
         run: |
           echo "Running smoke test for model claude-3-opus-20240229"

--- a/pkg/loader/github/github.go
+++ b/pkg/loader/github/github.go
@@ -88,9 +88,9 @@ func getCommit(ctx context.Context, account, repo, ref string) (string, error) {
 	return commit.SHA, nil
 }
 
-func Load(ctx context.Context, _ *cache.Client, urlName string) (string, *types.Repo, bool, error) {
+func Load(ctx context.Context, _ *cache.Client, urlName string) (string, string, *types.Repo, bool, error) {
 	if !strings.HasPrefix(urlName, GithubPrefix) {
-		return "", nil, false, nil
+		return "", "", nil, false, nil
 	}
 
 	url, ref, _ := strings.Cut(urlName, "@")
@@ -101,7 +101,7 @@ func Load(ctx context.Context, _ *cache.Client, urlName string) (string, *types.
 	parts := strings.Split(url, "/")
 	// Must be at least 3 parts github.com/ACCOUNT/REPO[/FILE]
 	if len(parts) < 3 {
-		return "", nil, false, nil
+		return "", "", nil, false, nil
 	}
 
 	account, repo := parts[1], parts[2]
@@ -109,7 +109,7 @@ func Load(ctx context.Context, _ *cache.Client, urlName string) (string, *types.
 
 	ref, err := getCommit(ctx, account, repo, ref)
 	if err != nil {
-		return "", nil, false, err
+		return "", "", nil, false, err
 	}
 
 	downloadURL := fmt.Sprintf(githubDownloadURL, account, repo, ref, path)
@@ -141,7 +141,7 @@ func Load(ctx context.Context, _ *cache.Client, urlName string) (string, *types.
 		path = testPath
 	}
 
-	return downloadURL, &types.Repo{
+	return downloadURL, githubAuthToken, &types.Repo{
 		VCS:      "git",
 		Root:     fmt.Sprintf(githubRepoURL, account, repo),
 		Path:     gpath.Dir(path),

--- a/pkg/loader/github/github_test.go
+++ b/pkg/loader/github/github_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestLoad(t *testing.T) {
-	url, repo, ok, err := Load(context.Background(), nil, "github.com/gptscript-ai/gptscript/pkg/loader/testdata/tool@172dfb0")
+	url, _, repo, ok, err := Load(context.Background(), nil, "github.com/gptscript-ai/gptscript/pkg/loader/testdata/tool@172dfb0")
 	require.NoError(t, err)
 	assert.True(t, ok)
 	autogold.Expect("https://raw.githubusercontent.com/gptscript-ai/gptscript/172dfb00b48c6adbbaa7e99270933f95887d1b91/pkg/loader/testdata/tool/tool.gpt").Equal(t, url)
@@ -22,7 +22,7 @@ func TestLoad(t *testing.T) {
 		Revision: "172dfb00b48c6adbbaa7e99270933f95887d1b91",
 	}).Equal(t, repo)
 
-	url, repo, ok, err = Load(context.Background(), nil, "github.com/gptscript-ai/gptscript/pkg/loader/testdata/agent@172dfb0")
+	url, _, repo, ok, err = Load(context.Background(), nil, "github.com/gptscript-ai/gptscript/pkg/loader/testdata/agent@172dfb0")
 	require.NoError(t, err)
 	assert.True(t, ok)
 	autogold.Expect("https://raw.githubusercontent.com/gptscript-ai/gptscript/172dfb00b48c6adbbaa7e99270933f95887d1b91/pkg/loader/testdata/agent/agent.gpt").Equal(t, url)
@@ -33,7 +33,7 @@ func TestLoad(t *testing.T) {
 		Revision: "172dfb00b48c6adbbaa7e99270933f95887d1b91",
 	}).Equal(t, repo)
 
-	url, repo, ok, err = Load(context.Background(), nil, "github.com/gptscript-ai/gptscript/pkg/loader/testdata/bothtoolagent@172dfb0")
+	url, _, repo, ok, err = Load(context.Background(), nil, "github.com/gptscript-ai/gptscript/pkg/loader/testdata/bothtoolagent@172dfb0")
 	require.NoError(t, err)
 	assert.True(t, ok)
 	autogold.Expect("https://raw.githubusercontent.com/gptscript-ai/gptscript/172dfb00b48c6adbbaa7e99270933f95887d1b91/pkg/loader/testdata/bothtoolagent/agent.gpt").Equal(t, url)

--- a/pkg/loader/url.go
+++ b/pkg/loader/url.go
@@ -14,7 +14,7 @@ import (
 	"github.com/gptscript-ai/gptscript/pkg/types"
 )
 
-type VCSLookup func(context.Context, *cache.Client, string) (string, *types.Repo, bool, error)
+type VCSLookup func(context.Context, *cache.Client, string) (string, string, *types.Repo, bool, error)
 
 var vcsLookups []VCSLookup
 
@@ -35,10 +35,11 @@ type cacheValue struct {
 
 func loadURL(ctx context.Context, cache *cache.Client, base *source, name string) (*source, bool, error) {
 	var (
-		repo      *types.Repo
-		url       = name
-		relative  = strings.HasPrefix(name, ".") || !strings.Contains(name, "/")
-		cachedKey = cacheKey{
+		repo        *types.Repo
+		url         = name
+		bearerToken = ""
+		relative    = strings.HasPrefix(name, ".") || !strings.Contains(name, "/")
+		cachedKey   = cacheKey{
 			Name: name,
 			Path: base.Path,
 			Repo: base.Repo,
@@ -67,12 +68,13 @@ func loadURL(ctx context.Context, cache *cache.Client, base *source, name string
 
 	if repo == nil || !relative {
 		for _, vcs := range vcsLookups {
-			newURL, newRepo, ok, err := vcs(ctx, cache, name)
+			newURL, newBearer, newRepo, ok, err := vcs(ctx, cache, name)
 			if err != nil {
 				return nil, false, err
 			} else if ok {
 				repo = newRepo
 				url = newURL
+				bearerToken = newBearer
 				break
 			}
 		}
@@ -103,6 +105,10 @@ func loadURL(ctx context.Context, cache *cache.Client, base *source, name string
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, false, err
+	}
+
+	if bearerToken != "" {
+		req.Header.Set("Authorization", "Bearer "+bearerToken)
 	}
 
 	data, err := getWithDefaults(req)

--- a/pkg/repos/get.go
+++ b/pkg/repos/get.go
@@ -127,7 +127,7 @@ func (m *Manager) deferredSetUpCredentialHelpers(ctx context.Context, cliCfg *co
 	}
 
 	// Load the credential helpers repo information.
-	_, repo, _, err := github.Load(ctx, nil, credentialHelpersRepo)
+	_, _, repo, _, err := github.Load(ctx, nil, credentialHelpersRepo)
 	if err != nil {
 		return err
 	}

--- a/pkg/tests/smoke/testdata/Bob/claude-3-opus-20240229-expected.json
+++ b/pkg/tests/smoke/testdata/Bob/claude-3-opus-20240229-expected.json
@@ -1,15 +1,15 @@
 [
     {
-        "time": "2024-06-20T17:10:23.193337-04:00",
+        "time": "2024-06-28T10:48:16.036954-04:00",
         "type": "runStart",
         "usage": {}
     },
     {
-        "time": "2024-06-20T17:10:23.19359-04:00",
+        "time": "2024-06-28T10:48:16.037294-04:00",
         "callContext": {
-            "id": "1718917824",
+            "id": "1719586097",
             "tool": {
-                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider@tool-beta",
+                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
@@ -34,55 +34,57 @@
                 },
                 "workingDir": "testdata/Bob"
             },
+            "currentAgent": {},
             "inputContext": null
         },
         "type": "callStart",
         "usage": {}
     },
     {
-        "time": "2024-06-20T17:10:24.059514-04:00",
+        "time": "2024-06-28T10:48:17.325263-04:00",
         "type": "runStart",
         "usage": {}
     },
     {
-        "time": "2024-06-20T17:10:24.059807-04:00",
+        "time": "2024-06-28T10:48:17.325584-04:00",
         "callContext": {
-            "id": "1718917825",
+            "id": "1719586098",
             "tool": {
                 "name": "Anthropic Claude3 Model Provider",
                 "description": "Model provider for Anthropic hosted Claude3 models",
-                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider@tool-beta",
+                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "modelProvider": true,
                 "internalPrompt": null,
                 "credentials": [
-                    "github.com/gptscript-ai/claude3-anthropic-provider/credential"
+                    "github.com/gptscript-ai/credential as github.com/gptscript-ai/claude3-anthropic-provider/credential with \"Please enter your Anthropic API Key\" as message and token as field and \"ANTHROPIC_API_KEY\" as env"
                 ],
                 "instructions": "#!sys.daemon /usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/main.py",
-                "id": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/d47b232371d18e0254cf7cc5e15a813e7e24a8ad/tool.gpt:Anthropic Claude3 Model Provider",
+                "id": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/dfd21adc6be9fbda34b79a71e661ac0cfb725548/tool.gpt:Anthropic Claude3 Model Provider",
                 "toolMapping": {
-                    "github.com/gptscript-ai/claude3-anthropic-provider/credential": [
+                    "github.com/gptscript-ai/credential as github.com/gptscript-ai/claude3-anthropic-provider/credential with \"Please enter your Anthropic API Key\" as message and token as field and \"ANTHROPIC_API_KEY\" as env": [
                         {
-                            "reference": "github.com/gptscript-ai/claude3-anthropic-provider/credential",
-                            "toolID": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/3b9b9365d469c4c702291f1764537ab5c226c2e0/credential/tool.gpt:claude3-anthropic-credential"
+                            "reference": "github.com/gptscript-ai/credential as github.com/gptscript-ai/claude3-anthropic-provider/credential with \"Please enter your Anthropic API Key\" as message and token as field and \"ANTHROPIC_API_KEY\" as env",
+                            "toolID": "https://raw.githubusercontent.com/gptscript-ai/credential/651dfad6e7cf3a385ef408afa93ce522c10f8508/tool.gpt:token"
                         }
                     ]
                 },
                 "localTools": {
-                    "anthropic claude3 model provider": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/d47b232371d18e0254cf7cc5e15a813e7e24a8ad/tool.gpt:Anthropic Claude3 Model Provider"
+                    "anthropic claude3 model provider": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/dfd21adc6be9fbda34b79a71e661ac0cfb725548/tool.gpt:Anthropic Claude3 Model Provider"
                 },
                 "source": {
-                    "location": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/d47b232371d18e0254cf7cc5e15a813e7e24a8ad/tool.gpt",
+                    "location": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/dfd21adc6be9fbda34b79a71e661ac0cfb725548/tool.gpt",
                     "lineNo": 1,
                     "repo": {
                         "VCS": "git",
                         "Root": "https://github.com/gptscript-ai/claude3-anthropic-provider.git",
                         "Path": "/",
                         "Name": "tool.gpt",
-                        "Revision": "d47b232371d18e0254cf7cc5e15a813e7e24a8ad"
+                        "Revision": "dfd21adc6be9fbda34b79a71e661ac0cfb725548"
                     }
                 },
-                "workingDir": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/d47b232371d18e0254cf7cc5e15a813e7e24a8ad"
+                "workingDir": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/dfd21adc6be9fbda34b79a71e661ac0cfb725548"
             },
+            "currentAgent": {},
             "inputContext": null,
             "toolCategory": "provider",
             "displayText": "Running sys.daemon"
@@ -91,63 +93,64 @@
         "usage": {}
     },
     {
-        "time": "2024-06-20T17:10:25.074481-04:00",
+        "time": "2024-06-28T10:48:18.342475-04:00",
         "callContext": {
-            "id": "1718917825",
+            "id": "1719586098",
             "tool": {
                 "name": "Anthropic Claude3 Model Provider",
                 "description": "Model provider for Anthropic hosted Claude3 models",
-                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider@tool-beta",
+                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "modelProvider": true,
                 "internalPrompt": null,
                 "credentials": [
-                    "github.com/gptscript-ai/claude3-anthropic-provider/credential"
+                    "github.com/gptscript-ai/credential as github.com/gptscript-ai/claude3-anthropic-provider/credential with \"Please enter your Anthropic API Key\" as message and token as field and \"ANTHROPIC_API_KEY\" as env"
                 ],
                 "instructions": "#!sys.daemon /usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/main.py",
-                "id": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/d47b232371d18e0254cf7cc5e15a813e7e24a8ad/tool.gpt:Anthropic Claude3 Model Provider",
+                "id": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/dfd21adc6be9fbda34b79a71e661ac0cfb725548/tool.gpt:Anthropic Claude3 Model Provider",
                 "toolMapping": {
-                    "github.com/gptscript-ai/claude3-anthropic-provider/credential": [
+                    "github.com/gptscript-ai/credential as github.com/gptscript-ai/claude3-anthropic-provider/credential with \"Please enter your Anthropic API Key\" as message and token as field and \"ANTHROPIC_API_KEY\" as env": [
                         {
-                            "reference": "github.com/gptscript-ai/claude3-anthropic-provider/credential",
-                            "toolID": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/3b9b9365d469c4c702291f1764537ab5c226c2e0/credential/tool.gpt:claude3-anthropic-credential"
+                            "reference": "github.com/gptscript-ai/credential as github.com/gptscript-ai/claude3-anthropic-provider/credential with \"Please enter your Anthropic API Key\" as message and token as field and \"ANTHROPIC_API_KEY\" as env",
+                            "toolID": "https://raw.githubusercontent.com/gptscript-ai/credential/651dfad6e7cf3a385ef408afa93ce522c10f8508/tool.gpt:token"
                         }
                     ]
                 },
                 "localTools": {
-                    "anthropic claude3 model provider": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/d47b232371d18e0254cf7cc5e15a813e7e24a8ad/tool.gpt:Anthropic Claude3 Model Provider"
+                    "anthropic claude3 model provider": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/dfd21adc6be9fbda34b79a71e661ac0cfb725548/tool.gpt:Anthropic Claude3 Model Provider"
                 },
                 "source": {
-                    "location": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/d47b232371d18e0254cf7cc5e15a813e7e24a8ad/tool.gpt",
+                    "location": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/dfd21adc6be9fbda34b79a71e661ac0cfb725548/tool.gpt",
                     "lineNo": 1,
                     "repo": {
                         "VCS": "git",
                         "Root": "https://github.com/gptscript-ai/claude3-anthropic-provider.git",
                         "Path": "/",
                         "Name": "tool.gpt",
-                        "Revision": "d47b232371d18e0254cf7cc5e15a813e7e24a8ad"
+                        "Revision": "dfd21adc6be9fbda34b79a71e661ac0cfb725548"
                     }
                 },
-                "workingDir": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/d47b232371d18e0254cf7cc5e15a813e7e24a8ad"
+                "workingDir": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/dfd21adc6be9fbda34b79a71e661ac0cfb725548"
             },
+            "currentAgent": {},
             "inputContext": null,
             "toolCategory": "provider",
             "displayText": "Running sys.daemon"
         },
         "type": "callFinish",
         "usage": {},
-        "content": "http://127.0.0.1:11060"
+        "content": "http://127.0.0.1:10961"
     },
     {
-        "time": "2024-06-20T17:10:25.074606-04:00",
+        "time": "2024-06-28T10:48:18.342649-04:00",
         "type": "runFinish",
         "usage": {}
     },
     {
-        "time": "2024-06-20T17:10:25.074685-04:00",
+        "time": "2024-06-28T10:48:18.342718-04:00",
         "callContext": {
-            "id": "1718917824",
+            "id": "1719586097",
             "tool": {
-                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider@tool-beta",
+                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
@@ -172,10 +175,11 @@
                 },
                 "workingDir": "testdata/Bob"
             },
+            "currentAgent": {},
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1718917826",
+        "chatCompletionId": "1719586099",
         "usage": {},
         "chatRequest": {
             "model": "claude-3-opus-20240229",
@@ -207,11 +211,11 @@
         }
     },
     {
-        "time": "2024-06-20T17:10:25.075088-04:00",
+        "time": "2024-06-28T10:48:18.343115-04:00",
         "callContext": {
-            "id": "1718917824",
+            "id": "1719586097",
             "tool": {
-                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider@tool-beta",
+                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
@@ -236,19 +240,20 @@
                 },
                 "workingDir": "testdata/Bob"
             },
+            "currentAgent": {},
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1718917826",
+        "chatCompletionId": "1719586099",
         "usage": {},
         "content": "Waiting for model response..."
     },
     {
-        "time": "2024-06-20T17:10:33.389627-04:00",
+        "time": "2024-06-28T10:48:21.291497-04:00",
         "callContext": {
-            "id": "1718917824",
+            "id": "1719586097",
             "tool": {
-                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider@tool-beta",
+                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
@@ -273,19 +278,20 @@
                 },
                 "workingDir": "testdata/Bob"
             },
+            "currentAgent": {},
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1718917826",
+        "chatCompletionId": "1719586099",
         "usage": {},
         "content": "\u003ctool call\u003e bob -\u003e {\"question\": \"how are you doing\"}"
     },
     {
-        "time": "2024-06-20T17:10:33.389848-04:00",
+        "time": "2024-06-28T10:48:21.291864-04:00",
         "callContext": {
-            "id": "1718917824",
+            "id": "1719586097",
             "tool": {
-                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider@tool-beta",
+                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
@@ -310,10 +316,11 @@
                 },
                 "workingDir": "testdata/Bob"
             },
+            "currentAgent": {},
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1718917826",
+        "chatCompletionId": "1719586099",
         "usage": {},
         "chatResponse": {
             "role": "assistant",
@@ -321,7 +328,7 @@
                 {
                     "toolCall": {
                         "index": 0,
-                        "id": "toolu_01EEcv7qDLHDmGAzm15vobxM",
+                        "id": "bob",
                         "function": {
                             "name": "bob",
                             "arguments": "{\"question\": \"how are you doing\"}"
@@ -333,11 +340,11 @@
         }
     },
     {
-        "time": "2024-06-20T17:10:33.389967-04:00",
+        "time": "2024-06-28T10:48:21.291966-04:00",
         "callContext": {
-            "id": "1718917824",
+            "id": "1719586097",
             "tool": {
-                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider@tool-beta",
+                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
@@ -362,10 +369,11 @@
                 },
                 "workingDir": "testdata/Bob"
             },
+            "currentAgent": {},
             "inputContext": null
         },
         "toolSubCalls": {
-            "toolu_01EEcv7qDLHDmGAzm15vobxM": {
+            "bob": {
                 "toolID": "testdata/Bob/test.gpt:bob",
                 "input": "{\"question\": \"how are you doing\"}"
             }
@@ -374,13 +382,13 @@
         "usage": {}
     },
     {
-        "time": "2024-06-20T17:10:33.389997-04:00",
+        "time": "2024-06-28T10:48:21.291997-04:00",
         "callContext": {
-            "id": "toolu_01EEcv7qDLHDmGAzm15vobxM",
+            "id": "bob",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
-                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider@tool-beta",
+                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -403,22 +411,23 @@
                 },
                 "workingDir": "testdata/Bob"
             },
+            "currentAgent": {},
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1718917824"
+            "parentID": "1719586097"
         },
         "type": "callStart",
         "usage": {},
         "content": "{\"question\": \"how are you doing\"}"
     },
     {
-        "time": "2024-06-20T17:10:33.584228-04:00",
+        "time": "2024-06-28T10:48:21.50264-04:00",
         "callContext": {
-            "id": "toolu_01EEcv7qDLHDmGAzm15vobxM",
+            "id": "bob",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
-                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider@tool-beta",
+                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -441,12 +450,13 @@
                 },
                 "workingDir": "testdata/Bob"
             },
+            "currentAgent": {},
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1718917824"
+            "parentID": "1719586097"
         },
         "type": "callChat",
-        "chatCompletionId": "1718917827",
+        "chatCompletionId": "1719586100",
         "usage": {},
         "chatRequest": {
             "model": "claude-3-opus-20240229",
@@ -464,13 +474,13 @@
         }
     },
     {
-        "time": "2024-06-20T17:10:33.584507-04:00",
+        "time": "2024-06-28T10:48:21.503008-04:00",
         "callContext": {
-            "id": "toolu_01EEcv7qDLHDmGAzm15vobxM",
+            "id": "bob",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
-                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider@tool-beta",
+                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -493,23 +503,24 @@
                 },
                 "workingDir": "testdata/Bob"
             },
+            "currentAgent": {},
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1718917824"
+            "parentID": "1719586097"
         },
         "type": "callProgress",
-        "chatCompletionId": "1718917827",
+        "chatCompletionId": "1719586100",
         "usage": {},
         "content": "Waiting for model response..."
     },
     {
-        "time": "2024-06-20T17:10:35.540664-04:00",
+        "time": "2024-06-28T10:48:22.875617-04:00",
         "callContext": {
-            "id": "toolu_01EEcv7qDLHDmGAzm15vobxM",
+            "id": "bob",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
-                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider@tool-beta",
+                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -532,23 +543,24 @@
                 },
                 "workingDir": "testdata/Bob"
             },
+            "currentAgent": {},
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1718917824"
+            "parentID": "1719586097"
         },
         "type": "callProgress",
-        "chatCompletionId": "1718917827",
+        "chatCompletionId": "1719586100",
         "usage": {},
         "content": "Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI tool!"
     },
     {
-        "time": "2024-06-20T17:10:35.540967-04:00",
+        "time": "2024-06-28T10:48:22.875964-04:00",
         "callContext": {
-            "id": "toolu_01EEcv7qDLHDmGAzm15vobxM",
+            "id": "bob",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
-                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider@tool-beta",
+                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -571,12 +583,13 @@
                 },
                 "workingDir": "testdata/Bob"
             },
+            "currentAgent": {},
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1718917824"
+            "parentID": "1719586097"
         },
         "type": "callChat",
-        "chatCompletionId": "1718917827",
+        "chatCompletionId": "1719586100",
         "usage": {},
         "chatResponse": {
             "role": "assistant",
@@ -589,13 +602,13 @@
         }
     },
     {
-        "time": "2024-06-20T17:10:35.541005-04:00",
+        "time": "2024-06-28T10:48:22.876034-04:00",
         "callContext": {
-            "id": "toolu_01EEcv7qDLHDmGAzm15vobxM",
+            "id": "bob",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
-                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider@tool-beta",
+                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -618,20 +631,21 @@
                 },
                 "workingDir": "testdata/Bob"
             },
+            "currentAgent": {},
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1718917824"
+            "parentID": "1719586097"
         },
         "type": "callFinish",
         "usage": {},
         "content": "Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI tool!"
     },
     {
-        "time": "2024-06-20T17:10:35.541033-04:00",
+        "time": "2024-06-28T10:48:22.876064-04:00",
         "callContext": {
-            "id": "1718917824",
+            "id": "1719586097",
             "tool": {
-                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider@tool-beta",
+                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
@@ -656,6 +670,7 @@
                 },
                 "workingDir": "testdata/Bob"
             },
+            "currentAgent": {},
             "inputContext": null
         },
         "toolResults": 1,
@@ -663,11 +678,11 @@
         "usage": {}
     },
     {
-        "time": "2024-06-20T17:10:35.71784-04:00",
+        "time": "2024-06-28T10:48:23.086894-04:00",
         "callContext": {
-            "id": "1718917824",
+            "id": "1719586097",
             "tool": {
-                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider@tool-beta",
+                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
@@ -692,10 +707,11 @@
                 },
                 "workingDir": "testdata/Bob"
             },
+            "currentAgent": {},
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1718917828",
+        "chatCompletionId": "1719586101",
         "usage": {},
         "chatRequest": {
             "model": "claude-3-opus-20240229",
@@ -709,7 +725,7 @@
                     "content": "",
                     "tool_calls": [
                         {
-                            "id": "toolu_01EEcv7qDLHDmGAzm15vobxM",
+                            "id": "bob",
                             "type": "function",
                             "function": {
                                 "name": "bob",
@@ -722,7 +738,7 @@
                     "role": "tool",
                     "content": "Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI tool!",
                     "name": "bob",
-                    "tool_call_id": "toolu_01EEcv7qDLHDmGAzm15vobxM"
+                    "tool_call_id": "bob"
                 }
             ],
             "temperature": 0,
@@ -747,11 +763,11 @@
         }
     },
     {
-        "time": "2024-06-20T17:10:35.718216-04:00",
+        "time": "2024-06-28T10:48:23.087303-04:00",
         "callContext": {
-            "id": "1718917824",
+            "id": "1719586097",
             "tool": {
-                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider@tool-beta",
+                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
@@ -776,19 +792,20 @@
                 },
                 "workingDir": "testdata/Bob"
             },
+            "currentAgent": {},
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1718917828",
+        "chatCompletionId": "1719586101",
         "usage": {},
         "content": "Waiting for model response..."
     },
     {
-        "time": "2024-06-20T17:10:39.50448-04:00",
+        "time": "2024-06-28T10:48:25.243408-04:00",
         "callContext": {
-            "id": "1718917824",
+            "id": "1719586097",
             "tool": {
-                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider@tool-beta",
+                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
@@ -813,19 +830,20 @@
                 },
                 "workingDir": "testdata/Bob"
             },
+            "currentAgent": {},
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1718917828",
+        "chatCompletionId": "1719586101",
         "usage": {},
-        "content": "Bob replied: \"Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI tool!\""
+        "content": "Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI tool!"
     },
     {
-        "time": "2024-06-20T17:10:39.504769-04:00",
+        "time": "2024-06-28T10:48:25.243765-04:00",
         "callContext": {
-            "id": "1718917824",
+            "id": "1719586097",
             "tool": {
-                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider@tool-beta",
+                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
@@ -850,27 +868,28 @@
                 },
                 "workingDir": "testdata/Bob"
             },
+            "currentAgent": {},
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1718917828",
+        "chatCompletionId": "1719586101",
         "usage": {},
         "chatResponse": {
             "role": "assistant",
             "content": [
                 {
-                    "text": "Bob replied: \"Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI tool!\""
+                    "text": "Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI tool!"
                 }
             ],
             "usage": {}
         }
     },
     {
-        "time": "2024-06-20T17:10:39.504807-04:00",
+        "time": "2024-06-28T10:48:25.243793-04:00",
         "callContext": {
-            "id": "1718917824",
+            "id": "1719586097",
             "tool": {
-                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider@tool-beta",
+                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
@@ -895,14 +914,15 @@
                 },
                 "workingDir": "testdata/Bob"
             },
+            "currentAgent": {},
             "inputContext": null
         },
         "type": "callFinish",
         "usage": {},
-        "content": "Bob replied: \"Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI tool!\""
+        "content": "Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI tool!"
     },
     {
-        "time": "2024-06-20T17:10:39.504821-04:00",
+        "time": "2024-06-28T10:48:25.243836-04:00",
         "type": "runFinish",
         "usage": {}
     }

--- a/pkg/tests/smoke/testdata/BobAsShell/claude-3-opus-20240229-expected.json
+++ b/pkg/tests/smoke/testdata/BobAsShell/claude-3-opus-20240229-expected.json
@@ -1,15 +1,15 @@
 [
     {
-        "time": "2024-06-20T17:10:39.522006-04:00",
+        "time": "2024-06-28T10:48:25.264658-04:00",
         "type": "runStart",
         "usage": {}
     },
     {
-        "time": "2024-06-20T17:10:39.522174-04:00",
+        "time": "2024-06-28T10:48:25.264853-04:00",
         "callContext": {
-            "id": "1718917840",
+            "id": "1719586106",
             "tool": {
-                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider@tool-beta",
+                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
@@ -34,55 +34,57 @@
                 },
                 "workingDir": "testdata/BobAsShell"
             },
+            "currentAgent": {},
             "inputContext": null
         },
         "type": "callStart",
         "usage": {}
     },
     {
-        "time": "2024-06-20T17:10:39.975716-04:00",
+        "time": "2024-06-28T10:48:26.063945-04:00",
         "type": "runStart",
         "usage": {}
     },
     {
-        "time": "2024-06-20T17:10:39.975965-04:00",
+        "time": "2024-06-28T10:48:26.064323-04:00",
         "callContext": {
-            "id": "1718917841",
+            "id": "1719586107",
             "tool": {
                 "name": "Anthropic Claude3 Model Provider",
                 "description": "Model provider for Anthropic hosted Claude3 models",
-                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider@tool-beta",
+                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "modelProvider": true,
                 "internalPrompt": null,
                 "credentials": [
-                    "github.com/gptscript-ai/claude3-anthropic-provider/credential"
+                    "github.com/gptscript-ai/credential as github.com/gptscript-ai/claude3-anthropic-provider/credential with \"Please enter your Anthropic API Key\" as message and token as field and \"ANTHROPIC_API_KEY\" as env"
                 ],
                 "instructions": "#!sys.daemon /usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/main.py",
-                "id": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/d47b232371d18e0254cf7cc5e15a813e7e24a8ad/tool.gpt:Anthropic Claude3 Model Provider",
+                "id": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/dfd21adc6be9fbda34b79a71e661ac0cfb725548/tool.gpt:Anthropic Claude3 Model Provider",
                 "toolMapping": {
-                    "github.com/gptscript-ai/claude3-anthropic-provider/credential": [
+                    "github.com/gptscript-ai/credential as github.com/gptscript-ai/claude3-anthropic-provider/credential with \"Please enter your Anthropic API Key\" as message and token as field and \"ANTHROPIC_API_KEY\" as env": [
                         {
-                            "reference": "github.com/gptscript-ai/claude3-anthropic-provider/credential",
-                            "toolID": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/3b9b9365d469c4c702291f1764537ab5c226c2e0/credential/tool.gpt:claude3-anthropic-credential"
+                            "reference": "github.com/gptscript-ai/credential as github.com/gptscript-ai/claude3-anthropic-provider/credential with \"Please enter your Anthropic API Key\" as message and token as field and \"ANTHROPIC_API_KEY\" as env",
+                            "toolID": "https://raw.githubusercontent.com/gptscript-ai/credential/651dfad6e7cf3a385ef408afa93ce522c10f8508/tool.gpt:token"
                         }
                     ]
                 },
                 "localTools": {
-                    "anthropic claude3 model provider": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/d47b232371d18e0254cf7cc5e15a813e7e24a8ad/tool.gpt:Anthropic Claude3 Model Provider"
+                    "anthropic claude3 model provider": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/dfd21adc6be9fbda34b79a71e661ac0cfb725548/tool.gpt:Anthropic Claude3 Model Provider"
                 },
                 "source": {
-                    "location": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/d47b232371d18e0254cf7cc5e15a813e7e24a8ad/tool.gpt",
+                    "location": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/dfd21adc6be9fbda34b79a71e661ac0cfb725548/tool.gpt",
                     "lineNo": 1,
                     "repo": {
                         "VCS": "git",
                         "Root": "https://github.com/gptscript-ai/claude3-anthropic-provider.git",
                         "Path": "/",
                         "Name": "tool.gpt",
-                        "Revision": "d47b232371d18e0254cf7cc5e15a813e7e24a8ad"
+                        "Revision": "dfd21adc6be9fbda34b79a71e661ac0cfb725548"
                     }
                 },
-                "workingDir": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/d47b232371d18e0254cf7cc5e15a813e7e24a8ad"
+                "workingDir": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/dfd21adc6be9fbda34b79a71e661ac0cfb725548"
             },
+            "currentAgent": {},
             "inputContext": null,
             "toolCategory": "provider",
             "displayText": "Running sys.daemon"
@@ -91,63 +93,64 @@
         "usage": {}
     },
     {
-        "time": "2024-06-20T17:10:40.990696-04:00",
+        "time": "2024-06-28T10:48:27.081163-04:00",
         "callContext": {
-            "id": "1718917841",
+            "id": "1719586107",
             "tool": {
                 "name": "Anthropic Claude3 Model Provider",
                 "description": "Model provider for Anthropic hosted Claude3 models",
-                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider@tool-beta",
+                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "modelProvider": true,
                 "internalPrompt": null,
                 "credentials": [
-                    "github.com/gptscript-ai/claude3-anthropic-provider/credential"
+                    "github.com/gptscript-ai/credential as github.com/gptscript-ai/claude3-anthropic-provider/credential with \"Please enter your Anthropic API Key\" as message and token as field and \"ANTHROPIC_API_KEY\" as env"
                 ],
                 "instructions": "#!sys.daemon /usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/main.py",
-                "id": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/d47b232371d18e0254cf7cc5e15a813e7e24a8ad/tool.gpt:Anthropic Claude3 Model Provider",
+                "id": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/dfd21adc6be9fbda34b79a71e661ac0cfb725548/tool.gpt:Anthropic Claude3 Model Provider",
                 "toolMapping": {
-                    "github.com/gptscript-ai/claude3-anthropic-provider/credential": [
+                    "github.com/gptscript-ai/credential as github.com/gptscript-ai/claude3-anthropic-provider/credential with \"Please enter your Anthropic API Key\" as message and token as field and \"ANTHROPIC_API_KEY\" as env": [
                         {
-                            "reference": "github.com/gptscript-ai/claude3-anthropic-provider/credential",
-                            "toolID": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/3b9b9365d469c4c702291f1764537ab5c226c2e0/credential/tool.gpt:claude3-anthropic-credential"
+                            "reference": "github.com/gptscript-ai/credential as github.com/gptscript-ai/claude3-anthropic-provider/credential with \"Please enter your Anthropic API Key\" as message and token as field and \"ANTHROPIC_API_KEY\" as env",
+                            "toolID": "https://raw.githubusercontent.com/gptscript-ai/credential/651dfad6e7cf3a385ef408afa93ce522c10f8508/tool.gpt:token"
                         }
                     ]
                 },
                 "localTools": {
-                    "anthropic claude3 model provider": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/d47b232371d18e0254cf7cc5e15a813e7e24a8ad/tool.gpt:Anthropic Claude3 Model Provider"
+                    "anthropic claude3 model provider": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/dfd21adc6be9fbda34b79a71e661ac0cfb725548/tool.gpt:Anthropic Claude3 Model Provider"
                 },
                 "source": {
-                    "location": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/d47b232371d18e0254cf7cc5e15a813e7e24a8ad/tool.gpt",
+                    "location": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/dfd21adc6be9fbda34b79a71e661ac0cfb725548/tool.gpt",
                     "lineNo": 1,
                     "repo": {
                         "VCS": "git",
                         "Root": "https://github.com/gptscript-ai/claude3-anthropic-provider.git",
                         "Path": "/",
                         "Name": "tool.gpt",
-                        "Revision": "d47b232371d18e0254cf7cc5e15a813e7e24a8ad"
+                        "Revision": "dfd21adc6be9fbda34b79a71e661ac0cfb725548"
                     }
                 },
-                "workingDir": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/d47b232371d18e0254cf7cc5e15a813e7e24a8ad"
+                "workingDir": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/dfd21adc6be9fbda34b79a71e661ac0cfb725548"
             },
+            "currentAgent": {},
             "inputContext": null,
             "toolCategory": "provider",
             "displayText": "Running sys.daemon"
         },
         "type": "callFinish",
         "usage": {},
-        "content": "http://127.0.0.1:11124"
+        "content": "http://127.0.0.1:10315"
     },
     {
-        "time": "2024-06-20T17:10:40.990787-04:00",
+        "time": "2024-06-28T10:48:27.081351-04:00",
         "type": "runFinish",
         "usage": {}
     },
     {
-        "time": "2024-06-20T17:10:40.990853-04:00",
+        "time": "2024-06-28T10:48:27.081414-04:00",
         "callContext": {
-            "id": "1718917840",
+            "id": "1719586106",
             "tool": {
-                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider@tool-beta",
+                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
@@ -172,10 +175,11 @@
                 },
                 "workingDir": "testdata/BobAsShell"
             },
+            "currentAgent": {},
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1718917842",
+        "chatCompletionId": "1719586108",
         "usage": {},
         "chatRequest": {
             "model": "claude-3-opus-20240229",
@@ -207,11 +211,11 @@
         }
     },
     {
-        "time": "2024-06-20T17:10:40.991247-04:00",
+        "time": "2024-06-28T10:48:27.081844-04:00",
         "callContext": {
-            "id": "1718917840",
+            "id": "1719586106",
             "tool": {
-                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider@tool-beta",
+                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
@@ -236,19 +240,20 @@
                 },
                 "workingDir": "testdata/BobAsShell"
             },
+            "currentAgent": {},
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1718917842",
+        "chatCompletionId": "1719586108",
         "usage": {},
         "content": "Waiting for model response..."
     },
     {
-        "time": "2024-06-20T17:10:49.116225-04:00",
+        "time": "2024-06-28T10:48:30.452648-04:00",
         "callContext": {
-            "id": "1718917840",
+            "id": "1719586106",
             "tool": {
-                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider@tool-beta",
+                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
@@ -273,19 +278,20 @@
                 },
                 "workingDir": "testdata/BobAsShell"
             },
+            "currentAgent": {},
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1718917842",
+        "chatCompletionId": "1719586108",
         "usage": {},
         "content": "\u003ctool call\u003e bob -\u003e {\"question\": \"how are you doing\"}"
     },
     {
-        "time": "2024-06-20T17:10:49.116466-04:00",
+        "time": "2024-06-28T10:48:30.452871-04:00",
         "callContext": {
-            "id": "1718917840",
+            "id": "1719586106",
             "tool": {
-                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider@tool-beta",
+                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
@@ -310,10 +316,11 @@
                 },
                 "workingDir": "testdata/BobAsShell"
             },
+            "currentAgent": {},
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1718917842",
+        "chatCompletionId": "1719586108",
         "usage": {},
         "chatResponse": {
             "role": "assistant",
@@ -321,7 +328,7 @@
                 {
                     "toolCall": {
                         "index": 0,
-                        "id": "toolu_01BzEjSj1HhTi52c1N9mS1jK",
+                        "id": "bob",
                         "function": {
                             "name": "bob",
                             "arguments": "{\"question\": \"how are you doing\"}"
@@ -333,11 +340,11 @@
         }
     },
     {
-        "time": "2024-06-20T17:10:49.116557-04:00",
+        "time": "2024-06-28T10:48:30.452992-04:00",
         "callContext": {
-            "id": "1718917840",
+            "id": "1719586106",
             "tool": {
-                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider@tool-beta",
+                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
@@ -362,10 +369,11 @@
                 },
                 "workingDir": "testdata/BobAsShell"
             },
+            "currentAgent": {},
             "inputContext": null
         },
         "toolSubCalls": {
-            "toolu_01BzEjSj1HhTi52c1N9mS1jK": {
+            "bob": {
                 "toolID": "testdata/BobAsShell/test.gpt:bob",
                 "input": "{\"question\": \"how are you doing\"}"
             }
@@ -374,13 +382,13 @@
         "usage": {}
     },
     {
-        "time": "2024-06-20T17:10:49.116583-04:00",
+        "time": "2024-06-28T10:48:30.453034-04:00",
         "callContext": {
-            "id": "toolu_01BzEjSj1HhTi52c1N9mS1jK",
+            "id": "bob",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
-                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider@tool-beta",
+                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -403,9 +411,10 @@
                 },
                 "workingDir": "testdata/BobAsShell"
             },
+            "currentAgent": {},
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1718917840",
+            "parentID": "1719586106",
             "displayText": "Running bob from testdata/BobAsShell/test.gpt"
         },
         "type": "callStart",
@@ -413,13 +422,13 @@
         "content": "{\"question\": \"how are you doing\"}"
     },
     {
-        "time": "2024-06-20T17:10:49.116924-04:00",
+        "time": "2024-06-28T10:48:30.453498-04:00",
         "callContext": {
-            "id": "toolu_01BzEjSj1HhTi52c1N9mS1jK",
+            "id": "bob",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
-                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider@tool-beta",
+                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -442,13 +451,14 @@
                 },
                 "workingDir": "testdata/BobAsShell"
             },
+            "currentAgent": {},
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1718917840",
+            "parentID": "1719586106",
             "displayText": "Running bob from testdata/BobAsShell/test.gpt"
         },
         "type": "callChat",
-        "chatCompletionId": "1718917843",
+        "chatCompletionId": "1719586109",
         "usage": {},
         "chatRequest": {
             "model": "",
@@ -456,13 +466,13 @@
         }
     },
     {
-        "time": "2024-06-20T17:10:49.119266-04:00",
+        "time": "2024-06-28T10:48:30.455907-04:00",
         "callContext": {
-            "id": "toolu_01BzEjSj1HhTi52c1N9mS1jK",
+            "id": "bob",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
-                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider@tool-beta",
+                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -485,24 +495,25 @@
                 },
                 "workingDir": "testdata/BobAsShell"
             },
+            "currentAgent": {},
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1718917840",
+            "parentID": "1719586106",
             "displayText": "Running bob from testdata/BobAsShell/test.gpt"
         },
         "type": "callProgress",
-        "chatCompletionId": "1718917843",
+        "chatCompletionId": "1719586109",
         "usage": {},
         "content": "Thanks for asking how are you doing, I'm doing great fellow friendly AI tool!\n"
     },
     {
-        "time": "2024-06-20T17:10:49.119489-04:00",
+        "time": "2024-06-28T10:48:30.45611-04:00",
         "callContext": {
-            "id": "toolu_01BzEjSj1HhTi52c1N9mS1jK",
+            "id": "bob",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
-                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider@tool-beta",
+                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -525,26 +536,27 @@
                 },
                 "workingDir": "testdata/BobAsShell"
             },
+            "currentAgent": {},
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1718917840",
+            "parentID": "1719586106",
             "displayText": "Running bob from testdata/BobAsShell/test.gpt"
         },
         "type": "callChat",
-        "chatCompletionId": "1718917843",
+        "chatCompletionId": "1719586109",
         "usage": {},
         "chatResponse": {
             "usage": {}
         }
     },
     {
-        "time": "2024-06-20T17:10:49.119539-04:00",
+        "time": "2024-06-28T10:48:30.456161-04:00",
         "callContext": {
-            "id": "toolu_01BzEjSj1HhTi52c1N9mS1jK",
+            "id": "bob",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
-                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider@tool-beta",
+                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -567,9 +579,10 @@
                 },
                 "workingDir": "testdata/BobAsShell"
             },
+            "currentAgent": {},
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1718917840",
+            "parentID": "1719586106",
             "displayText": "Running bob from testdata/BobAsShell/test.gpt"
         },
         "type": "callFinish",
@@ -577,11 +590,11 @@
         "content": "Thanks for asking how are you doing, I'm doing great fellow friendly AI tool!\n"
     },
     {
-        "time": "2024-06-20T17:10:49.119572-04:00",
+        "time": "2024-06-28T10:48:30.456194-04:00",
         "callContext": {
-            "id": "1718917840",
+            "id": "1719586106",
             "tool": {
-                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider@tool-beta",
+                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
@@ -606,6 +619,7 @@
                 },
                 "workingDir": "testdata/BobAsShell"
             },
+            "currentAgent": {},
             "inputContext": null
         },
         "toolResults": 1,
@@ -613,11 +627,11 @@
         "usage": {}
     },
     {
-        "time": "2024-06-20T17:10:49.298305-04:00",
+        "time": "2024-06-28T10:48:30.652688-04:00",
         "callContext": {
-            "id": "1718917840",
+            "id": "1719586106",
             "tool": {
-                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider@tool-beta",
+                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
@@ -642,10 +656,11 @@
                 },
                 "workingDir": "testdata/BobAsShell"
             },
+            "currentAgent": {},
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1718917844",
+        "chatCompletionId": "1719586110",
         "usage": {},
         "chatRequest": {
             "model": "claude-3-opus-20240229",
@@ -659,7 +674,7 @@
                     "content": "",
                     "tool_calls": [
                         {
-                            "id": "toolu_01BzEjSj1HhTi52c1N9mS1jK",
+                            "id": "bob",
                             "type": "function",
                             "function": {
                                 "name": "bob",
@@ -672,7 +687,7 @@
                     "role": "tool",
                     "content": "Thanks for asking how are you doing, I'm doing great fellow friendly AI tool!\n",
                     "name": "bob",
-                    "tool_call_id": "toolu_01BzEjSj1HhTi52c1N9mS1jK"
+                    "tool_call_id": "bob"
                 }
             ],
             "temperature": 0,
@@ -697,11 +712,11 @@
         }
     },
     {
-        "time": "2024-06-20T17:10:49.298759-04:00",
+        "time": "2024-06-28T10:48:30.652933-04:00",
         "callContext": {
-            "id": "1718917840",
+            "id": "1719586106",
             "tool": {
-                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider@tool-beta",
+                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
@@ -726,19 +741,20 @@
                 },
                 "workingDir": "testdata/BobAsShell"
             },
+            "currentAgent": {},
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1718917844",
+        "chatCompletionId": "1719586110",
         "usage": {},
         "content": "Waiting for model response..."
     },
     {
-        "time": "2024-06-20T17:10:51.580939-04:00",
+        "time": "2024-06-28T10:48:33.127339-04:00",
         "callContext": {
-            "id": "1718917840",
+            "id": "1719586106",
             "tool": {
-                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider@tool-beta",
+                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
@@ -763,19 +779,20 @@
                 },
                 "workingDir": "testdata/BobAsShell"
             },
+            "currentAgent": {},
             "inputContext": null
         },
         "type": "callProgress",
-        "chatCompletionId": "1718917844",
+        "chatCompletionId": "1719586110",
         "usage": {},
-        "content": "Bob replied: \"Thanks for asking how are you doing, I'm doing great fellow friendly AI tool!\""
+        "content": "Thanks for asking how are you doing, I'm doing great fellow friendly AI tool!"
     },
     {
-        "time": "2024-06-20T17:10:51.581258-04:00",
+        "time": "2024-06-28T10:48:33.127696-04:00",
         "callContext": {
-            "id": "1718917840",
+            "id": "1719586106",
             "tool": {
-                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider@tool-beta",
+                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
@@ -800,27 +817,28 @@
                 },
                 "workingDir": "testdata/BobAsShell"
             },
+            "currentAgent": {},
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1718917844",
+        "chatCompletionId": "1719586110",
         "usage": {},
         "chatResponse": {
             "role": "assistant",
             "content": [
                 {
-                    "text": "Bob replied: \"Thanks for asking how are you doing, I'm doing great fellow friendly AI tool!\""
+                    "text": "Thanks for asking how are you doing, I'm doing great fellow friendly AI tool!"
                 }
             ],
             "usage": {}
         }
     },
     {
-        "time": "2024-06-20T17:10:51.581281-04:00",
+        "time": "2024-06-28T10:48:33.127717-04:00",
         "callContext": {
-            "id": "1718917840",
+            "id": "1719586106",
             "tool": {
-                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider@tool-beta",
+                "modelName": "claude-3-opus-20240229 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
@@ -845,14 +863,15 @@
                 },
                 "workingDir": "testdata/BobAsShell"
             },
+            "currentAgent": {},
             "inputContext": null
         },
         "type": "callFinish",
         "usage": {},
-        "content": "Bob replied: \"Thanks for asking how are you doing, I'm doing great fellow friendly AI tool!\""
+        "content": "Thanks for asking how are you doing, I'm doing great fellow friendly AI tool!"
     },
     {
-        "time": "2024-06-20T17:10:51.581291-04:00",
+        "time": "2024-06-28T10:48:33.127758-04:00",
         "type": "runFinish",
         "usage": {}
     }


### PR DESCRIPTION
With this change, we now use the GitHub token for VCS lookups when resolving tools. This can help avoid rate limits.

I also fix the Claude smoke test in this PR, but it runs the old version against this PR, which is why it is still failing.