### PR TITLE
fix: remove requirement that cred aliases be alphanumeric

### DIFF
--- a/pkg/types/tool.go
+++ b/pkg/types/tool.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
-	"regexp"
 	"slices"
 	"sort"
 	"strings"
@@ -282,10 +281,6 @@ func ParseCredentialArgs(toolName string, input string) (string, string, map[str
 		}
 		alias = fields[1]
 		fields = fields[2:]
-	}
-
-	if alias != "" && !isAlphaNumeric(alias) {
-		return "", "", nil, fmt.Errorf("credential alias must be alphanumeric")
 	}
 
 	if len(fields) == 0 { // Nothing left, so just return
@@ -784,8 +779,4 @@ func FirstSet[T comparable](in ...T) (result T) {
 		}
 	}
 	return
-}
-
-func isAlphaNumeric(s string) bool {
-	return regexp.MustCompile(`^[a-zA-Z0-9_.]+$`).MatchString(s)
 }


### PR DESCRIPTION
This requirement would probably cause us more problems than it's worth (like weird edge cases in tool generation for OpenAPI), so it's probably best that we just remove it.