### PR TITLE
fix: join the server and url with url joinpath.

### DIFF
--- a/pkg/engine/openapi.go
+++ b/pkg/engine/openapi.go
@@ -112,7 +112,12 @@ func (e *Engine) runOpenAPI(tool types.Tool, input string) (*Return, error) {
 	instructions.Path = handlePathParameters(instructions.Path, instructions.PathParameters, input)
 
 	// Parse the URL
-	u, err := url.Parse(instructions.Server + instructions.Path)
+	path, err := url.JoinPath(instructions.Server, instructions.Path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to join server and path: %w", err)
+	}
+
+	u, err := url.Parse(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse server URL %s: %w", instructions.Server+instructions.Path, err)
 	}


### PR DESCRIPTION
When joining url paths, you sometimes end up with // or /./ in them. When interacting with some apis you get redirects, like a 308, that are not handled by the default client.

This just cleans it up in an effort to avoid.