### PR TITLE
fix: option hiding in cred subcommands

### DIFF
--- a/pkg/cli/gptscript.go
+++ b/pkg/cli/gptscript.go
@@ -109,6 +109,7 @@ func New() *cobra.Command {
 					newFlag := pflag.Flag{
 						Name:  f.Name,
 						Usage: f.Usage,
+						Value: f.Value,
 					}
 
 					if f.Name != "credential-context" {


### PR DESCRIPTION
The credential subcommands throw a nil ptr exception due to a nil
credential override flag value. Prevent this by including the value when
hiding flags from credential subcommands.

@g-linville and I missed this in #596