### PR TITLE
fix: create cred helper dir properly on Windows

### DIFF
--- a/pkg/credentials/util.go
+++ b/pkg/credentials/util.go
@@ -5,7 +5,7 @@ import (
 )
 
 type CredentialHelperDirs struct {
-	RevisionFile, LastCheckedFile, BinDir, RepoDir string
+	RevisionFile, LastCheckedFile, BinDir, RepoDir, HelperDir string
 }
 
 func GetCredentialHelperDirs(cacheDir string) CredentialHelperDirs {
@@ -14,5 +14,6 @@ func GetCredentialHelperDirs(cacheDir string) CredentialHelperDirs {
 		LastCheckedFile: filepath.Join(cacheDir, "repos", "gptscript-credential-helpers", "last-checked"),
 		BinDir:          filepath.Join(cacheDir, "repos", "gptscript-credential-helpers", "bin"),
 		RepoDir:         filepath.Join(cacheDir, "repos", "gptscript-credential-helpers", "repo"),
+		HelperDir:       filepath.Join(cacheDir, "repos", "gptscript-credential-helpers"),
 	}
 }

--- a/pkg/repos/get.go
+++ b/pkg/repos/get.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -133,7 +132,7 @@ func (m *Manager) deferredSetUpCredentialHelpers(ctx context.Context, cliCfg *co
 		return err
 	}
 
-	if err := os.MkdirAll(path.Dir(m.credHelperDirs.LastCheckedFile), 0755); err != nil {
+	if err := os.MkdirAll(m.credHelperDirs.HelperDir, 0755); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
The `path.Dir` function was totally broken on Windows (I think it was returning an empty string or something). This fixes the problem