### PR TITLE
Fix: Try to send interupt to sys.daemon to allow cleanup

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"runtime"
 )
 
 func SysDaemon() error {
@@ -19,5 +20,11 @@ func SysDaemon() error {
 	cmd := exec.CommandContext(ctx, os.Args[2], os.Args[3:]...)
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout
+	cmd.Cancel = func() error {
+		if runtime.GOOS == "windows" {
+			return cmd.Process.Kill()
+		}
+		return cmd.Process.Signal(os.Interrupt)
+	}
 	return cmd.Run()
 }


### PR DESCRIPTION
We should try to send os.interupt to sys daemon process. This allows daemon process to be able to intercept and perform possible cleanup function.

It was causing an issue where in browser tool, when script is executed, the browser session is not closed.