### PR TITLE
chore: fix Go version to 1.22.4

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -26,7 +26,9 @@ jobs:
         uses: actions/setup-go@v5
         with:
           cache: false
-          go-version: "1.22"
+          # This can't be upgraded until the issue with sys.daemon on Windows is resolved
+          # After the issue is resolved, this can be set to 1.22
+          go-version: "1.22.4"
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,9 @@ jobs:
         uses: actions/setup-go@v5
         with:
           cache: false
-          go-version: "1.22"
+          # This can't be upgraded until the issue with sys.daemon on Windows is resolved
+          # After the issue is resolved, this can be set to 1.22
+          go-version: "1.22.4"
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4
         with:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/gptscript-ai/gptscript
 
-go 1.22.3
+// This can't be upgraded until the issue with sys.daemon on Windows is resolved
+go 1.22.4
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7


### PR DESCRIPTION
There is a change in 1.22.5 that breaks sys.daemon on Windows. Fixing this version for now until we address this issue.