### PR TITLE
Un-revert "Fix: Try to send interupt to sys.daemon to allow cleanup""

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"runtime"
 )
 
 func SysDaemon() error {
@@ -19,5 +20,11 @@ func SysDaemon() error {
 	cmd := exec.CommandContext(ctx, os.Args[2], os.Args[3:]...)
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout
+	cmd.Cancel = func() error {
+		if runtime.GOOS == "windows" {
+			return cmd.Process.Kill()
+		}
+		return cmd.Process.Signal(os.Interrupt)
+	}
 	return cmd.Run()
 }


### PR DESCRIPTION
Reverts gptscript-ai/gptscript#611.

The providers will be updated to handle interrupts gracefully to accommodate this change.

See:

- https://github.com/gptscript-ai/mistral-laplateforme-provider/pull/1
- https://github.com/gptscript-ai/claude3-anthropic-provider/pull/7
- https://github.com/gptscript-ai/claude3-bedrock-provider/pull/1
- https://github.com/gptscript-ai/azure-other-provider/pull/3
- https://github.com/gptscript-ai/azure-openai-provider/pull/2
- https://github.com/gptscript-ai/gemini-aistudio-provider/pull/2
- https://github.com/gptscript-ai/gemini-aistudio-provider/pull/2