### PR TITLE
chore: remove references to tap in favor of homebrew-core

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -50,16 +50,3 @@ release:
     owner: gptscript-ai
     name: gptscript
   prerelease: auto
-
-brews:
-  - description: "GPTScript CLI"
-    install: |
-      bin.install "gptscript"
-      generate_completions_from_executable(bin/"gptscript", "completion", shells: [:bash, :zsh, :fish])
-    homepage: "https://github.com/gptscript-ai/gptscript"
-    skip_upload: false
-    folder: "Formula"
-    repository:
-      owner: gptscript-ai
-      name: homebrew-tap
-      token: "{{ .Env.GH_PROJECT_TOKEN }}"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Here are some sample use cases of GPTScript:
 ### Getting started
 MacOS and Linux (Homebrew):
 ```
-brew install gptscript-ai/tap/gptscript 
+brew install gptscript 
 gptscript github.com/gptscript-ai/llm-basics-demo
 ```
 

--- a/docs/docs/01-overview.md
+++ b/docs/docs/01-overview.md
@@ -22,7 +22,7 @@ Here are some sample use cases of GPTScript:
 <Tabs>
     <TabItem value="MacOS and Linux (Homebrew)">
     ```shell
-    brew install gptscript-ai/tap/gptscript 
+    brew install gptscript 
     gptscript github.com/gptscript-ai/llm-basics-demo
     ```
     </TabItem>


### PR DESCRIPTION
This means releases will get into homebrew-core when their automation detects we have released a new version. Looking at the last several releases, it looks like that takes ~2 hours after we cut our release.