### PR TITLE
chore: set the run file env var when starting the ui

### DIFF
--- a/pkg/cli/gptscript.go
+++ b/pkg/cli/gptscript.go
@@ -371,7 +371,7 @@ func (r *GPTScript) Run(cmd *cobra.Command, args []string) (retErr error) {
 				gptOpt.Env = append(gptOpt.Env, "GPTSCRIPT_SDKSERVER_CREDENTIAL_OVERRIDE="+strings.Join(r.CredentialOverride, ","))
 			}
 
-			args = append([]string{args[0]}, "--file="+file)
+			gptOpt.Env = append(gptOpt.Env, "UI_RUN_FILE="+file)
 
 			if len(args) > 2 {
 				args = append(args, args[2:]...)


### PR DESCRIPTION
Set the `UI_RUN_FILE` env var before starting the UI tool
when a run file is provided; e.g. `gptscript --ui <run-file.gpt>`. This
tells the UI to use the file's run page as the landing page on start.

Depends on https://github.com/gptscript-ai/ui/pull/30
