### PR TITLE
enhance: share credential

### DIFF
--- a/integration/cred_test.go
+++ b/integration/cred_test.go
@@ -11,3 +11,19 @@ func TestGPTScriptCredential(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, out, "CREDENTIAL")
 }
+
+// TestCredentialScopes makes sure that environment variables set by credential tools and shared credential tools
+// are only available to the correct tools. See scripts/credscopes.gpt for more details.
+func TestCredentialScopes(t *testing.T) {
+	out, err := RunScript("scripts/credscopes.gpt", "--sub-tool", "oneOne")
+	require.NoError(t, err)
+	require.Contains(t, out, "good")
+
+	out, err = RunScript("scripts/credscopes.gpt", "--sub-tool", "twoOne")
+	require.NoError(t, err)
+	require.Contains(t, out, "good")
+
+	out, err = RunScript("scripts/credscopes.gpt", "--sub-tool", "twoTwo")
+	require.NoError(t, err)
+	require.Contains(t, out, "good")
+}

--- a/integration/helpers.go
+++ b/integration/helpers.go
@@ -14,3 +14,7 @@ func GPTScriptExec(args ...string) (string, error) {
 	out, err := cmd.CombinedOutput()
 	return string(out), err
 }
+
+func RunScript(script string, options ...string) (string, error) {
+	return GPTScriptExec(append(options, "--quiet", script)...)
+}

--- a/integration/scripts/credscopes.gpt
+++ b/integration/scripts/credscopes.gpt
@@ -1,0 +1,160 @@
+# This script sets up a chain of tools in a tree structure.
+# The root is oneOne, with children twoOne and twoTwo, with children threeOne, threeTwo, and threeThree, with only
+# threeTwo shared between them.
+# Each tool should only have access to any credentials it defines and any credentials exported/shared by its
+# immediate children (but not grandchildren).
+# This script checks to make sure that this is working properly.
+name: oneOne
+tools: twoOne, twoTwo
+cred: getcred with oneOne as var and 11 as val
+
+#!python3
+
+import os
+
+oneOne = os.getenv('oneOne')
+twoOne = os.getenv('twoOne')
+twoTwo = os.getenv('twoTwo')
+threeOne = os.getenv('threeOne')
+threeTwo = os.getenv('threeTwo')
+threeThree = os.getenv('threeThree')
+
+if oneOne != '11':
+  print('error: oneOne is not 11')
+  exit(1)
+
+if twoOne != '21':
+  print('error: twoOne is not 21')
+  exit(1)
+
+if twoTwo != '22':
+  print('error: twoTwo is not 22')
+  exit(1)
+
+if threeOne is not None:
+  print('error: threeOne is not None')
+  exit(1)
+
+if threeTwo is not None:
+  print('error: threeTwo is not None')
+  exit(1)
+
+if threeThree is not None:
+  print('error: threeThree is not None')
+  exit(1)
+
+print('good')
+
+---
+name: twoOne
+tools: threeOne, threeTwo
+exportcred: getcred with twoOne as var and 21 as val
+
+#!python3
+
+import os
+
+oneOne = os.getenv('oneOne')
+twoOne = os.getenv('twoOne')
+twoTwo = os.getenv('twoTwo')
+threeOne = os.getenv('threeOne')
+threeTwo = os.getenv('threeTwo')
+threeThree = os.getenv('threeThree')
+
+if oneOne is not None:
+  print('error: oneOne is not None')
+  exit(1)
+
+if twoOne is not None:
+  print('error: twoOne is not None')
+  exit(1)
+
+if twoTwo is not None:
+  print('error: twoTwo is not None')
+  exit(1)
+
+if threeOne != '31':
+  print('error: threeOne is not 31')
+  exit(1)
+
+if threeTwo != '32':
+  print('error: threeTwo is not 32')
+  exit(1)
+
+if threeThree is not None:
+  print('error: threeThree is not None')
+  exit(1)
+
+print('good')
+
+---
+name: twoTwo
+tools: threeTwo, threeThree
+exportcred: getcred with twoTwo as var and 22 as val
+
+#!python3
+
+import os
+
+oneOne = os.getenv('oneOne')
+twoOne = os.getenv('twoOne')
+twoTwo = os.getenv('twoTwo')
+threeOne = os.getenv('threeOne')
+threeTwo = os.getenv('threeTwo')
+threeThree = os.getenv('threeThree')
+
+if oneOne is not None:
+  print('error: oneOne is not None')
+  exit(1)
+
+if twoOne is not None:
+  print('error: twoOne is not None')
+  exit(1)
+
+if twoTwo is not None:
+  print('error: twoTwo is not None')
+  exit(1)
+
+if threeOne is not None:
+  print('error: threeOne is not None')
+  exit(1)
+
+if threeTwo != '32':
+  print('error: threeTwo is not 32')
+  exit(1)
+
+if threeThree != '33':
+  print('error: threeThree is not 33')
+  exit(1)
+
+print('good')
+
+---
+name: threeOne
+exportcred: getcred with threeOne as var and 31 as val
+
+---
+name: threeTwo
+exportcred: getcred with threeTwo as var and 32 as val
+
+---
+name: threeThree
+exportcred: getcred with threeThree as var and 33 as val
+
+---
+name: getcred
+
+#!python3
+
+import os
+import json
+
+var = os.getenv('var')
+val = os.getenv('val')
+
+output = {
+    "env": {
+        var: val
+    }
+}
+print(json.dumps(output))

--- a/integration/scripts/credscopes.gpt
+++ b/integration/scripts/credscopes.gpt
@@ -48,7 +48,7 @@ print('good')
 ---
 name: twoOne
 tools: threeOne, threeTwo
-exportcred: getcred with twoOne as var and 21 as val
+sharecred: getcred with twoOne as var and 21 as val
 
 #!python3
 
@@ -90,7 +90,7 @@ print('good')
 ---
 name: twoTwo
 tools: threeTwo, threeThree
-exportcred: getcred with twoTwo as var and 22 as val
+sharecred: getcred with twoTwo as var and 22 as val
 
 #!python3
 
@@ -131,15 +131,15 @@ print('good')
 
 ---
 name: threeOne
-exportcred: getcred with threeOne as var and 31 as val
+sharecred: getcred with threeOne as var and 31 as val
 
 ---
 name: threeTwo
-exportcred: getcred with threeTwo as var and 32 as val
+sharecred: getcred with threeTwo as var and 32 as val
 
 ---
 name: threeThree
-exportcred: getcred with threeThree as var and 33 as val
+sharecred: getcred with threeThree as var and 33 as val
 
 ---
 name: getcred

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -148,7 +148,7 @@ func isParam(line string, tool *types.Tool) (_ bool, err error) {
 		}
 	case "credentials", "creds", "credential", "cred":
 		tool.Parameters.Credentials = append(tool.Parameters.Credentials, value)
-	case "exportcredentials", "exportcreds", "exportcredential", "exportcred", "sharecredentials", "sharecreds", "sharecredential", "sharecred":
+	case "sharecredentials", "sharecreds", "sharecredential", "sharecred":
 		tool.Parameters.ExportCredentials = append(tool.Parameters.ExportCredentials, value)
 	default:
 		return false, nil

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -148,6 +148,8 @@ func isParam(line string, tool *types.Tool) (_ bool, err error) {
 		}
 	case "credentials", "creds", "credential", "cred":
 		tool.Parameters.Credentials = append(tool.Parameters.Credentials, value)
+	case "exportcredentials", "exportcreds", "exportcredential", "exportcred", "sharecredentials", "sharecreds", "sharecredential", "sharecred":
+		tool.Parameters.ExportCredentials = append(tool.Parameters.ExportCredentials, value)
 	default:
 		return false, nil
 	}


### PR DESCRIPTION
This adds a new tool parameter, `Share Credentials` (with several aliases), which is essentially the same thing as `Share Tools` but specifically for credential tools.

I also added a new integration test that tests credential "scopes" to make sure that in a tree of tools that define and share credentials, each tool only has access to credentials that it defines and credentials shared by its immediate children in the tree.