### PR TITLE
fix: normalize LLM-hallucinated tool names

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -396,7 +396,7 @@ func (e *Engine) complete(ctx context.Context, state *State) (*Return, error) {
 			}
 			if toolID == "" {
 				log.Debugf("failed to find tool id for tool %s in tool_call result", content.ToolCall.Function.Name)
-				toolID = content.ToolCall.Function.Name
+				toolID = types.ToolNormalizer(content.ToolCall.Function.Name)
 				missing = true
 			}
 			state.Pending[content.ToolCall.ID] = *content.ToolCall

--- a/pkg/tests/runner_test.go
+++ b/pkg/tests/runner_test.go
@@ -954,7 +954,7 @@ func TestMissingTool(t *testing.T) {
 
 	r.RespondWith(tester.Result{
 		Func: types.CompletionFunctionCall{
-			Name: "not bob",
+			Name: "not.bob",
 		},
 	})
 

--- a/pkg/tests/testdata/TestMissingTool/call1-resp.golden
+++ b/pkg/tests/testdata/TestMissingTool/call1-resp.golden
@@ -5,7 +5,7 @@
       "toolCall": {
         "id": "call_1",
         "function": {
-          "name": "not bob"
+          "name": "not.bob"
         }
       }
     }

--- a/pkg/tests/testdata/TestMissingTool/call2.golden
+++ b/pkg/tests/testdata/TestMissingTool/call2.golden
@@ -35,7 +35,7 @@
           "toolCall": {
             "id": "call_1",
             "function": {
-              "name": "not bob"
+              "name": "not.bob"
             }
           }
         }
@@ -46,13 +46,13 @@
       "role": "tool",
       "content": [
         {
-          "text": "ERROR: can not call unknown tool named [not bob]"
+          "text": "ERROR: can not call unknown tool named [notBob]"
         }
       ],
       "toolCall": {
         "id": "call_1",
         "function": {
-          "name": "not bob"
+          "name": "not.bob"
         }
       },
       "usage": {}


### PR DESCRIPTION
When the LLM tries to call a tool that doesn't exist, gptscript is supposed to give it an error message so that it can correct itself and keep working. But if the tool name that the LLM hallucinated is an invalid tool ID, then gptscript would crash. This change makes it so that we normalize the hallucinated tool name first and avoid crashing.