### PR TITLE
fix: Append all credentials for OpenAPI security infos

### DIFF
--- a/pkg/loader/openapi.go
+++ b/pkg/loader/openapi.go
@@ -305,7 +305,7 @@ func getOpenAPITools(t *openapi3.T, defaultHost, source, targetToolName string) 
 					if err != nil {
 						return nil, fmt.Errorf("failed to parse operation server URL: %w", err)
 					}
-					tool.Credentials = info.GetCredentialToolStrings(operationServerURL.Hostname())
+					tool.Credentials = append(tool.Credentials, info.GetCredentialToolStrings(operationServerURL.Hostname())...)
 				}
 			}
 


### PR DESCRIPTION
When using an OpenAPI definition with multiple security infos that should be AND'd together (per https://docs.gptscript.ai/tools/openapi#1-security-schemes), the tools credential injection with only include 1 of the environment variables instead of all of them. The result is non-deterministic on which envvar will be included to do Go's behavior with slices.
This changes the behavior to include credential injections for all schemes declared in the 1st security info block in the api definition.