### PR TITLE
chore: remove homebrew-release step

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,16 +40,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
           GORELEASER_CURRENT_TAG: ${{ github.ref_name }}
-  homebrew-release:
-    needs: release-tag
-    if: "! contains(github.ref_name, '-rc')"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Update Homebrew formula
-        uses: dawidd6/action-homebrew-bump-formula@v3
-        with:
-          token: ${{secrets.BREW_GH_TOKEN}}
-          formula: gptscript
   winget-release:
     needs: release-tag
     if: "! contains(github.ref_name, '-rc')"


### PR DESCRIPTION
Since gptscript is on the homebrew autobump list, the formula can't be updated manually.