### PR TITLE
fix: ensure default model is parsed when using default model provider

### DIFF
--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -51,7 +51,12 @@ func (c *Client) Call(ctx context.Context, messageRequest types.CompletionReques
 		return nil, fmt.Errorf("failed to find remote model %s", messageRequest.Model)
 	}
 
-	_, modelName := types.SplitToolRef(messageRequest.Model)
+	toolName, modelName := types.SplitToolRef(messageRequest.Model)
+	if modelName == "" {
+		// modelName is empty, then the messageRequest.Model is not of the form 'modelName from provider'
+		// Therefore, the modelName is the toolName
+		modelName = toolName
+	}
 	messageRequest.Model = modelName
 	return client.Call(ctx, messageRequest, status)
 }


### PR DESCRIPTION
When using the default model provider flag, the default model will be
gpt-4o. However, when it is parsed, the expected format is 'gpt-4p from
my-model-provider'. When using a default model provider, the 'gpt-4o'
was being parsed and the model was set to the empty string.

After this change, if the model name is empty after parsing, then we
know that the model from the request doesn't have a 'from' in it and the
first part of the split reference should be used.