### PR TITLE
chore: add type field to tools

### DIFF
--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -150,6 +150,8 @@ func isParam(line string, tool *types.Tool) (_ bool, err error) {
 		tool.Parameters.Credentials = append(tool.Parameters.Credentials, value)
 	case "sharecredentials", "sharecreds", "sharecredential", "sharecred", "sharedcredentials", "sharedcreds", "sharedcredential", "sharedcred":
 		tool.Parameters.ExportCredentials = append(tool.Parameters.ExportCredentials, value)
+	case "type":
+		tool.Type = types.ToolType(strings.ToLower(value))
 	default:
 		return false, nil
 	}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -332,7 +332,7 @@ func getToolRefInput(prg *types.Program, ref types.ToolReference, input string) 
 }
 
 func (r *Runner) getContext(callCtx engine.Context, state *State, monitor Monitor, env []string, input string) (result []engine.InputContext, _ *State, _ error) {
-	toolRefs, err := callCtx.Program.GetContextToolRefs(callCtx.Tool.ID)
+	toolRefs, err := callCtx.Tool.GetContextTools(*callCtx.Program)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/tests/runner_test.go
+++ b/pkg/tests/runner_test.go
@@ -995,3 +995,8 @@ func TestMissingTool(t *testing.T) {
 	r.AssertResponded(t)
 	autogold.Expect("TEST RESULT CALL: 2").Equal(t, resp)
 }
+
+func TestToolRefAll(t *testing.T) {
+	r := tester.NewRunner(t)
+	r.RunDefault()
+}

--- a/pkg/tests/testdata/TestToolRefAll/call1-resp.golden
+++ b/pkg/tests/testdata/TestToolRefAll/call1-resp.golden
@@ -1,0 +1,9 @@
+`{
+  "role": "assistant",
+  "content": [
+    {
+      "text": "TEST RESULT CALL: 1"
+    }
+  ],
+  "usage": {}
+}`

--- a/pkg/tests/testdata/TestToolRefAll/call1.golden
+++ b/pkg/tests/testdata/TestToolRefAll/call1.golden
@@ -1,0 +1,61 @@
+`{
+  "model": "gpt-4o",
+  "tools": [
+    {
+      "function": {
+        "toolID": "testdata/TestToolRefAll/test.gpt:tool",
+        "name": "tool",
+        "parameters": {
+          "properties": {
+            "toolArg": {
+              "description": "stuff",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      }
+    },
+    {
+      "function": {
+        "toolID": "testdata/TestToolRefAll/test.gpt:none",
+        "name": "none",
+        "parameters": {
+          "properties": {
+            "noneArg": {
+              "description": "stuff",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      }
+    },
+    {
+      "function": {
+        "toolID": "testdata/TestToolRefAll/test.gpt:agentAssistant",
+        "name": "agent",
+        "parameters": {
+          "properties": {
+            "defaultPromptParameter": {
+              "description": "Prompt to send to the tool. This may be an instruction or question.",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      }
+    }
+  ],
+  "messages": [
+    {
+      "role": "system",
+      "content": [
+        {
+          "text": "\nContext Body\nMain tool"
+        }
+      ],
+      "usage": {}
+    }
+  ]
+}`

--- a/pkg/tests/testdata/TestToolRefAll/test.gpt
+++ b/pkg/tests/testdata/TestToolRefAll/test.gpt
@@ -1,0 +1,30 @@
+tools: tool, agentAssistant, context, none
+
+Main tool
+
+---
+name: agentAssistant
+type: agent
+
+Agent body
+
+---
+name: context
+type: context
+
+#!sys.echo
+
+Context Body
+
+---
+name: none
+param: noneArg: stuff
+
+Default type
+
+---
+name: tool
+type: Tool
+param: toolArg: stuff
+
+Typed tool

--- a/pkg/types/tool_test.go
+++ b/pkg/types/tool_test.go
@@ -33,6 +33,8 @@ func TestToolDef_String(t *testing.T) {
 			ExportInputFilters:  []string{"SharedFilter1", "SharedFilter2"},
 			OutputFilters:       []string{"Filter1", "Filter2"},
 			ExportOutputFilters: []string{"SharedFilter1", "SharedFilter2"},
+			ExportCredentials:   []string{"ExportCredential1", "ExportCredential2"},
+			Type:                ToolTypeContext,
 		},
 		Instructions: "This is a sample instruction",
 	}
@@ -41,6 +43,7 @@ func TestToolDef_String(t *testing.T) {
 Global Tools: GlobalTool1, GlobalTool2
 Name: Tool Sample
 Description: This is a sample tool
+Type: Context
 Agents: Agent1, Agent2
 Tools: Tool1, Tool2
 Share Tools: Export1, Export2
@@ -60,6 +63,8 @@ Parameter: arg2: desc2
 Internal Prompt: true
 Credential: Credential1
 Credential: Credential2
+Share Credential: ExportCredential1
+Share Credential: ExportCredential2
 Chat: true
 
 This is a sample instruction


### PR DESCRIPTION
This allows the tools field to reference tools, context tools, or agent
tools without using the context:, agent: fields.
