### PR TITLE
test: add smoke test based on examples/samples-readme.md

### DIFF
--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -59,6 +59,35 @@ jobs:
 
           echo "run_smoke_tests=false" >> $GITHUB_OUTPUT
 
+  gpt-4o-2024-08-06:
+    needs: check-label
+    if: ${{ needs.check-label.outputs.run_smoke_tests == 'true' }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout base repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - name: Checkout PR code if running for a PR
+        if: ${{ github.event_name == 'pull_request_target' }}
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+      - uses: actions/setup-go@v5
+        with:
+          cache: false
+          go-version: "1.21"
+      - env:
+          OPENAI_API_KEY: ${{ secrets.SMOKE_OPENAI_API_KEY }}
+          GPTSCRIPT_DEFAULT_MODEL: gpt-4o-2024-08-06
+        name: Run smoke test for gpt-4o-2024-08-06
+        run: |
+          echo "Running smoke test for model gpt-4o-2024-08-06"
+          export PATH="$(pwd)/bin:${PATH}"
+          make smoke
+
   gpt-4o-2024-05-13:
     needs: check-label
     if: ${{ needs.check-label.outputs.run_smoke_tests == 'true' }}

--- a/pkg/tests/judge/judge.go
+++ b/pkg/tests/judge/judge.go
@@ -84,10 +84,10 @@ func New[T any](client *openai.Client) (*Judge[T], error) {
 }
 
 func (j *Judge[T]) Equal(ctx context.Context, expected, actual T, criteria string) (equal bool, reasoning string, err error) {
-	comparisonJSON, err := json.MarshalIndent(&comparison[T]{
+	comparisonJSON, err := json.Marshal(&comparison[T]{
 		Expected: expected,
 		Actual:   actual,
-	}, "", "    ")
+	})
 	if err != nil {
 		return false, "", fmt.Errorf("failed to marshal judge testcase JSON: %w", err)
 	}

--- a/pkg/tests/judge/judge.go
+++ b/pkg/tests/judge/judge.go
@@ -40,6 +40,8 @@ After making a determination, respond with a JSON object that conforms to the fo
   ]
 }
 
+If you determine actual and expected are not equivalent, include a diff of the parts of actual and expected that are not equivalent in the reasoning field of your response.
+
 Your responses are concise and include only the json object described above.
 `
 

--- a/pkg/tests/smoke/smoke_test.go
+++ b/pkg/tests/smoke/smoke_test.go
@@ -175,6 +175,11 @@ func getActualEvents(t *testing.T, eventsFile string) []event {
 
 		var e event
 		require.NoError(t, json.Unmarshal([]byte(line), &e))
+
+		if e.Type == runner.EventTypeCallProgress {
+			continue
+		}
+
 		events = append(events, e)
 	}
 

--- a/pkg/tests/smoke/smoke_test.go
+++ b/pkg/tests/smoke/smoke_test.go
@@ -82,8 +82,8 @@ func TestSmoke(t *testing.T) {
 				expectedEvents,
 				actualEvents,
 				`
-- disregard differences in timestamps, generated IDs, natural language verbiage, and event order
-- omit callProgress events from the comparison
+- disregard differences in event order, timestamps, generated IDs, and natural language verbiage, grammar, and punctuation
+- compare events with matching event types
 - the overall stream of events and set of tools called should roughly match
 - arguments passed in tool calls should be roughly the same
 - the final callFinish event should be semantically similar

--- a/pkg/tests/smoke/testdata/Bob/claude-3-5-sonnet-20240620-expected.json
+++ b/pkg/tests/smoke/testdata/Bob/claude-3-5-sonnet-20240620-expected.json
@@ -1,13 +1,13 @@
 [
     {
-        "time": "2024-07-02T19:39:41.734737-04:00",
+        "time": "2024-08-23T11:56:53.66449-04:00",
         "type": "runStart",
         "usage": {}
     },
     {
-        "time": "2024-07-02T19:39:41.735252-04:00",
+        "time": "2024-08-23T11:56:53.665162-04:00",
         "callContext": {
-            "id": "1719963582",
+            "id": "1724428614",
             "tool": {
                 "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "internalPrompt": null,
@@ -41,14 +41,14 @@
         "usage": {}
     },
     {
-        "time": "2024-07-02T19:39:42.643066-04:00",
+        "time": "2024-08-23T11:56:54.68224-04:00",
         "type": "runStart",
         "usage": {}
     },
     {
-        "time": "2024-07-02T19:39:42.643356-04:00",
+        "time": "2024-08-23T11:56:54.682516-04:00",
         "callContext": {
-            "id": "1719963583",
+            "id": "1724428615",
             "tool": {
                 "name": "Anthropic Claude3 Model Provider",
                 "description": "Model provider for Anthropic hosted Claude3 models",
@@ -59,30 +59,30 @@
                     "github.com/gptscript-ai/credential as github.com/gptscript-ai/claude3-anthropic-provider/credential with \"Please enter your Anthropic API Key\" as message and token as field and \"ANTHROPIC_API_KEY\" as env"
                 ],
                 "instructions": "#!sys.daemon /usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/main.py",
-                "id": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/6b5a88075b1e4501e845f4dab5be16ea8739aa4c/tool.gpt:Anthropic Claude3 Model Provider",
+                "id": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/ee5c02a9aeca5a1cbffcf569751e37432bfe0344/tool.gpt:Anthropic Claude3 Model Provider",
                 "toolMapping": {
                     "github.com/gptscript-ai/credential as github.com/gptscript-ai/claude3-anthropic-provider/credential with \"Please enter your Anthropic API Key\" as message and token as field and \"ANTHROPIC_API_KEY\" as env": [
                         {
                             "reference": "github.com/gptscript-ai/credential as github.com/gptscript-ai/claude3-anthropic-provider/credential with \"Please enter your Anthropic API Key\" as message and token as field and \"ANTHROPIC_API_KEY\" as env",
-                            "toolID": "https://raw.githubusercontent.com/gptscript-ai/credential/651dfad6e7cf3a385ef408afa93ce522c10f8508/tool.gpt:token"
+                            "toolID": "https://raw.githubusercontent.com/gptscript-ai/credential/37e5f870e195b896438c0bc35867403a42f82e89/tool.gpt:token"
                         }
                     ]
                 },
                 "localTools": {
-                    "anthropic claude3 model provider": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/6b5a88075b1e4501e845f4dab5be16ea8739aa4c/tool.gpt:Anthropic Claude3 Model Provider"
+                    "anthropic claude3 model provider": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/ee5c02a9aeca5a1cbffcf569751e37432bfe0344/tool.gpt:Anthropic Claude3 Model Provider"
                 },
                 "source": {
-                    "location": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/6b5a88075b1e4501e845f4dab5be16ea8739aa4c/tool.gpt",
+                    "location": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/ee5c02a9aeca5a1cbffcf569751e37432bfe0344/tool.gpt",
                     "lineNo": 1,
                     "repo": {
                         "VCS": "git",
                         "Root": "https://github.com/gptscript-ai/claude3-anthropic-provider.git",
                         "Path": "/",
                         "Name": "tool.gpt",
-                        "Revision": "6b5a88075b1e4501e845f4dab5be16ea8739aa4c"
+                        "Revision": "ee5c02a9aeca5a1cbffcf569751e37432bfe0344"
                     }
                 },
-                "workingDir": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/6b5a88075b1e4501e845f4dab5be16ea8739aa4c"
+                "workingDir": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/ee5c02a9aeca5a1cbffcf569751e37432bfe0344"
             },
             "currentAgent": {},
             "inputContext": null,
@@ -93,9 +93,9 @@
         "usage": {}
     },
     {
-        "time": "2024-07-02T19:39:43.666188-04:00",
+        "time": "2024-08-23T11:56:55.69666-04:00",
         "callContext": {
-            "id": "1719963583",
+            "id": "1724428615",
             "tool": {
                 "name": "Anthropic Claude3 Model Provider",
                 "description": "Model provider for Anthropic hosted Claude3 models",
@@ -106,30 +106,30 @@
                     "github.com/gptscript-ai/credential as github.com/gptscript-ai/claude3-anthropic-provider/credential with \"Please enter your Anthropic API Key\" as message and token as field and \"ANTHROPIC_API_KEY\" as env"
                 ],
                 "instructions": "#!sys.daemon /usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/main.py",
-                "id": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/6b5a88075b1e4501e845f4dab5be16ea8739aa4c/tool.gpt:Anthropic Claude3 Model Provider",
+                "id": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/ee5c02a9aeca5a1cbffcf569751e37432bfe0344/tool.gpt:Anthropic Claude3 Model Provider",
                 "toolMapping": {
                     "github.com/gptscript-ai/credential as github.com/gptscript-ai/claude3-anthropic-provider/credential with \"Please enter your Anthropic API Key\" as message and token as field and \"ANTHROPIC_API_KEY\" as env": [
                         {
                             "reference": "github.com/gptscript-ai/credential as github.com/gptscript-ai/claude3-anthropic-provider/credential with \"Please enter your Anthropic API Key\" as message and token as field and \"ANTHROPIC_API_KEY\" as env",
-                            "toolID": "https://raw.githubusercontent.com/gptscript-ai/credential/651dfad6e7cf3a385ef408afa93ce522c10f8508/tool.gpt:token"
+                            "toolID": "https://raw.githubusercontent.com/gptscript-ai/credential/37e5f870e195b896438c0bc35867403a42f82e89/tool.gpt:token"
                         }
                     ]
                 },
                 "localTools": {
-                    "anthropic claude3 model provider": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/6b5a88075b1e4501e845f4dab5be16ea8739aa4c/tool.gpt:Anthropic Claude3 Model Provider"
+                    "anthropic claude3 model provider": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/ee5c02a9aeca5a1cbffcf569751e37432bfe0344/tool.gpt:Anthropic Claude3 Model Provider"
                 },
                 "source": {
-                    "location": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/6b5a88075b1e4501e845f4dab5be16ea8739aa4c/tool.gpt",
+                    "location": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/ee5c02a9aeca5a1cbffcf569751e37432bfe0344/tool.gpt",
                     "lineNo": 1,
                     "repo": {
                         "VCS": "git",
                         "Root": "https://github.com/gptscript-ai/claude3-anthropic-provider.git",
                         "Path": "/",
                         "Name": "tool.gpt",
-                        "Revision": "6b5a88075b1e4501e845f4dab5be16ea8739aa4c"
+                        "Revision": "ee5c02a9aeca5a1cbffcf569751e37432bfe0344"
                     }
                 },
-                "workingDir": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/6b5a88075b1e4501e845f4dab5be16ea8739aa4c"
+                "workingDir": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/ee5c02a9aeca5a1cbffcf569751e37432bfe0344"
             },
             "currentAgent": {},
             "inputContext": null,
@@ -138,17 +138,17 @@
         },
         "type": "callFinish",
         "usage": {},
-        "content": "http://127.0.0.1:10887"
+        "content": "http://127.0.0.1:10797"
     },
     {
-        "time": "2024-07-02T19:39:43.666385-04:00",
+        "time": "2024-08-23T11:56:55.696858-04:00",
         "type": "runFinish",
         "usage": {}
     },
     {
-        "time": "2024-07-02T19:39:43.666475-04:00",
+        "time": "2024-08-23T11:56:55.696913-04:00",
         "callContext": {
-            "id": "1719963582",
+            "id": "1724428614",
             "tool": {
                 "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "internalPrompt": null,
@@ -179,7 +179,7 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1719963584",
+        "chatCompletionId": "1724428616",
         "usage": {},
         "chatRequest": {
             "model": "claude-3-5-sonnet-20240620",
@@ -211,85 +211,9 @@
         }
     },
     {
-        "time": "2024-07-02T19:39:43.66707-04:00",
+        "time": "2024-08-23T11:56:59.400506-04:00",
         "callContext": {
-            "id": "1719963582",
-            "tool": {
-                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "currentAgent": {},
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1719963584",
-        "usage": {},
-        "content": "Waiting for model response..."
-    },
-    {
-        "time": "2024-07-02T19:39:45.331397-04:00",
-        "callContext": {
-            "id": "1719963582",
-            "tool": {
-                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "currentAgent": {},
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1719963584",
-        "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\"question\": \"how are you doing\"}"
-    },
-    {
-        "time": "2024-07-02T19:39:45.332721-04:00",
-        "callContext": {
-            "id": "1719963582",
+            "id": "1724428614",
             "tool": {
                 "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "internalPrompt": null,
@@ -320,7 +244,7 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1719963584",
+        "chatCompletionId": "1724428616",
         "usage": {},
         "chatResponse": {
             "role": "assistant",
@@ -328,7 +252,7 @@
                 {
                     "toolCall": {
                         "index": 0,
-                        "id": "toolu_01XLGhfvziYUf8rFoQEbvw4P",
+                        "id": "toolu_01RvNTnUzwXhpBumHEACT4Qo",
                         "function": {
                             "name": "bob",
                             "arguments": "{\"question\": \"how are you doing\"}"
@@ -340,9 +264,9 @@
         }
     },
     {
-        "time": "2024-07-02T19:39:45.332824-04:00",
+        "time": "2024-08-23T11:56:59.400599-04:00",
         "callContext": {
-            "id": "1719963582",
+            "id": "1724428614",
             "tool": {
                 "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "internalPrompt": null,
@@ -373,7 +297,7 @@
             "inputContext": null
         },
         "toolSubCalls": {
-            "toolu_01XLGhfvziYUf8rFoQEbvw4P": {
+            "toolu_01RvNTnUzwXhpBumHEACT4Qo": {
                 "toolID": "testdata/Bob/test.gpt:bob",
                 "input": "{\"question\": \"how are you doing\"}"
             }
@@ -382,9 +306,9 @@
         "usage": {}
     },
     {
-        "time": "2024-07-02T19:39:45.332869-04:00",
+        "time": "2024-08-23T11:56:59.400645-04:00",
         "callContext": {
-            "id": "toolu_01XLGhfvziYUf8rFoQEbvw4P",
+            "id": "toolu_01RvNTnUzwXhpBumHEACT4Qo",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -399,7 +323,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${QUESTION}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -414,16 +338,16 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1719963582"
+            "parentID": "1724428614"
         },
         "type": "callStart",
         "usage": {},
         "content": "{\"question\": \"how are you doing\"}"
     },
     {
-        "time": "2024-07-02T19:39:45.487113-04:00",
+        "time": "2024-08-23T11:56:59.66279-04:00",
         "callContext": {
-            "id": "toolu_01XLGhfvziYUf8rFoQEbvw4P",
+            "id": "toolu_01RvNTnUzwXhpBumHEACT4Qo",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -438,7 +362,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${QUESTION}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -453,17 +377,17 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1719963582"
+            "parentID": "1724428614"
         },
         "type": "callChat",
-        "chatCompletionId": "1719963585",
+        "chatCompletionId": "1724428617",
         "usage": {},
         "chatRequest": {
             "model": "claude-3-5-sonnet-20240620",
             "messages": [
                 {
                     "role": "system",
-                    "content": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\""
+                    "content": "When asked how I am doing, respond with exactly \"Thanks for asking \"${QUESTION}\", I'm doing great fellow friendly AI tool!\""
                 },
                 {
                     "role": "user",
@@ -474,9 +398,9 @@
         }
     },
     {
-        "time": "2024-07-02T19:39:45.487696-04:00",
+        "time": "2024-08-23T11:57:01.055866-04:00",
         "callContext": {
-            "id": "toolu_01XLGhfvziYUf8rFoQEbvw4P",
+            "id": "toolu_01RvNTnUzwXhpBumHEACT4Qo",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -491,7 +415,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${QUESTION}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -506,90 +430,10 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1719963582"
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1719963585",
-        "usage": {},
-        "content": "Waiting for model response..."
-    },
-    {
-        "time": "2024-07-02T19:39:46.547634-04:00",
-        "callContext": {
-            "id": "toolu_01XLGhfvziYUf8rFoQEbvw4P",
-            "tool": {
-                "name": "bob",
-                "description": "I'm Bob, a friendly guy.",
-                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "question": {
-                            "description": "The question to ask Bob.",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
-                "id": "testdata/Bob/test.gpt:bob",
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 6
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "currentAgent": {},
-            "inputContext": null,
-            "toolName": "bob",
-            "parentID": "1719963582"
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1719963585",
-        "usage": {},
-        "content": "Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI tool!"
-    },
-    {
-        "time": "2024-07-02T19:39:46.549112-04:00",
-        "callContext": {
-            "id": "toolu_01XLGhfvziYUf8rFoQEbvw4P",
-            "tool": {
-                "name": "bob",
-                "description": "I'm Bob, a friendly guy.",
-                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "question": {
-                            "description": "The question to ask Bob.",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
-                "id": "testdata/Bob/test.gpt:bob",
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 6
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "currentAgent": {},
-            "inputContext": null,
-            "toolName": "bob",
-            "parentID": "1719963582"
+            "parentID": "1724428614"
         },
         "type": "callChat",
-        "chatCompletionId": "1719963585",
+        "chatCompletionId": "1724428617",
         "usage": {},
         "chatResponse": {
             "role": "assistant",
@@ -602,9 +446,9 @@
         }
     },
     {
-        "time": "2024-07-02T19:39:46.549192-04:00",
+        "time": "2024-08-23T11:57:01.055916-04:00",
         "callContext": {
-            "id": "toolu_01XLGhfvziYUf8rFoQEbvw4P",
+            "id": "toolu_01RvNTnUzwXhpBumHEACT4Qo",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -619,7 +463,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${QUESTION}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -634,16 +478,16 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1719963582"
+            "parentID": "1724428614"
         },
         "type": "callFinish",
         "usage": {},
         "content": "Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI tool!"
     },
     {
-        "time": "2024-07-02T19:39:46.549253-04:00",
+        "time": "2024-08-23T11:57:01.055981-04:00",
         "callContext": {
-            "id": "1719963582",
+            "id": "1724428614",
             "tool": {
                 "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "internalPrompt": null,
@@ -678,9 +522,9 @@
         "usage": {}
     },
     {
-        "time": "2024-07-02T19:39:46.710406-04:00",
+        "time": "2024-08-23T11:57:01.287438-04:00",
         "callContext": {
-            "id": "1719963582",
+            "id": "1724428614",
             "tool": {
                 "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "internalPrompt": null,
@@ -711,7 +555,7 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1719963586",
+        "chatCompletionId": "1724428618",
         "usage": {},
         "chatRequest": {
             "model": "claude-3-5-sonnet-20240620",
@@ -725,7 +569,7 @@
                     "content": "",
                     "tool_calls": [
                         {
-                            "id": "toolu_01XLGhfvziYUf8rFoQEbvw4P",
+                            "id": "toolu_01RvNTnUzwXhpBumHEACT4Qo",
                             "type": "function",
                             "function": {
                                 "name": "bob",
@@ -738,7 +582,7 @@
                     "role": "tool",
                     "content": "Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI tool!",
                     "name": "bob",
-                    "tool_call_id": "toolu_01XLGhfvziYUf8rFoQEbvw4P"
+                    "tool_call_id": "toolu_01RvNTnUzwXhpBumHEACT4Qo"
                 }
             ],
             "temperature": 0,
@@ -763,85 +607,9 @@
         }
     },
     {
-        "time": "2024-07-02T19:39:46.710675-04:00",
+        "time": "2024-08-23T11:57:02.411152-04:00",
         "callContext": {
-            "id": "1719963582",
-            "tool": {
-                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "currentAgent": {},
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1719963586",
-        "usage": {},
-        "content": "Waiting for model response..."
-    },
-    {
-        "time": "2024-07-02T19:39:48.861353-04:00",
-        "callContext": {
-            "id": "1719963582",
-            "tool": {
-                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "currentAgent": {},
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1719963586",
-        "usage": {},
-        "content": "Bob's reply to the question \"how are you doing\" is:\n\n\"Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI tool!\"\n\nI have repeated his reply exactly as requested."
-    },
-    {
-        "time": "2024-07-02T19:39:48.862116-04:00",
-        "callContext": {
-            "id": "1719963582",
+            "id": "1724428614",
             "tool": {
                 "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "internalPrompt": null,
@@ -872,22 +640,22 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1719963586",
+        "chatCompletionId": "1724428618",
         "usage": {},
         "chatResponse": {
             "role": "assistant",
             "content": [
                 {
-                    "text": "Bob's reply to the question \"how are you doing\" is:\n\n\"Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI tool!\"\n\nI have repeated his reply exactly as requested."
+                    "text": "Bob's reply was: \"Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI tool!\""
                 }
             ],
             "usage": {}
         }
     },
     {
-        "time": "2024-07-02T19:39:48.862154-04:00",
+        "time": "2024-08-23T11:57:02.411186-04:00",
         "callContext": {
-            "id": "1719963582",
+            "id": "1724428614",
             "tool": {
                 "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "internalPrompt": null,
@@ -919,10 +687,10 @@
         },
         "type": "callFinish",
         "usage": {},
-        "content": "Bob's reply to the question \"how are you doing\" is:\n\n\"Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI tool!\"\n\nI have repeated his reply exactly as requested."
+        "content": "Bob's reply was: \"Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI tool!\""
     },
     {
-        "time": "2024-07-02T19:39:48.862164-04:00",
+        "time": "2024-08-23T11:57:02.411205-04:00",
         "type": "runFinish",
         "usage": {}
     }

--- a/pkg/tests/smoke/testdata/Bob/gpt-4o-2024-05-13-expected.json
+++ b/pkg/tests/smoke/testdata/Bob/gpt-4o-2024-05-13-expected.json
@@ -1,13 +1,13 @@
 [
     {
-        "time": "2024-06-20T16:58:11.3174-04:00",
+        "time": "2024-08-23T10:52:21.524039-04:00",
         "type": "runStart",
         "usage": {}
     },
     {
-        "time": "2024-06-20T16:58:11.317644-04:00",
+        "time": "2024-08-23T10:52:21.524345-04:00",
         "callContext": {
-            "id": "1718917092",
+            "id": "1724424742",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
@@ -34,15 +34,16 @@
                 },
                 "workingDir": "testdata/Bob"
             },
+            "currentAgent": {},
             "inputContext": null
         },
         "type": "callStart",
         "usage": {}
     },
     {
-        "time": "2024-06-20T16:58:11.638778-04:00",
+        "time": "2024-08-23T10:52:21.524388-04:00",
         "callContext": {
-            "id": "1718917092",
+            "id": "1724424742",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
@@ -69,10 +70,11 @@
                 },
                 "workingDir": "testdata/Bob"
             },
+            "currentAgent": {},
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1718917093",
+        "chatCompletionId": "1724424743",
         "usage": {},
         "chatRequest": {
             "model": "gpt-4o-2024-05-13",
@@ -104,9 +106,9 @@
         }
     },
     {
-        "time": "2024-06-20T16:58:11.639016-04:00",
+        "time": "2024-08-23T10:52:22.05589-04:00",
         "callContext": {
-            "id": "1718917092",
+            "id": "1724424742",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
@@ -133,454 +135,11 @@
                 },
                 "workingDir": "testdata/Bob"
             },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917093",
-        "usage": {},
-        "content": "Waiting for model response..."
-    },
-    {
-        "time": "2024-06-20T16:58:12.564724-04:00",
-        "callContext": {
-            "id": "1718917092",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917093",
-        "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\""
-    },
-    {
-        "time": "2024-06-20T16:58:12.564911-04:00",
-        "callContext": {
-            "id": "1718917092",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917093",
-        "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\"question"
-    },
-    {
-        "time": "2024-06-20T16:58:12.564948-04:00",
-        "callContext": {
-            "id": "1718917092",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917093",
-        "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\"question"
-    },
-    {
-        "time": "2024-06-20T16:58:12.56497-04:00",
-        "callContext": {
-            "id": "1718917092",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917093",
-        "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\""
-    },
-    {
-        "time": "2024-06-20T16:58:12.564995-04:00",
-        "callContext": {
-            "id": "1718917092",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917093",
-        "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"how"
-    },
-    {
-        "time": "2024-06-20T16:58:12.565045-04:00",
-        "callContext": {
-            "id": "1718917092",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917093",
-        "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"how are you"
-    },
-    {
-        "time": "2024-06-20T16:58:12.565071-04:00",
-        "callContext": {
-            "id": "1718917092",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917093",
-        "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"how are you"
-    },
-    {
-        "time": "2024-06-20T16:58:12.565112-04:00",
-        "callContext": {
-            "id": "1718917092",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917093",
-        "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"how are you doing\"}"
-    },
-    {
-        "time": "2024-06-20T16:58:12.565137-04:00",
-        "callContext": {
-            "id": "1718917092",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917093",
-        "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"how are you doing\"}"
-    },
-    {
-        "time": "2024-06-20T16:58:12.56516-04:00",
-        "callContext": {
-            "id": "1718917092",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917093",
-        "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"how are you doing\"}"
-    },
-    {
-        "time": "2024-06-20T16:58:12.565176-04:00",
-        "callContext": {
-            "id": "1718917092",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917093",
-        "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"how are you doing\"}"
-    },
-    {
-        "time": "2024-06-20T16:58:12.565397-04:00",
-        "callContext": {
-            "id": "1718917092",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
+            "currentAgent": {},
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1718917093",
+        "chatCompletionId": "1724424743",
         "usage": {
             "promptTokens": 138,
             "completionTokens": 17,
@@ -592,7 +151,7 @@
                 {
                     "toolCall": {
                         "index": 0,
-                        "id": "call_rTx93wiIASDA8uk8XHwjVmCC",
+                        "id": "call_llqga49DSQM9Ftf9vMhk0qac",
                         "function": {
                             "name": "bob",
                             "arguments": "{\"question\":\"how are you doing\"}"
@@ -608,9 +167,9 @@
         }
     },
     {
-        "time": "2024-06-20T16:58:12.565644-04:00",
+        "time": "2024-08-23T10:52:22.05621-04:00",
         "callContext": {
-            "id": "1718917092",
+            "id": "1724424742",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
@@ -637,10 +196,11 @@
                 },
                 "workingDir": "testdata/Bob"
             },
+            "currentAgent": {},
             "inputContext": null
         },
         "toolSubCalls": {
-            "call_rTx93wiIASDA8uk8XHwjVmCC": {
+            "call_llqga49DSQM9Ftf9vMhk0qac": {
                 "toolID": "testdata/Bob/test.gpt:bob",
                 "input": "{\"question\":\"how are you doing\"}"
             }
@@ -649,9 +209,9 @@
         "usage": {}
     },
     {
-        "time": "2024-06-20T16:58:12.565728-04:00",
+        "time": "2024-08-23T10:52:22.056372-04:00",
         "callContext": {
-            "id": "call_rTx93wiIASDA8uk8XHwjVmCC",
+            "id": "call_llqga49DSQM9Ftf9vMhk0qac",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -666,7 +226,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${QUESTION}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -678,18 +238,19 @@
                 },
                 "workingDir": "testdata/Bob"
             },
+            "currentAgent": {},
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1718917092"
+            "parentID": "1724424742"
         },
         "type": "callStart",
         "usage": {},
         "content": "{\"question\":\"how are you doing\"}"
     },
     {
-        "time": "2024-06-20T16:58:12.72779-04:00",
+        "time": "2024-08-23T10:52:22.056577-04:00",
         "callContext": {
-            "id": "call_rTx93wiIASDA8uk8XHwjVmCC",
+            "id": "call_llqga49DSQM9Ftf9vMhk0qac",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -704,7 +265,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${QUESTION}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -716,19 +277,20 @@
                 },
                 "workingDir": "testdata/Bob"
             },
+            "currentAgent": {},
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1718917092"
+            "parentID": "1724424742"
         },
         "type": "callChat",
-        "chatCompletionId": "1718917094",
+        "chatCompletionId": "1724424744",
         "usage": {},
         "chatRequest": {
             "model": "gpt-4o-2024-05-13",
             "messages": [
                 {
                     "role": "system",
-                    "content": "\nYou are task oriented system.\nYou receive input from a user, process the input from the given instructions, and then output the result.\nYour objective is to provide consistent and correct results.\nYou do not need to explain the steps taken, only provide the result to the given instructions.\nYou are referred to as a tool.\nYou don't move to the next step until you have a result.\n\nWhen asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\""
+                    "content": "\nYou are task oriented system.\nYou receive input from a user, process the input from the given instructions, and then output the result.\nYour objective is to provide consistent and correct results.\nYou do not need to explain the steps taken, only provide the result to the given instructions.\nYou are referred to as a tool.\nYou don't move to the next step until you have a result.\n\nWhen asked how I am doing, respond with exactly \"Thanks for asking \"${QUESTION}\", I'm doing great fellow friendly AI tool!\""
                 },
                 {
                     "role": "user",
@@ -739,9 +301,9 @@
         }
     },
     {
-        "time": "2024-06-20T16:58:12.728069-04:00",
+        "time": "2024-08-23T10:52:22.505872-04:00",
         "callContext": {
-            "id": "call_rTx93wiIASDA8uk8XHwjVmCC",
+            "id": "call_llqga49DSQM9Ftf9vMhk0qac",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -756,7 +318,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${QUESTION}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -768,830 +330,13 @@
                 },
                 "workingDir": "testdata/Bob"
             },
+            "currentAgent": {},
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1718917092"
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917094",
-        "usage": {},
-        "content": "Waiting for model response..."
-    },
-    {
-        "time": "2024-06-20T16:58:13.077264-04:00",
-        "callContext": {
-            "id": "call_rTx93wiIASDA8uk8XHwjVmCC",
-            "tool": {
-                "name": "bob",
-                "description": "I'm Bob, a friendly guy.",
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "question": {
-                            "description": "The question to ask Bob.",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
-                "id": "testdata/Bob/test.gpt:bob",
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 6
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null,
-            "toolName": "bob",
-            "parentID": "1718917092"
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917094",
-        "usage": {}
-    },
-    {
-        "time": "2024-06-20T16:58:13.077534-04:00",
-        "callContext": {
-            "id": "call_rTx93wiIASDA8uk8XHwjVmCC",
-            "tool": {
-                "name": "bob",
-                "description": "I'm Bob, a friendly guy.",
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "question": {
-                            "description": "The question to ask Bob.",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
-                "id": "testdata/Bob/test.gpt:bob",
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 6
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null,
-            "toolName": "bob",
-            "parentID": "1718917092"
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917094",
-        "usage": {},
-        "content": "Thanks"
-    },
-    {
-        "time": "2024-06-20T16:58:13.134723-04:00",
-        "callContext": {
-            "id": "call_rTx93wiIASDA8uk8XHwjVmCC",
-            "tool": {
-                "name": "bob",
-                "description": "I'm Bob, a friendly guy.",
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "question": {
-                            "description": "The question to ask Bob.",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
-                "id": "testdata/Bob/test.gpt:bob",
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 6
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null,
-            "toolName": "bob",
-            "parentID": "1718917092"
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917094",
-        "usage": {},
-        "content": "Thanks for asking"
-    },
-    {
-        "time": "2024-06-20T16:58:13.134893-04:00",
-        "callContext": {
-            "id": "call_rTx93wiIASDA8uk8XHwjVmCC",
-            "tool": {
-                "name": "bob",
-                "description": "I'm Bob, a friendly guy.",
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "question": {
-                            "description": "The question to ask Bob.",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
-                "id": "testdata/Bob/test.gpt:bob",
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 6
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null,
-            "toolName": "bob",
-            "parentID": "1718917092"
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917094",
-        "usage": {},
-        "content": "Thanks for asking"
-    },
-    {
-        "time": "2024-06-20T16:58:13.230591-04:00",
-        "callContext": {
-            "id": "call_rTx93wiIASDA8uk8XHwjVmCC",
-            "tool": {
-                "name": "bob",
-                "description": "I'm Bob, a friendly guy.",
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "question": {
-                            "description": "The question to ask Bob.",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
-                "id": "testdata/Bob/test.gpt:bob",
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 6
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null,
-            "toolName": "bob",
-            "parentID": "1718917092"
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917094",
-        "usage": {},
-        "content": "Thanks for asking \"how"
-    },
-    {
-        "time": "2024-06-20T16:58:13.230667-04:00",
-        "callContext": {
-            "id": "call_rTx93wiIASDA8uk8XHwjVmCC",
-            "tool": {
-                "name": "bob",
-                "description": "I'm Bob, a friendly guy.",
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "question": {
-                            "description": "The question to ask Bob.",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
-                "id": "testdata/Bob/test.gpt:bob",
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 6
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null,
-            "toolName": "bob",
-            "parentID": "1718917092"
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917094",
-        "usage": {},
-        "content": "Thanks for asking \"how"
-    },
-    {
-        "time": "2024-06-20T16:58:13.246344-04:00",
-        "callContext": {
-            "id": "call_rTx93wiIASDA8uk8XHwjVmCC",
-            "tool": {
-                "name": "bob",
-                "description": "I'm Bob, a friendly guy.",
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "question": {
-                            "description": "The question to ask Bob.",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
-                "id": "testdata/Bob/test.gpt:bob",
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 6
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null,
-            "toolName": "bob",
-            "parentID": "1718917092"
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917094",
-        "usage": {},
-        "content": "Thanks for asking \"how are you"
-    },
-    {
-        "time": "2024-06-20T16:58:13.246468-04:00",
-        "callContext": {
-            "id": "call_rTx93wiIASDA8uk8XHwjVmCC",
-            "tool": {
-                "name": "bob",
-                "description": "I'm Bob, a friendly guy.",
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "question": {
-                            "description": "The question to ask Bob.",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
-                "id": "testdata/Bob/test.gpt:bob",
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 6
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null,
-            "toolName": "bob",
-            "parentID": "1718917092"
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917094",
-        "usage": {},
-        "content": "Thanks for asking \"how are you doing"
-    },
-    {
-        "time": "2024-06-20T16:58:13.246531-04:00",
-        "callContext": {
-            "id": "call_rTx93wiIASDA8uk8XHwjVmCC",
-            "tool": {
-                "name": "bob",
-                "description": "I'm Bob, a friendly guy.",
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "question": {
-                            "description": "The question to ask Bob.",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
-                "id": "testdata/Bob/test.gpt:bob",
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 6
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null,
-            "toolName": "bob",
-            "parentID": "1718917092"
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917094",
-        "usage": {},
-        "content": "Thanks for asking \"how are you doing"
-    },
-    {
-        "time": "2024-06-20T16:58:13.246592-04:00",
-        "callContext": {
-            "id": "call_rTx93wiIASDA8uk8XHwjVmCC",
-            "tool": {
-                "name": "bob",
-                "description": "I'm Bob, a friendly guy.",
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "question": {
-                            "description": "The question to ask Bob.",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
-                "id": "testdata/Bob/test.gpt:bob",
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 6
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null,
-            "toolName": "bob",
-            "parentID": "1718917092"
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917094",
-        "usage": {},
-        "content": "Thanks for asking \"how are you doing\", I'm"
-    },
-    {
-        "time": "2024-06-20T16:58:13.246645-04:00",
-        "callContext": {
-            "id": "call_rTx93wiIASDA8uk8XHwjVmCC",
-            "tool": {
-                "name": "bob",
-                "description": "I'm Bob, a friendly guy.",
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "question": {
-                            "description": "The question to ask Bob.",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
-                "id": "testdata/Bob/test.gpt:bob",
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 6
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null,
-            "toolName": "bob",
-            "parentID": "1718917092"
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917094",
-        "usage": {},
-        "content": "Thanks for asking \"how are you doing\", I'm doing"
-    },
-    {
-        "time": "2024-06-20T16:58:13.246736-04:00",
-        "callContext": {
-            "id": "call_rTx93wiIASDA8uk8XHwjVmCC",
-            "tool": {
-                "name": "bob",
-                "description": "I'm Bob, a friendly guy.",
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "question": {
-                            "description": "The question to ask Bob.",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
-                "id": "testdata/Bob/test.gpt:bob",
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 6
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null,
-            "toolName": "bob",
-            "parentID": "1718917092"
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917094",
-        "usage": {},
-        "content": "Thanks for asking \"how are you doing\", I'm doing great"
-    },
-    {
-        "time": "2024-06-20T16:58:13.246796-04:00",
-        "callContext": {
-            "id": "call_rTx93wiIASDA8uk8XHwjVmCC",
-            "tool": {
-                "name": "bob",
-                "description": "I'm Bob, a friendly guy.",
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "question": {
-                            "description": "The question to ask Bob.",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
-                "id": "testdata/Bob/test.gpt:bob",
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 6
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null,
-            "toolName": "bob",
-            "parentID": "1718917092"
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917094",
-        "usage": {},
-        "content": "Thanks for asking \"how are you doing\", I'm doing great"
-    },
-    {
-        "time": "2024-06-20T16:58:13.30169-04:00",
-        "callContext": {
-            "id": "call_rTx93wiIASDA8uk8XHwjVmCC",
-            "tool": {
-                "name": "bob",
-                "description": "I'm Bob, a friendly guy.",
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "question": {
-                            "description": "The question to ask Bob.",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
-                "id": "testdata/Bob/test.gpt:bob",
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 6
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null,
-            "toolName": "bob",
-            "parentID": "1718917092"
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917094",
-        "usage": {},
-        "content": "Thanks for asking \"how are you doing\", I'm doing great fellow friendly"
-    },
-    {
-        "time": "2024-06-20T16:58:13.301837-04:00",
-        "callContext": {
-            "id": "call_rTx93wiIASDA8uk8XHwjVmCC",
-            "tool": {
-                "name": "bob",
-                "description": "I'm Bob, a friendly guy.",
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "question": {
-                            "description": "The question to ask Bob.",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
-                "id": "testdata/Bob/test.gpt:bob",
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 6
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null,
-            "toolName": "bob",
-            "parentID": "1718917092"
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917094",
-        "usage": {},
-        "content": "Thanks for asking \"how are you doing\", I'm doing great fellow friendly"
-    },
-    {
-        "time": "2024-06-20T16:58:13.31565-04:00",
-        "callContext": {
-            "id": "call_rTx93wiIASDA8uk8XHwjVmCC",
-            "tool": {
-                "name": "bob",
-                "description": "I'm Bob, a friendly guy.",
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "question": {
-                            "description": "The question to ask Bob.",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
-                "id": "testdata/Bob/test.gpt:bob",
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 6
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null,
-            "toolName": "bob",
-            "parentID": "1718917092"
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917094",
-        "usage": {},
-        "content": "Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI tool"
-    },
-    {
-        "time": "2024-06-20T16:58:13.315798-04:00",
-        "callContext": {
-            "id": "call_rTx93wiIASDA8uk8XHwjVmCC",
-            "tool": {
-                "name": "bob",
-                "description": "I'm Bob, a friendly guy.",
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "question": {
-                            "description": "The question to ask Bob.",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
-                "id": "testdata/Bob/test.gpt:bob",
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 6
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null,
-            "toolName": "bob",
-            "parentID": "1718917092"
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917094",
-        "usage": {},
-        "content": "Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI tool!"
-    },
-    {
-        "time": "2024-06-20T16:58:13.315842-04:00",
-        "callContext": {
-            "id": "call_rTx93wiIASDA8uk8XHwjVmCC",
-            "tool": {
-                "name": "bob",
-                "description": "I'm Bob, a friendly guy.",
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "question": {
-                            "description": "The question to ask Bob.",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
-                "id": "testdata/Bob/test.gpt:bob",
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 6
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null,
-            "toolName": "bob",
-            "parentID": "1718917092"
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917094",
-        "usage": {},
-        "content": "Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI tool!"
-    },
-    {
-        "time": "2024-06-20T16:58:13.315879-04:00",
-        "callContext": {
-            "id": "call_rTx93wiIASDA8uk8XHwjVmCC",
-            "tool": {
-                "name": "bob",
-                "description": "I'm Bob, a friendly guy.",
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "question": {
-                            "description": "The question to ask Bob.",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
-                "id": "testdata/Bob/test.gpt:bob",
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 6
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null,
-            "toolName": "bob",
-            "parentID": "1718917092"
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917094",
-        "usage": {},
-        "content": "Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI tool!"
-    },
-    {
-        "time": "2024-06-20T16:58:13.315951-04:00",
-        "callContext": {
-            "id": "call_rTx93wiIASDA8uk8XHwjVmCC",
-            "tool": {
-                "name": "bob",
-                "description": "I'm Bob, a friendly guy.",
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "question": {
-                            "description": "The question to ask Bob.",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
-                "id": "testdata/Bob/test.gpt:bob",
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 6
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null,
-            "toolName": "bob",
-            "parentID": "1718917092"
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917094",
-        "usage": {},
-        "content": "Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI tool!"
-    },
-    {
-        "time": "2024-06-20T16:58:13.316055-04:00",
-        "callContext": {
-            "id": "call_rTx93wiIASDA8uk8XHwjVmCC",
-            "tool": {
-                "name": "bob",
-                "description": "I'm Bob, a friendly guy.",
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "question": {
-                            "description": "The question to ask Bob.",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
-                "id": "testdata/Bob/test.gpt:bob",
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 6
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null,
-            "toolName": "bob",
-            "parentID": "1718917092"
+            "parentID": "1724424742"
         },
         "type": "callChat",
-        "chatCompletionId": "1718917094",
+        "chatCompletionId": "1724424744",
         "usage": {
             "promptTokens": 122,
             "completionTokens": 17,
@@ -1612,9 +357,9 @@
         }
     },
     {
-        "time": "2024-06-20T16:58:13.316115-04:00",
+        "time": "2024-08-23T10:52:22.505998-04:00",
         "callContext": {
-            "id": "call_rTx93wiIASDA8uk8XHwjVmCC",
+            "id": "call_llqga49DSQM9Ftf9vMhk0qac",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -1629,7 +374,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${QUESTION}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -1641,18 +386,19 @@
                 },
                 "workingDir": "testdata/Bob"
             },
+            "currentAgent": {},
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1718917092"
+            "parentID": "1724424742"
         },
         "type": "callFinish",
         "usage": {},
         "content": "Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI tool!"
     },
     {
-        "time": "2024-06-20T16:58:13.316171-04:00",
+        "time": "2024-08-23T10:52:22.506086-04:00",
         "callContext": {
-            "id": "1718917092",
+            "id": "1724424742",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
@@ -1679,6 +425,7 @@
                 },
                 "workingDir": "testdata/Bob"
             },
+            "currentAgent": {},
             "inputContext": null
         },
         "toolResults": 1,
@@ -1686,9 +433,9 @@
         "usage": {}
     },
     {
-        "time": "2024-06-20T16:58:13.533625-04:00",
+        "time": "2024-08-23T10:52:22.50621-04:00",
         "callContext": {
-            "id": "1718917092",
+            "id": "1724424742",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
@@ -1715,10 +462,11 @@
                 },
                 "workingDir": "testdata/Bob"
             },
+            "currentAgent": {},
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1718917095",
+        "chatCompletionId": "1724424745",
         "usage": {},
         "chatRequest": {
             "model": "gpt-4o-2024-05-13",
@@ -1732,7 +480,7 @@
                     "content": "",
                     "tool_calls": [
                         {
-                            "id": "call_rTx93wiIASDA8uk8XHwjVmCC",
+                            "id": "call_llqga49DSQM9Ftf9vMhk0qac",
                             "type": "function",
                             "function": {
                                 "name": "bob",
@@ -1745,7 +493,7 @@
                     "role": "tool",
                     "content": "Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI tool!",
                     "name": "bob",
-                    "tool_call_id": "call_rTx93wiIASDA8uk8XHwjVmCC"
+                    "tool_call_id": "call_llqga49DSQM9Ftf9vMhk0qac"
                 }
             ],
             "temperature": 0,
@@ -1770,9 +518,9 @@
         }
     },
     {
-        "time": "2024-06-20T16:58:13.53384-04:00",
+        "time": "2024-08-23T10:52:23.026795-04:00",
         "callContext": {
-            "id": "1718917092",
+            "id": "1724424742",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
@@ -1799,787 +547,11 @@
                 },
                 "workingDir": "testdata/Bob"
             },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917095",
-        "usage": {},
-        "content": "Waiting for model response..."
-    },
-    {
-        "time": "2024-06-20T16:58:13.856349-04:00",
-        "callContext": {
-            "id": "1718917092",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917095",
-        "usage": {},
-        "content": "Thanks"
-    },
-    {
-        "time": "2024-06-20T16:58:13.856437-04:00",
-        "callContext": {
-            "id": "1718917092",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917095",
-        "usage": {},
-        "content": "Thanks"
-    },
-    {
-        "time": "2024-06-20T16:58:13.874317-04:00",
-        "callContext": {
-            "id": "1718917092",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917095",
-        "usage": {},
-        "content": "Thanks for asking"
-    },
-    {
-        "time": "2024-06-20T16:58:13.874428-04:00",
-        "callContext": {
-            "id": "1718917092",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917095",
-        "usage": {},
-        "content": "Thanks for asking"
-    },
-    {
-        "time": "2024-06-20T16:58:14.060243-04:00",
-        "callContext": {
-            "id": "1718917092",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917095",
-        "usage": {},
-        "content": "Thanks for asking \"how are"
-    },
-    {
-        "time": "2024-06-20T16:58:14.060366-04:00",
-        "callContext": {
-            "id": "1718917092",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917095",
-        "usage": {},
-        "content": "Thanks for asking \"how are"
-    },
-    {
-        "time": "2024-06-20T16:58:14.060418-04:00",
-        "callContext": {
-            "id": "1718917092",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917095",
-        "usage": {},
-        "content": "Thanks for asking \"how are"
-    },
-    {
-        "time": "2024-06-20T16:58:14.060435-04:00",
-        "callContext": {
-            "id": "1718917092",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917095",
-        "usage": {},
-        "content": "Thanks for asking \"how are you"
-    },
-    {
-        "time": "2024-06-20T16:58:14.060456-04:00",
-        "callContext": {
-            "id": "1718917092",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917095",
-        "usage": {},
-        "content": "Thanks for asking \"how are you doing"
-    },
-    {
-        "time": "2024-06-20T16:58:14.060521-04:00",
-        "callContext": {
-            "id": "1718917092",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917095",
-        "usage": {},
-        "content": "Thanks for asking \"how are you doing\", I'm doing"
-    },
-    {
-        "time": "2024-06-20T16:58:14.060555-04:00",
-        "callContext": {
-            "id": "1718917092",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917095",
-        "usage": {},
-        "content": "Thanks for asking \"how are you doing\", I'm doing"
-    },
-    {
-        "time": "2024-06-20T16:58:14.060577-04:00",
-        "callContext": {
-            "id": "1718917092",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917095",
-        "usage": {},
-        "content": "Thanks for asking \"how are you doing\", I'm doing"
-    },
-    {
-        "time": "2024-06-20T16:58:14.06061-04:00",
-        "callContext": {
-            "id": "1718917092",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917095",
-        "usage": {},
-        "content": "Thanks for asking \"how are you doing\", I'm doing great fellow"
-    },
-    {
-        "time": "2024-06-20T16:58:14.060626-04:00",
-        "callContext": {
-            "id": "1718917092",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917095",
-        "usage": {},
-        "content": "Thanks for asking \"how are you doing\", I'm doing great fellow"
-    },
-    {
-        "time": "2024-06-20T16:58:14.060686-04:00",
-        "callContext": {
-            "id": "1718917092",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917095",
-        "usage": {},
-        "content": "Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI"
-    },
-    {
-        "time": "2024-06-20T16:58:14.06071-04:00",
-        "callContext": {
-            "id": "1718917092",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917095",
-        "usage": {},
-        "content": "Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI tool"
-    },
-    {
-        "time": "2024-06-20T16:58:14.060727-04:00",
-        "callContext": {
-            "id": "1718917092",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917095",
-        "usage": {},
-        "content": "Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI tool"
-    },
-    {
-        "time": "2024-06-20T16:58:14.060743-04:00",
-        "callContext": {
-            "id": "1718917092",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917095",
-        "usage": {},
-        "content": "Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI tool!"
-    },
-    {
-        "time": "2024-06-20T16:58:14.060788-04:00",
-        "callContext": {
-            "id": "1718917092",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917095",
-        "usage": {},
-        "content": "Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI tool!"
-    },
-    {
-        "time": "2024-06-20T16:58:14.060806-04:00",
-        "callContext": {
-            "id": "1718917092",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917095",
-        "usage": {},
-        "content": "Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI tool!"
-    },
-    {
-        "time": "2024-06-20T16:58:14.061001-04:00",
-        "callContext": {
-            "id": "1718917092",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
+            "currentAgent": {},
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1718917095",
+        "chatCompletionId": "1724424745",
         "usage": {
             "promptTokens": 179,
             "completionTokens": 18,
@@ -2600,9 +572,9 @@
         }
     },
     {
-        "time": "2024-06-20T16:58:14.061031-04:00",
+        "time": "2024-08-23T10:52:23.026887-04:00",
         "callContext": {
-            "id": "1718917092",
+            "id": "1724424742",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
@@ -2629,6 +601,7 @@
                 },
                 "workingDir": "testdata/Bob"
             },
+            "currentAgent": {},
             "inputContext": null
         },
         "type": "callFinish",
@@ -2636,7 +609,7 @@
         "content": "Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI tool!"
     },
     {
-        "time": "2024-06-20T16:58:14.061047-04:00",
+        "time": "2024-08-23T10:52:23.026977-04:00",
         "type": "runFinish",
         "usage": {}
     }

--- a/pkg/tests/smoke/testdata/Bob/gpt-4o-2024-08-06-expected.json
+++ b/pkg/tests/smoke/testdata/Bob/gpt-4o-2024-08-06-expected.json
@@ -1,15 +1,15 @@
 [
     {
-        "time": "2024-08-23T10:57:23.621143-04:00",
+        "time": "2024-08-23T11:30:01.577023-04:00",
         "type": "runStart",
         "usage": {}
     },
     {
-        "time": "2024-08-23T10:57:23.62178-04:00",
+        "time": "2024-08-23T11:30:01.577297-04:00",
         "callContext": {
-            "id": "1724425044",
+            "id": "1724427002",
             "tool": {
-                "modelName": "gpt-4-turbo-2024-04-09",
+                "modelName": "gpt-4o-2024-08-06",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
@@ -41,11 +41,11 @@
         "usage": {}
     },
     {
-        "time": "2024-08-23T10:57:23.621807-04:00",
+        "time": "2024-08-23T11:30:01.577466-04:00",
         "callContext": {
-            "id": "1724425044",
+            "id": "1724427002",
             "tool": {
-                "modelName": "gpt-4-turbo-2024-04-09",
+                "modelName": "gpt-4o-2024-08-06",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
@@ -74,10 +74,10 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1724425045",
+        "chatCompletionId": "1724427003",
         "usage": {},
         "chatRequest": {
-            "model": "gpt-4-turbo-2024-04-09",
+            "model": "gpt-4o-2024-08-06",
             "messages": [
                 {
                     "role": "system",
@@ -106,11 +106,11 @@
         }
     },
     {
-        "time": "2024-08-23T10:57:24.816101-04:00",
+        "time": "2024-08-23T11:30:02.103572-04:00",
         "callContext": {
-            "id": "1724425044",
+            "id": "1724427002",
             "tool": {
-                "modelName": "gpt-4-turbo-2024-04-09",
+                "modelName": "gpt-4o-2024-08-06",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
@@ -139,11 +139,11 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1724425045",
+        "chatCompletionId": "1724427003",
         "usage": {
-            "promptTokens": 142,
+            "promptTokens": 138,
             "completionTokens": 17,
-            "totalTokens": 159
+            "totalTokens": 155
         },
         "chatResponse": {
             "role": "assistant",
@@ -151,7 +151,7 @@
                 {
                     "toolCall": {
                         "index": 0,
-                        "id": "call_GuCVVGT6CDEdsFWn13k880S2",
+                        "id": "call_k5gUMCNtxH9gKglmCEkjfWAR",
                         "function": {
                             "name": "bob",
                             "arguments": "{\"question\":\"how are you doing\"}"
@@ -160,18 +160,18 @@
                 }
             ],
             "usage": {
-                "promptTokens": 142,
+                "promptTokens": 138,
                 "completionTokens": 17,
-                "totalTokens": 159
+                "totalTokens": 155
             }
         }
     },
     {
-        "time": "2024-08-23T10:57:24.81638-04:00",
+        "time": "2024-08-23T11:30:02.103835-04:00",
         "callContext": {
-            "id": "1724425044",
+            "id": "1724427002",
             "tool": {
-                "modelName": "gpt-4-turbo-2024-04-09",
+                "modelName": "gpt-4o-2024-08-06",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
@@ -200,7 +200,7 @@
             "inputContext": null
         },
         "toolSubCalls": {
-            "call_GuCVVGT6CDEdsFWn13k880S2": {
+            "call_k5gUMCNtxH9gKglmCEkjfWAR": {
                 "toolID": "testdata/Bob/test.gpt:bob",
                 "input": "{\"question\":\"how are you doing\"}"
             }
@@ -209,13 +209,13 @@
         "usage": {}
     },
     {
-        "time": "2024-08-23T10:57:24.816559-04:00",
+        "time": "2024-08-23T11:30:02.103996-04:00",
         "callContext": {
-            "id": "call_GuCVVGT6CDEdsFWn13k880S2",
+            "id": "call_k5gUMCNtxH9gKglmCEkjfWAR",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
-                "modelName": "gpt-4-turbo-2024-04-09",
+                "modelName": "gpt-4o-2024-08-06",
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -241,20 +241,20 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1724425044"
+            "parentID": "1724427002"
         },
         "type": "callStart",
         "usage": {},
         "content": "{\"question\":\"how are you doing\"}"
     },
     {
-        "time": "2024-08-23T10:57:24.818507-04:00",
+        "time": "2024-08-23T11:30:02.104177-04:00",
         "callContext": {
-            "id": "call_GuCVVGT6CDEdsFWn13k880S2",
+            "id": "call_k5gUMCNtxH9gKglmCEkjfWAR",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
-                "modelName": "gpt-4-turbo-2024-04-09",
+                "modelName": "gpt-4o-2024-08-06",
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -280,13 +280,13 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1724425044"
+            "parentID": "1724427002"
         },
         "type": "callChat",
-        "chatCompletionId": "1724425046",
+        "chatCompletionId": "1724427004",
         "usage": {},
         "chatRequest": {
-            "model": "gpt-4-turbo-2024-04-09",
+            "model": "gpt-4o-2024-08-06",
             "messages": [
                 {
                     "role": "system",
@@ -301,13 +301,13 @@
         }
     },
     {
-        "time": "2024-08-23T10:57:25.978016-04:00",
+        "time": "2024-08-23T11:30:02.567871-04:00",
         "callContext": {
-            "id": "call_GuCVVGT6CDEdsFWn13k880S2",
+            "id": "call_k5gUMCNtxH9gKglmCEkjfWAR",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
-                "modelName": "gpt-4-turbo-2024-04-09",
+                "modelName": "gpt-4o-2024-08-06",
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -333,37 +333,37 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1724425044"
+            "parentID": "1724427002"
         },
         "type": "callChat",
-        "chatCompletionId": "1724425046",
+        "chatCompletionId": "1724427004",
         "usage": {
-            "promptTokens": 124,
-            "completionTokens": 18,
-            "totalTokens": 142
+            "promptTokens": 122,
+            "completionTokens": 14,
+            "totalTokens": 136
         },
         "chatResponse": {
             "role": "assistant",
             "content": [
                 {
-                    "text": "Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI tool!"
+                    "text": "Thanks for asking \"${QUESTION}\", I'm doing great fellow friendly AI tool!"
                 }
             ],
             "usage": {
-                "promptTokens": 124,
-                "completionTokens": 18,
-                "totalTokens": 142
+                "promptTokens": 122,
+                "completionTokens": 14,
+                "totalTokens": 136
             }
         }
     },
     {
-        "time": "2024-08-23T10:57:25.978152-04:00",
+        "time": "2024-08-23T11:30:02.568006-04:00",
         "callContext": {
-            "id": "call_GuCVVGT6CDEdsFWn13k880S2",
+            "id": "call_k5gUMCNtxH9gKglmCEkjfWAR",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
-                "modelName": "gpt-4-turbo-2024-04-09",
+                "modelName": "gpt-4o-2024-08-06",
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -389,18 +389,18 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1724425044"
+            "parentID": "1724427002"
         },
         "type": "callFinish",
         "usage": {},
-        "content": "Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI tool!"
+        "content": "Thanks for asking \"${QUESTION}\", I'm doing great fellow friendly AI tool!"
     },
     {
-        "time": "2024-08-23T10:57:25.978236-04:00",
+        "time": "2024-08-23T11:30:02.568167-04:00",
         "callContext": {
-            "id": "1724425044",
+            "id": "1724427002",
             "tool": {
-                "modelName": "gpt-4-turbo-2024-04-09",
+                "modelName": "gpt-4o-2024-08-06",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
@@ -433,11 +433,11 @@
         "usage": {}
     },
     {
-        "time": "2024-08-23T10:57:25.980293-04:00",
+        "time": "2024-08-23T11:30:02.568274-04:00",
         "callContext": {
-            "id": "1724425044",
+            "id": "1724427002",
             "tool": {
-                "modelName": "gpt-4-turbo-2024-04-09",
+                "modelName": "gpt-4o-2024-08-06",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
@@ -466,10 +466,10 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1724425047",
+        "chatCompletionId": "1724427005",
         "usage": {},
         "chatRequest": {
-            "model": "gpt-4-turbo-2024-04-09",
+            "model": "gpt-4o-2024-08-06",
             "messages": [
                 {
                     "role": "system",
@@ -480,7 +480,7 @@
                     "content": "",
                     "tool_calls": [
                         {
-                            "id": "call_GuCVVGT6CDEdsFWn13k880S2",
+                            "id": "call_k5gUMCNtxH9gKglmCEkjfWAR",
                             "type": "function",
                             "function": {
                                 "name": "bob",
@@ -491,9 +491,9 @@
                 },
                 {
                     "role": "tool",
-                    "content": "Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI tool!",
+                    "content": "Thanks for asking \"${QUESTION}\", I'm doing great fellow friendly AI tool!",
                     "name": "bob",
-                    "tool_call_id": "call_GuCVVGT6CDEdsFWn13k880S2"
+                    "tool_call_id": "call_k5gUMCNtxH9gKglmCEkjfWAR"
                 }
             ],
             "temperature": 0,
@@ -518,11 +518,11 @@
         }
     },
     {
-        "time": "2024-08-23T10:57:26.937038-04:00",
+        "time": "2024-08-23T11:30:03.052817-04:00",
         "callContext": {
-            "id": "1724425044",
+            "id": "1724427002",
             "tool": {
-                "modelName": "gpt-4-turbo-2024-04-09",
+                "modelName": "gpt-4o-2024-08-06",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
@@ -551,32 +551,32 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1724425047",
+        "chatCompletionId": "1724427005",
         "usage": {
-            "promptTokens": 184,
-            "completionTokens": 10,
+            "promptTokens": 176,
+            "completionTokens": 18,
             "totalTokens": 194
         },
         "chatResponse": {
             "role": "assistant",
             "content": [
                 {
-                    "text": "I'm doing great fellow friendly AI tool!"
+                    "text": "Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI tool!"
                 }
             ],
             "usage": {
-                "promptTokens": 184,
-                "completionTokens": 10,
+                "promptTokens": 176,
+                "completionTokens": 18,
                 "totalTokens": 194
             }
         }
     },
     {
-        "time": "2024-08-23T10:57:26.937115-04:00",
+        "time": "2024-08-23T11:30:03.05287-04:00",
         "callContext": {
-            "id": "1724425044",
+            "id": "1724427002",
             "tool": {
-                "modelName": "gpt-4-turbo-2024-04-09",
+                "modelName": "gpt-4o-2024-08-06",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
@@ -606,10 +606,10 @@
         },
         "type": "callFinish",
         "usage": {},
-        "content": "I'm doing great fellow friendly AI tool!"
+        "content": "Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI tool!"
     },
     {
-        "time": "2024-08-23T10:57:26.937179-04:00",
+        "time": "2024-08-23T11:30:03.052914-04:00",
         "type": "runFinish",
         "usage": {}
     }

--- a/pkg/tests/smoke/testdata/Bob/mistral-large-2402-expected.json
+++ b/pkg/tests/smoke/testdata/Bob/mistral-large-2402-expected.json
@@ -1,13 +1,13 @@
 [
     {
-        "time": "2024-07-03T10:53:01.406601-04:00",
+        "time": "2024-08-23T12:02:00.839221-04:00",
         "type": "runStart",
         "usage": {}
     },
     {
-        "time": "2024-07-03T10:53:01.406888-04:00",
+        "time": "2024-08-23T12:02:00.839582-04:00",
         "callContext": {
-            "id": "1720018382",
+            "id": "1724428921",
             "tool": {
                 "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
                 "internalPrompt": null,
@@ -41,14 +41,14 @@
         "usage": {}
     },
     {
-        "time": "2024-07-03T10:53:02.106674-04:00",
+        "time": "2024-08-23T12:02:01.834156-04:00",
         "type": "runStart",
         "usage": {}
     },
     {
-        "time": "2024-07-03T10:53:02.107085-04:00",
+        "time": "2024-08-23T12:02:01.834944-04:00",
         "callContext": {
-            "id": "1720018383",
+            "id": "1724428922",
             "tool": {
                 "name": "Mistral La Plateforme Provider",
                 "description": "Model provider for Mistral models running on La Plateforme",
@@ -59,30 +59,30 @@
                     "github.com/gptscript-ai/credential as github.com/gptscript-ai/mistral-laplateforme-provider/credential with \"Please enter your Mistral La Plateforme API Key\" as message and token as field and \"MISTRAL_API_KEY\" as env"
                 ],
                 "instructions": "#!sys.daemon /usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/main.py",
-                "id": "https://raw.githubusercontent.com/gptscript-ai/mistral-laplateforme-provider/cbf1aeb6db495b9b6223984651d29ac511d2748d/tool.gpt:Mistral La Plateforme Provider",
+                "id": "https://raw.githubusercontent.com/gptscript-ai/mistral-laplateforme-provider/aa4353e7d1de7e90e1078bfbc88526266e587a64/tool.gpt:Mistral La Plateforme Provider",
                 "toolMapping": {
                     "github.com/gptscript-ai/credential as github.com/gptscript-ai/mistral-laplateforme-provider/credential with \"Please enter your Mistral La Plateforme API Key\" as message and token as field and \"MISTRAL_API_KEY\" as env": [
                         {
                             "reference": "github.com/gptscript-ai/credential as github.com/gptscript-ai/mistral-laplateforme-provider/credential with \"Please enter your Mistral La Plateforme API Key\" as message and token as field and \"MISTRAL_API_KEY\" as env",
-                            "toolID": "https://raw.githubusercontent.com/gptscript-ai/credential/651dfad6e7cf3a385ef408afa93ce522c10f8508/tool.gpt:token"
+                            "toolID": "https://raw.githubusercontent.com/gptscript-ai/credential/37e5f870e195b896438c0bc35867403a42f82e89/tool.gpt:token"
                         }
                     ]
                 },
                 "localTools": {
-                    "mistral la plateforme provider": "https://raw.githubusercontent.com/gptscript-ai/mistral-laplateforme-provider/cbf1aeb6db495b9b6223984651d29ac511d2748d/tool.gpt:Mistral La Plateforme Provider"
+                    "mistral la plateforme provider": "https://raw.githubusercontent.com/gptscript-ai/mistral-laplateforme-provider/aa4353e7d1de7e90e1078bfbc88526266e587a64/tool.gpt:Mistral La Plateforme Provider"
                 },
                 "source": {
-                    "location": "https://raw.githubusercontent.com/gptscript-ai/mistral-laplateforme-provider/cbf1aeb6db495b9b6223984651d29ac511d2748d/tool.gpt",
+                    "location": "https://raw.githubusercontent.com/gptscript-ai/mistral-laplateforme-provider/aa4353e7d1de7e90e1078bfbc88526266e587a64/tool.gpt",
                     "lineNo": 1,
                     "repo": {
                         "VCS": "git",
                         "Root": "https://github.com/gptscript-ai/mistral-laplateforme-provider.git",
                         "Path": "/",
                         "Name": "tool.gpt",
-                        "Revision": "cbf1aeb6db495b9b6223984651d29ac511d2748d"
+                        "Revision": "aa4353e7d1de7e90e1078bfbc88526266e587a64"
                     }
                 },
-                "workingDir": "https://raw.githubusercontent.com/gptscript-ai/mistral-laplateforme-provider/cbf1aeb6db495b9b6223984651d29ac511d2748d"
+                "workingDir": "https://raw.githubusercontent.com/gptscript-ai/mistral-laplateforme-provider/aa4353e7d1de7e90e1078bfbc88526266e587a64"
             },
             "currentAgent": {},
             "inputContext": null,
@@ -93,9 +93,9 @@
         "usage": {}
     },
     {
-        "time": "2024-07-03T10:53:03.125117-04:00",
+        "time": "2024-08-23T12:02:02.848161-04:00",
         "callContext": {
-            "id": "1720018383",
+            "id": "1724428922",
             "tool": {
                 "name": "Mistral La Plateforme Provider",
                 "description": "Model provider for Mistral models running on La Plateforme",
@@ -106,30 +106,30 @@
                     "github.com/gptscript-ai/credential as github.com/gptscript-ai/mistral-laplateforme-provider/credential with \"Please enter your Mistral La Plateforme API Key\" as message and token as field and \"MISTRAL_API_KEY\" as env"
                 ],
                 "instructions": "#!sys.daemon /usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/main.py",
-                "id": "https://raw.githubusercontent.com/gptscript-ai/mistral-laplateforme-provider/cbf1aeb6db495b9b6223984651d29ac511d2748d/tool.gpt:Mistral La Plateforme Provider",
+                "id": "https://raw.githubusercontent.com/gptscript-ai/mistral-laplateforme-provider/aa4353e7d1de7e90e1078bfbc88526266e587a64/tool.gpt:Mistral La Plateforme Provider",
                 "toolMapping": {
                     "github.com/gptscript-ai/credential as github.com/gptscript-ai/mistral-laplateforme-provider/credential with \"Please enter your Mistral La Plateforme API Key\" as message and token as field and \"MISTRAL_API_KEY\" as env": [
                         {
                             "reference": "github.com/gptscript-ai/credential as github.com/gptscript-ai/mistral-laplateforme-provider/credential with \"Please enter your Mistral La Plateforme API Key\" as message and token as field and \"MISTRAL_API_KEY\" as env",
-                            "toolID": "https://raw.githubusercontent.com/gptscript-ai/credential/651dfad6e7cf3a385ef408afa93ce522c10f8508/tool.gpt:token"
+                            "toolID": "https://raw.githubusercontent.com/gptscript-ai/credential/37e5f870e195b896438c0bc35867403a42f82e89/tool.gpt:token"
                         }
                     ]
                 },
                 "localTools": {
-                    "mistral la plateforme provider": "https://raw.githubusercontent.com/gptscript-ai/mistral-laplateforme-provider/cbf1aeb6db495b9b6223984651d29ac511d2748d/tool.gpt:Mistral La Plateforme Provider"
+                    "mistral la plateforme provider": "https://raw.githubusercontent.com/gptscript-ai/mistral-laplateforme-provider/aa4353e7d1de7e90e1078bfbc88526266e587a64/tool.gpt:Mistral La Plateforme Provider"
                 },
                 "source": {
-                    "location": "https://raw.githubusercontent.com/gptscript-ai/mistral-laplateforme-provider/cbf1aeb6db495b9b6223984651d29ac511d2748d/tool.gpt",
+                    "location": "https://raw.githubusercontent.com/gptscript-ai/mistral-laplateforme-provider/aa4353e7d1de7e90e1078bfbc88526266e587a64/tool.gpt",
                     "lineNo": 1,
                     "repo": {
                         "VCS": "git",
                         "Root": "https://github.com/gptscript-ai/mistral-laplateforme-provider.git",
                         "Path": "/",
                         "Name": "tool.gpt",
-                        "Revision": "cbf1aeb6db495b9b6223984651d29ac511d2748d"
+                        "Revision": "aa4353e7d1de7e90e1078bfbc88526266e587a64"
                     }
                 },
-                "workingDir": "https://raw.githubusercontent.com/gptscript-ai/mistral-laplateforme-provider/cbf1aeb6db495b9b6223984651d29ac511d2748d"
+                "workingDir": "https://raw.githubusercontent.com/gptscript-ai/mistral-laplateforme-provider/aa4353e7d1de7e90e1078bfbc88526266e587a64"
             },
             "currentAgent": {},
             "inputContext": null,
@@ -138,17 +138,17 @@
         },
         "type": "callFinish",
         "usage": {},
-        "content": "http://127.0.0.1:10244"
+        "content": "http://127.0.0.1:10437"
     },
     {
-        "time": "2024-07-03T10:53:03.125375-04:00",
+        "time": "2024-08-23T12:02:02.848319-04:00",
         "type": "runFinish",
         "usage": {}
     },
     {
-        "time": "2024-07-03T10:53:03.12547-04:00",
+        "time": "2024-08-23T12:02:02.848376-04:00",
         "callContext": {
-            "id": "1720018382",
+            "id": "1724428921",
             "tool": {
                 "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
                 "internalPrompt": null,
@@ -179,7 +179,7 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1720018384",
+        "chatCompletionId": "1724428923",
         "usage": {},
         "chatRequest": {
             "model": "mistral-large-2402",
@@ -211,122 +211,9 @@
         }
     },
     {
-        "time": "2024-07-03T10:53:03.126002-04:00",
+        "time": "2024-08-23T12:02:04.855513-04:00",
         "callContext": {
-            "id": "1720018382",
-            "tool": {
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "currentAgent": {},
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018384",
-        "usage": {},
-        "content": "Waiting for model response..."
-    },
-    {
-        "time": "2024-07-03T10:53:03.438634-04:00",
-        "callContext": {
-            "id": "1720018382",
-            "tool": {
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "currentAgent": {},
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018384",
-        "usage": {}
-    },
-    {
-        "time": "2024-07-03T10:53:03.917633-04:00",
-        "callContext": {
-            "id": "1720018382",
-            "tool": {
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "currentAgent": {},
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018384",
-        "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\"question\": \"how are you doing\"}"
-    },
-    {
-        "time": "2024-07-03T10:53:03.9181-04:00",
-        "callContext": {
-            "id": "1720018382",
+            "id": "1724428921",
             "tool": {
                 "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
                 "internalPrompt": null,
@@ -357,7 +244,7 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1720018384",
+        "chatCompletionId": "1724428923",
         "usage": {
             "promptTokens": 188,
             "completionTokens": 23,
@@ -369,7 +256,7 @@
                 {
                     "toolCall": {
                         "index": 0,
-                        "id": "IePX3uH5y",
+                        "id": "pIMgThIue",
                         "function": {
                             "name": "bob",
                             "arguments": "{\"question\": \"how are you doing\"}"
@@ -385,9 +272,9 @@
         }
     },
     {
-        "time": "2024-07-03T10:53:03.918447-04:00",
+        "time": "2024-08-23T12:02:04.855681-04:00",
         "callContext": {
-            "id": "1720018382",
+            "id": "1724428921",
             "tool": {
                 "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
                 "internalPrompt": null,
@@ -418,7 +305,7 @@
             "inputContext": null
         },
         "toolSubCalls": {
-            "IePX3uH5y": {
+            "pIMgThIue": {
                 "toolID": "testdata/Bob/test.gpt:bob",
                 "input": "{\"question\": \"how are you doing\"}"
             }
@@ -427,9 +314,9 @@
         "usage": {}
     },
     {
-        "time": "2024-07-03T10:53:03.918585-04:00",
+        "time": "2024-08-23T12:02:04.855749-04:00",
         "callContext": {
-            "id": "IePX3uH5y",
+            "id": "pIMgThIue",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -444,7 +331,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${QUESTION}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -459,16 +346,16 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1720018382"
+            "parentID": "1724428921"
         },
         "type": "callStart",
         "usage": {},
         "content": "{\"question\": \"how are you doing\"}"
     },
     {
-        "time": "2024-07-03T10:53:04.089188-04:00",
+        "time": "2024-08-23T12:02:05.209879-04:00",
         "callContext": {
-            "id": "IePX3uH5y",
+            "id": "pIMgThIue",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -483,7 +370,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${QUESTION}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -498,17 +385,17 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1720018382"
+            "parentID": "1724428921"
         },
         "type": "callChat",
-        "chatCompletionId": "1720018385",
+        "chatCompletionId": "1724428924",
         "usage": {},
         "chatRequest": {
             "model": "mistral-large-2402",
             "messages": [
                 {
                     "role": "system",
-                    "content": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\""
+                    "content": "When asked how I am doing, respond with exactly \"Thanks for asking \"${QUESTION}\", I'm doing great fellow friendly AI tool!\""
                 },
                 {
                     "role": "user",
@@ -519,9 +406,9 @@
         }
     },
     {
-        "time": "2024-07-03T10:53:04.089548-04:00",
+        "time": "2024-08-23T12:02:05.965183-04:00",
         "callContext": {
-            "id": "IePX3uH5y",
+            "id": "pIMgThIue",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -536,7 +423,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${QUESTION}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -551,893 +438,14 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1720018382"
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018385",
-        "usage": {},
-        "content": "Waiting for model response..."
-    },
-    {
-        "time": "2024-07-03T10:53:04.287287-04:00",
-        "callContext": {
-            "id": "IePX3uH5y",
-            "tool": {
-                "name": "bob",
-                "description": "I'm Bob, a friendly guy.",
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "question": {
-                            "description": "The question to ask Bob.",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
-                "id": "testdata/Bob/test.gpt:bob",
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 6
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "currentAgent": {},
-            "inputContext": null,
-            "toolName": "bob",
-            "parentID": "1720018382"
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018385",
-        "usage": {}
-    },
-    {
-        "time": "2024-07-03T10:53:04.287688-04:00",
-        "callContext": {
-            "id": "IePX3uH5y",
-            "tool": {
-                "name": "bob",
-                "description": "I'm Bob, a friendly guy.",
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "question": {
-                            "description": "The question to ask Bob.",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
-                "id": "testdata/Bob/test.gpt:bob",
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 6
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "currentAgent": {},
-            "inputContext": null,
-            "toolName": "bob",
-            "parentID": "1720018382"
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018385",
-        "usage": {},
-        "content": "Thanks"
-    },
-    {
-        "time": "2024-07-03T10:53:04.302879-04:00",
-        "callContext": {
-            "id": "IePX3uH5y",
-            "tool": {
-                "name": "bob",
-                "description": "I'm Bob, a friendly guy.",
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "question": {
-                            "description": "The question to ask Bob.",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
-                "id": "testdata/Bob/test.gpt:bob",
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 6
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "currentAgent": {},
-            "inputContext": null,
-            "toolName": "bob",
-            "parentID": "1720018382"
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018385",
-        "usage": {},
-        "content": "Thanks for"
-    },
-    {
-        "time": "2024-07-03T10:53:04.323886-04:00",
-        "callContext": {
-            "id": "IePX3uH5y",
-            "tool": {
-                "name": "bob",
-                "description": "I'm Bob, a friendly guy.",
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "question": {
-                            "description": "The question to ask Bob.",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
-                "id": "testdata/Bob/test.gpt:bob",
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 6
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "currentAgent": {},
-            "inputContext": null,
-            "toolName": "bob",
-            "parentID": "1720018382"
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018385",
-        "usage": {},
-        "content": "Thanks for asking"
-    },
-    {
-        "time": "2024-07-03T10:53:04.345227-04:00",
-        "callContext": {
-            "id": "IePX3uH5y",
-            "tool": {
-                "name": "bob",
-                "description": "I'm Bob, a friendly guy.",
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "question": {
-                            "description": "The question to ask Bob.",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
-                "id": "testdata/Bob/test.gpt:bob",
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 6
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "currentAgent": {},
-            "inputContext": null,
-            "toolName": "bob",
-            "parentID": "1720018382"
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018385",
-        "usage": {},
-        "content": "Thanks for asking \""
-    },
-    {
-        "time": "2024-07-03T10:53:04.364182-04:00",
-        "callContext": {
-            "id": "IePX3uH5y",
-            "tool": {
-                "name": "bob",
-                "description": "I'm Bob, a friendly guy.",
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "question": {
-                            "description": "The question to ask Bob.",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
-                "id": "testdata/Bob/test.gpt:bob",
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 6
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "currentAgent": {},
-            "inputContext": null,
-            "toolName": "bob",
-            "parentID": "1720018382"
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018385",
-        "usage": {},
-        "content": "Thanks for asking \"how"
-    },
-    {
-        "time": "2024-07-03T10:53:04.387098-04:00",
-        "callContext": {
-            "id": "IePX3uH5y",
-            "tool": {
-                "name": "bob",
-                "description": "I'm Bob, a friendly guy.",
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "question": {
-                            "description": "The question to ask Bob.",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
-                "id": "testdata/Bob/test.gpt:bob",
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 6
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "currentAgent": {},
-            "inputContext": null,
-            "toolName": "bob",
-            "parentID": "1720018382"
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018385",
-        "usage": {},
-        "content": "Thanks for asking \"how are"
-    },
-    {
-        "time": "2024-07-03T10:53:04.405872-04:00",
-        "callContext": {
-            "id": "IePX3uH5y",
-            "tool": {
-                "name": "bob",
-                "description": "I'm Bob, a friendly guy.",
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "question": {
-                            "description": "The question to ask Bob.",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
-                "id": "testdata/Bob/test.gpt:bob",
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 6
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "currentAgent": {},
-            "inputContext": null,
-            "toolName": "bob",
-            "parentID": "1720018382"
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018385",
-        "usage": {},
-        "content": "Thanks for asking \"how are you"
-    },
-    {
-        "time": "2024-07-03T10:53:04.427749-04:00",
-        "callContext": {
-            "id": "IePX3uH5y",
-            "tool": {
-                "name": "bob",
-                "description": "I'm Bob, a friendly guy.",
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "question": {
-                            "description": "The question to ask Bob.",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
-                "id": "testdata/Bob/test.gpt:bob",
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 6
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "currentAgent": {},
-            "inputContext": null,
-            "toolName": "bob",
-            "parentID": "1720018382"
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018385",
-        "usage": {},
-        "content": "Thanks for asking \"how are you doing"
-    },
-    {
-        "time": "2024-07-03T10:53:04.448563-04:00",
-        "callContext": {
-            "id": "IePX3uH5y",
-            "tool": {
-                "name": "bob",
-                "description": "I'm Bob, a friendly guy.",
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "question": {
-                            "description": "The question to ask Bob.",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
-                "id": "testdata/Bob/test.gpt:bob",
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 6
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "currentAgent": {},
-            "inputContext": null,
-            "toolName": "bob",
-            "parentID": "1720018382"
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018385",
-        "usage": {},
-        "content": "Thanks for asking \"how are you doing\","
-    },
-    {
-        "time": "2024-07-03T10:53:04.468026-04:00",
-        "callContext": {
-            "id": "IePX3uH5y",
-            "tool": {
-                "name": "bob",
-                "description": "I'm Bob, a friendly guy.",
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "question": {
-                            "description": "The question to ask Bob.",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
-                "id": "testdata/Bob/test.gpt:bob",
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 6
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "currentAgent": {},
-            "inputContext": null,
-            "toolName": "bob",
-            "parentID": "1720018382"
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018385",
-        "usage": {},
-        "content": "Thanks for asking \"how are you doing\", I"
-    },
-    {
-        "time": "2024-07-03T10:53:04.490606-04:00",
-        "callContext": {
-            "id": "IePX3uH5y",
-            "tool": {
-                "name": "bob",
-                "description": "I'm Bob, a friendly guy.",
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "question": {
-                            "description": "The question to ask Bob.",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
-                "id": "testdata/Bob/test.gpt:bob",
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 6
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "currentAgent": {},
-            "inputContext": null,
-            "toolName": "bob",
-            "parentID": "1720018382"
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018385",
-        "usage": {},
-        "content": "Thanks for asking \"how are you doing\", I'"
-    },
-    {
-        "time": "2024-07-03T10:53:04.511171-04:00",
-        "callContext": {
-            "id": "IePX3uH5y",
-            "tool": {
-                "name": "bob",
-                "description": "I'm Bob, a friendly guy.",
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "question": {
-                            "description": "The question to ask Bob.",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
-                "id": "testdata/Bob/test.gpt:bob",
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 6
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "currentAgent": {},
-            "inputContext": null,
-            "toolName": "bob",
-            "parentID": "1720018382"
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018385",
-        "usage": {},
-        "content": "Thanks for asking \"how are you doing\", I'm"
-    },
-    {
-        "time": "2024-07-03T10:53:04.531235-04:00",
-        "callContext": {
-            "id": "IePX3uH5y",
-            "tool": {
-                "name": "bob",
-                "description": "I'm Bob, a friendly guy.",
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "question": {
-                            "description": "The question to ask Bob.",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
-                "id": "testdata/Bob/test.gpt:bob",
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 6
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "currentAgent": {},
-            "inputContext": null,
-            "toolName": "bob",
-            "parentID": "1720018382"
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018385",
-        "usage": {},
-        "content": "Thanks for asking \"how are you doing\", I'm doing"
-    },
-    {
-        "time": "2024-07-03T10:53:04.553855-04:00",
-        "callContext": {
-            "id": "IePX3uH5y",
-            "tool": {
-                "name": "bob",
-                "description": "I'm Bob, a friendly guy.",
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "question": {
-                            "description": "The question to ask Bob.",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
-                "id": "testdata/Bob/test.gpt:bob",
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 6
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "currentAgent": {},
-            "inputContext": null,
-            "toolName": "bob",
-            "parentID": "1720018382"
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018385",
-        "usage": {},
-        "content": "Thanks for asking \"how are you doing\", I'm doing great"
-    },
-    {
-        "time": "2024-07-03T10:53:04.574503-04:00",
-        "callContext": {
-            "id": "IePX3uH5y",
-            "tool": {
-                "name": "bob",
-                "description": "I'm Bob, a friendly guy.",
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "question": {
-                            "description": "The question to ask Bob.",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
-                "id": "testdata/Bob/test.gpt:bob",
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 6
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "currentAgent": {},
-            "inputContext": null,
-            "toolName": "bob",
-            "parentID": "1720018382"
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018385",
-        "usage": {},
-        "content": "Thanks for asking \"how are you doing\", I'm doing great fellow"
-    },
-    {
-        "time": "2024-07-03T10:53:04.598055-04:00",
-        "callContext": {
-            "id": "IePX3uH5y",
-            "tool": {
-                "name": "bob",
-                "description": "I'm Bob, a friendly guy.",
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "question": {
-                            "description": "The question to ask Bob.",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
-                "id": "testdata/Bob/test.gpt:bob",
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 6
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "currentAgent": {},
-            "inputContext": null,
-            "toolName": "bob",
-            "parentID": "1720018382"
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018385",
-        "usage": {},
-        "content": "Thanks for asking \"how are you doing\", I'm doing great fellow friendly"
-    },
-    {
-        "time": "2024-07-03T10:53:04.613412-04:00",
-        "callContext": {
-            "id": "IePX3uH5y",
-            "tool": {
-                "name": "bob",
-                "description": "I'm Bob, a friendly guy.",
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "question": {
-                            "description": "The question to ask Bob.",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
-                "id": "testdata/Bob/test.gpt:bob",
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 6
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "currentAgent": {},
-            "inputContext": null,
-            "toolName": "bob",
-            "parentID": "1720018382"
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018385",
-        "usage": {},
-        "content": "Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI"
-    },
-    {
-        "time": "2024-07-03T10:53:04.635897-04:00",
-        "callContext": {
-            "id": "IePX3uH5y",
-            "tool": {
-                "name": "bob",
-                "description": "I'm Bob, a friendly guy.",
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "question": {
-                            "description": "The question to ask Bob.",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
-                "id": "testdata/Bob/test.gpt:bob",
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 6
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "currentAgent": {},
-            "inputContext": null,
-            "toolName": "bob",
-            "parentID": "1720018382"
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018385",
-        "usage": {},
-        "content": "Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI tool"
-    },
-    {
-        "time": "2024-07-03T10:53:04.656116-04:00",
-        "callContext": {
-            "id": "IePX3uH5y",
-            "tool": {
-                "name": "bob",
-                "description": "I'm Bob, a friendly guy.",
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "question": {
-                            "description": "The question to ask Bob.",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
-                "id": "testdata/Bob/test.gpt:bob",
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 6
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "currentAgent": {},
-            "inputContext": null,
-            "toolName": "bob",
-            "parentID": "1720018382"
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018385",
-        "usage": {},
-        "content": "Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI tool!"
-    },
-    {
-        "time": "2024-07-03T10:53:04.680962-04:00",
-        "callContext": {
-            "id": "IePX3uH5y",
-            "tool": {
-                "name": "bob",
-                "description": "I'm Bob, a friendly guy.",
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "question": {
-                            "description": "The question to ask Bob.",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
-                "id": "testdata/Bob/test.gpt:bob",
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 6
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "currentAgent": {},
-            "inputContext": null,
-            "toolName": "bob",
-            "parentID": "1720018382"
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018385",
-        "usage": {},
-        "content": "Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI tool!"
-    },
-    {
-        "time": "2024-07-03T10:53:04.681447-04:00",
-        "callContext": {
-            "id": "IePX3uH5y",
-            "tool": {
-                "name": "bob",
-                "description": "I'm Bob, a friendly guy.",
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "question": {
-                            "description": "The question to ask Bob.",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
-                "id": "testdata/Bob/test.gpt:bob",
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 6
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "currentAgent": {},
-            "inputContext": null,
-            "toolName": "bob",
-            "parentID": "1720018382"
+            "parentID": "1724428921"
         },
         "type": "callChat",
-        "chatCompletionId": "1720018385",
+        "chatCompletionId": "1724428924",
         "usage": {
-            "promptTokens": 143,
+            "promptTokens": 145,
             "completionTokens": 19,
-            "totalTokens": 162
+            "totalTokens": 164
         },
         "chatResponse": {
             "role": "assistant",
@@ -1447,16 +455,16 @@
                 }
             ],
             "usage": {
-                "promptTokens": 143,
+                "promptTokens": 145,
                 "completionTokens": 19,
-                "totalTokens": 162
+                "totalTokens": 164
             }
         }
     },
     {
-        "time": "2024-07-03T10:53:04.681598-04:00",
+        "time": "2024-08-23T12:02:05.965343-04:00",
         "callContext": {
-            "id": "IePX3uH5y",
+            "id": "pIMgThIue",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -1471,7 +479,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"",
+                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${QUESTION}\", I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/Bob/test.gpt:bob",
                 "localTools": {
                     "": "testdata/Bob/test.gpt:",
@@ -1486,16 +494,16 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1720018382"
+            "parentID": "1724428921"
         },
         "type": "callFinish",
         "usage": {},
         "content": "Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI tool!"
     },
     {
-        "time": "2024-07-03T10:53:04.681725-04:00",
+        "time": "2024-08-23T12:02:05.965434-04:00",
         "callContext": {
-            "id": "1720018382",
+            "id": "1724428921",
             "tool": {
                 "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
                 "internalPrompt": null,
@@ -1530,9 +538,9 @@
         "usage": {}
     },
     {
-        "time": "2024-07-03T10:53:04.842182-04:00",
+        "time": "2024-08-23T12:02:06.194066-04:00",
         "callContext": {
-            "id": "1720018382",
+            "id": "1724428921",
             "tool": {
                 "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
                 "internalPrompt": null,
@@ -1563,7 +571,7 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1720018386",
+        "chatCompletionId": "1724428925",
         "usage": {},
         "chatRequest": {
             "model": "mistral-large-2402",
@@ -1577,7 +585,7 @@
                     "content": "",
                     "tool_calls": [
                         {
-                            "id": "IePX3uH5y",
+                            "id": "pIMgThIue",
                             "type": "function",
                             "function": {
                                 "name": "bob",
@@ -1590,7 +598,7 @@
                     "role": "tool",
                     "content": "Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI tool!",
                     "name": "bob",
-                    "tool_call_id": "IePX3uH5y"
+                    "tool_call_id": "pIMgThIue"
                 }
             ],
             "temperature": 0,
@@ -1615,996 +623,9 @@
         }
     },
     {
-        "time": "2024-07-03T10:53:04.842685-04:00",
+        "time": "2024-08-23T12:02:07.70213-04:00",
         "callContext": {
-            "id": "1720018382",
-            "tool": {
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "currentAgent": {},
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018386",
-        "usage": {},
-        "content": "Waiting for model response..."
-    },
-    {
-        "time": "2024-07-03T10:53:05.384131-04:00",
-        "callContext": {
-            "id": "1720018382",
-            "tool": {
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "currentAgent": {},
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018386",
-        "usage": {}
-    },
-    {
-        "time": "2024-07-03T10:53:05.384657-04:00",
-        "callContext": {
-            "id": "1720018382",
-            "tool": {
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "currentAgent": {},
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018386",
-        "usage": {},
-        "content": "Bob"
-    },
-    {
-        "time": "2024-07-03T10:53:05.404612-04:00",
-        "callContext": {
-            "id": "1720018382",
-            "tool": {
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "currentAgent": {},
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018386",
-        "usage": {},
-        "content": "Bob said"
-    },
-    {
-        "time": "2024-07-03T10:53:05.430068-04:00",
-        "callContext": {
-            "id": "1720018382",
-            "tool": {
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "currentAgent": {},
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018386",
-        "usage": {},
-        "content": "Bob said,"
-    },
-    {
-        "time": "2024-07-03T10:53:05.452982-04:00",
-        "callContext": {
-            "id": "1720018382",
-            "tool": {
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "currentAgent": {},
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018386",
-        "usage": {},
-        "content": "Bob said, \""
-    },
-    {
-        "time": "2024-07-03T10:53:05.501525-04:00",
-        "callContext": {
-            "id": "1720018382",
-            "tool": {
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "currentAgent": {},
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018386",
-        "usage": {},
-        "content": "Bob said, \"Thanks for"
-    },
-    {
-        "time": "2024-07-03T10:53:05.50179-04:00",
-        "callContext": {
-            "id": "1720018382",
-            "tool": {
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "currentAgent": {},
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018386",
-        "usage": {},
-        "content": "Bob said, \"Thanks for"
-    },
-    {
-        "time": "2024-07-03T10:53:05.532152-04:00",
-        "callContext": {
-            "id": "1720018382",
-            "tool": {
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "currentAgent": {},
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018386",
-        "usage": {},
-        "content": "Bob said, \"Thanks for asking"
-    },
-    {
-        "time": "2024-07-03T10:53:05.553295-04:00",
-        "callContext": {
-            "id": "1720018382",
-            "tool": {
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "currentAgent": {},
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018386",
-        "usage": {},
-        "content": "Bob said, \"Thanks for asking '"
-    },
-    {
-        "time": "2024-07-03T10:53:05.576012-04:00",
-        "callContext": {
-            "id": "1720018382",
-            "tool": {
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "currentAgent": {},
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018386",
-        "usage": {},
-        "content": "Bob said, \"Thanks for asking 'how"
-    },
-    {
-        "time": "2024-07-03T10:53:05.602885-04:00",
-        "callContext": {
-            "id": "1720018382",
-            "tool": {
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "currentAgent": {},
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018386",
-        "usage": {},
-        "content": "Bob said, \"Thanks for asking 'how are"
-    },
-    {
-        "time": "2024-07-03T10:53:05.624751-04:00",
-        "callContext": {
-            "id": "1720018382",
-            "tool": {
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "currentAgent": {},
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018386",
-        "usage": {},
-        "content": "Bob said, \"Thanks for asking 'how are you"
-    },
-    {
-        "time": "2024-07-03T10:53:05.649543-04:00",
-        "callContext": {
-            "id": "1720018382",
-            "tool": {
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "currentAgent": {},
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018386",
-        "usage": {},
-        "content": "Bob said, \"Thanks for asking 'how are you doing"
-    },
-    {
-        "time": "2024-07-03T10:53:05.674199-04:00",
-        "callContext": {
-            "id": "1720018382",
-            "tool": {
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "currentAgent": {},
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018386",
-        "usage": {},
-        "content": "Bob said, \"Thanks for asking 'how are you doing',"
-    },
-    {
-        "time": "2024-07-03T10:53:05.697398-04:00",
-        "callContext": {
-            "id": "1720018382",
-            "tool": {
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "currentAgent": {},
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018386",
-        "usage": {},
-        "content": "Bob said, \"Thanks for asking 'how are you doing', I"
-    },
-    {
-        "time": "2024-07-03T10:53:05.725234-04:00",
-        "callContext": {
-            "id": "1720018382",
-            "tool": {
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "currentAgent": {},
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018386",
-        "usage": {},
-        "content": "Bob said, \"Thanks for asking 'how are you doing', I'"
-    },
-    {
-        "time": "2024-07-03T10:53:05.747687-04:00",
-        "callContext": {
-            "id": "1720018382",
-            "tool": {
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "currentAgent": {},
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018386",
-        "usage": {},
-        "content": "Bob said, \"Thanks for asking 'how are you doing', I'm"
-    },
-    {
-        "time": "2024-07-03T10:53:05.773761-04:00",
-        "callContext": {
-            "id": "1720018382",
-            "tool": {
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "currentAgent": {},
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018386",
-        "usage": {},
-        "content": "Bob said, \"Thanks for asking 'how are you doing', I'm doing"
-    },
-    {
-        "time": "2024-07-03T10:53:05.798352-04:00",
-        "callContext": {
-            "id": "1720018382",
-            "tool": {
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "currentAgent": {},
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018386",
-        "usage": {},
-        "content": "Bob said, \"Thanks for asking 'how are you doing', I'm doing great"
-    },
-    {
-        "time": "2024-07-03T10:53:05.823105-04:00",
-        "callContext": {
-            "id": "1720018382",
-            "tool": {
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "currentAgent": {},
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018386",
-        "usage": {},
-        "content": "Bob said, \"Thanks for asking 'how are you doing', I'm doing great fellow"
-    },
-    {
-        "time": "2024-07-03T10:53:05.846373-04:00",
-        "callContext": {
-            "id": "1720018382",
-            "tool": {
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "currentAgent": {},
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018386",
-        "usage": {},
-        "content": "Bob said, \"Thanks for asking 'how are you doing', I'm doing great fellow friendly"
-    },
-    {
-        "time": "2024-07-03T10:53:05.871647-04:00",
-        "callContext": {
-            "id": "1720018382",
-            "tool": {
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "currentAgent": {},
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018386",
-        "usage": {},
-        "content": "Bob said, \"Thanks for asking 'how are you doing', I'm doing great fellow friendly AI"
-    },
-    {
-        "time": "2024-07-03T10:53:05.895603-04:00",
-        "callContext": {
-            "id": "1720018382",
-            "tool": {
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "currentAgent": {},
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018386",
-        "usage": {},
-        "content": "Bob said, \"Thanks for asking 'how are you doing', I'm doing great fellow friendly AI tool"
-    },
-    {
-        "time": "2024-07-03T10:53:05.919754-04:00",
-        "callContext": {
-            "id": "1720018382",
-            "tool": {
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "currentAgent": {},
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018386",
-        "usage": {},
-        "content": "Bob said, \"Thanks for asking 'how are you doing', I'm doing great fellow friendly AI tool!\""
-    },
-    {
-        "time": "2024-07-03T10:53:05.956244-04:00",
-        "callContext": {
-            "id": "1720018382",
-            "tool": {
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/Bob"
-            },
-            "currentAgent": {},
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018386",
-        "usage": {},
-        "content": "Bob said, \"Thanks for asking 'how are you doing', I'm doing great fellow friendly AI tool!\""
-    },
-    {
-        "time": "2024-07-03T10:53:05.956647-04:00",
-        "callContext": {
-            "id": "1720018382",
+            "id": "1724428921",
             "tool": {
                 "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
                 "internalPrompt": null,
@@ -2635,7 +656,7 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1720018386",
+        "chatCompletionId": "1724428925",
         "usage": {
             "promptTokens": 246,
             "completionTokens": 23,
@@ -2656,9 +677,9 @@
         }
     },
     {
-        "time": "2024-07-03T10:53:05.956695-04:00",
+        "time": "2024-08-23T12:02:07.702186-04:00",
         "callContext": {
-            "id": "1720018382",
+            "id": "1724428921",
             "tool": {
                 "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
                 "internalPrompt": null,
@@ -2693,7 +714,7 @@
         "content": "Bob said, \"Thanks for asking 'how are you doing', I'm doing great fellow friendly AI tool!\""
     },
     {
-        "time": "2024-07-03T10:53:05.956743-04:00",
+        "time": "2024-08-23T12:02:07.702253-04:00",
         "type": "runFinish",
         "usage": {}
     }

--- a/pkg/tests/smoke/testdata/BobAsShell/claude-3-5-sonnet-20240620-expected.json
+++ b/pkg/tests/smoke/testdata/BobAsShell/claude-3-5-sonnet-20240620-expected.json
@@ -1,13 +1,13 @@
 [
     {
-        "time": "2024-07-02T19:39:48.881112-04:00",
+        "time": "2024-08-23T12:02:17.549859-04:00",
         "type": "runStart",
         "usage": {}
     },
     {
-        "time": "2024-07-02T19:39:48.881306-04:00",
+        "time": "2024-08-23T12:02:17.55023-04:00",
         "callContext": {
-            "id": "1719963589",
+            "id": "1724428938",
             "tool": {
                 "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "internalPrompt": null,
@@ -41,14 +41,14 @@
         "usage": {}
     },
     {
-        "time": "2024-07-02T19:39:49.304999-04:00",
+        "time": "2024-08-23T12:02:18.283201-04:00",
         "type": "runStart",
         "usage": {}
     },
     {
-        "time": "2024-07-02T19:39:49.305331-04:00",
+        "time": "2024-08-23T12:02:18.28339-04:00",
         "callContext": {
-            "id": "1719963590",
+            "id": "1724428939",
             "tool": {
                 "name": "Anthropic Claude3 Model Provider",
                 "description": "Model provider for Anthropic hosted Claude3 models",
@@ -59,30 +59,30 @@
                     "github.com/gptscript-ai/credential as github.com/gptscript-ai/claude3-anthropic-provider/credential with \"Please enter your Anthropic API Key\" as message and token as field and \"ANTHROPIC_API_KEY\" as env"
                 ],
                 "instructions": "#!sys.daemon /usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/main.py",
-                "id": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/6b5a88075b1e4501e845f4dab5be16ea8739aa4c/tool.gpt:Anthropic Claude3 Model Provider",
+                "id": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/ee5c02a9aeca5a1cbffcf569751e37432bfe0344/tool.gpt:Anthropic Claude3 Model Provider",
                 "toolMapping": {
                     "github.com/gptscript-ai/credential as github.com/gptscript-ai/claude3-anthropic-provider/credential with \"Please enter your Anthropic API Key\" as message and token as field and \"ANTHROPIC_API_KEY\" as env": [
                         {
                             "reference": "github.com/gptscript-ai/credential as github.com/gptscript-ai/claude3-anthropic-provider/credential with \"Please enter your Anthropic API Key\" as message and token as field and \"ANTHROPIC_API_KEY\" as env",
-                            "toolID": "https://raw.githubusercontent.com/gptscript-ai/credential/651dfad6e7cf3a385ef408afa93ce522c10f8508/tool.gpt:token"
+                            "toolID": "https://raw.githubusercontent.com/gptscript-ai/credential/37e5f870e195b896438c0bc35867403a42f82e89/tool.gpt:token"
                         }
                     ]
                 },
                 "localTools": {
-                    "anthropic claude3 model provider": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/6b5a88075b1e4501e845f4dab5be16ea8739aa4c/tool.gpt:Anthropic Claude3 Model Provider"
+                    "anthropic claude3 model provider": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/ee5c02a9aeca5a1cbffcf569751e37432bfe0344/tool.gpt:Anthropic Claude3 Model Provider"
                 },
                 "source": {
-                    "location": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/6b5a88075b1e4501e845f4dab5be16ea8739aa4c/tool.gpt",
+                    "location": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/ee5c02a9aeca5a1cbffcf569751e37432bfe0344/tool.gpt",
                     "lineNo": 1,
                     "repo": {
                         "VCS": "git",
                         "Root": "https://github.com/gptscript-ai/claude3-anthropic-provider.git",
                         "Path": "/",
                         "Name": "tool.gpt",
-                        "Revision": "6b5a88075b1e4501e845f4dab5be16ea8739aa4c"
+                        "Revision": "ee5c02a9aeca5a1cbffcf569751e37432bfe0344"
                     }
                 },
-                "workingDir": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/6b5a88075b1e4501e845f4dab5be16ea8739aa4c"
+                "workingDir": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/ee5c02a9aeca5a1cbffcf569751e37432bfe0344"
             },
             "currentAgent": {},
             "inputContext": null,
@@ -93,9 +93,9 @@
         "usage": {}
     },
     {
-        "time": "2024-07-02T19:39:50.324048-04:00",
+        "time": "2024-08-23T12:02:19.295369-04:00",
         "callContext": {
-            "id": "1719963590",
+            "id": "1724428939",
             "tool": {
                 "name": "Anthropic Claude3 Model Provider",
                 "description": "Model provider for Anthropic hosted Claude3 models",
@@ -106,30 +106,30 @@
                     "github.com/gptscript-ai/credential as github.com/gptscript-ai/claude3-anthropic-provider/credential with \"Please enter your Anthropic API Key\" as message and token as field and \"ANTHROPIC_API_KEY\" as env"
                 ],
                 "instructions": "#!sys.daemon /usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/main.py",
-                "id": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/6b5a88075b1e4501e845f4dab5be16ea8739aa4c/tool.gpt:Anthropic Claude3 Model Provider",
+                "id": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/ee5c02a9aeca5a1cbffcf569751e37432bfe0344/tool.gpt:Anthropic Claude3 Model Provider",
                 "toolMapping": {
                     "github.com/gptscript-ai/credential as github.com/gptscript-ai/claude3-anthropic-provider/credential with \"Please enter your Anthropic API Key\" as message and token as field and \"ANTHROPIC_API_KEY\" as env": [
                         {
                             "reference": "github.com/gptscript-ai/credential as github.com/gptscript-ai/claude3-anthropic-provider/credential with \"Please enter your Anthropic API Key\" as message and token as field and \"ANTHROPIC_API_KEY\" as env",
-                            "toolID": "https://raw.githubusercontent.com/gptscript-ai/credential/651dfad6e7cf3a385ef408afa93ce522c10f8508/tool.gpt:token"
+                            "toolID": "https://raw.githubusercontent.com/gptscript-ai/credential/37e5f870e195b896438c0bc35867403a42f82e89/tool.gpt:token"
                         }
                     ]
                 },
                 "localTools": {
-                    "anthropic claude3 model provider": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/6b5a88075b1e4501e845f4dab5be16ea8739aa4c/tool.gpt:Anthropic Claude3 Model Provider"
+                    "anthropic claude3 model provider": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/ee5c02a9aeca5a1cbffcf569751e37432bfe0344/tool.gpt:Anthropic Claude3 Model Provider"
                 },
                 "source": {
-                    "location": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/6b5a88075b1e4501e845f4dab5be16ea8739aa4c/tool.gpt",
+                    "location": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/ee5c02a9aeca5a1cbffcf569751e37432bfe0344/tool.gpt",
                     "lineNo": 1,
                     "repo": {
                         "VCS": "git",
                         "Root": "https://github.com/gptscript-ai/claude3-anthropic-provider.git",
                         "Path": "/",
                         "Name": "tool.gpt",
-                        "Revision": "6b5a88075b1e4501e845f4dab5be16ea8739aa4c"
+                        "Revision": "ee5c02a9aeca5a1cbffcf569751e37432bfe0344"
                     }
                 },
-                "workingDir": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/6b5a88075b1e4501e845f4dab5be16ea8739aa4c"
+                "workingDir": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/ee5c02a9aeca5a1cbffcf569751e37432bfe0344"
             },
             "currentAgent": {},
             "inputContext": null,
@@ -138,17 +138,17 @@
         },
         "type": "callFinish",
         "usage": {},
-        "content": "http://127.0.0.1:10585"
+        "content": "http://127.0.0.1:10739"
     },
     {
-        "time": "2024-07-02T19:39:50.324287-04:00",
+        "time": "2024-08-23T12:02:19.295542-04:00",
         "type": "runFinish",
         "usage": {}
     },
     {
-        "time": "2024-07-02T19:39:50.324366-04:00",
+        "time": "2024-08-23T12:02:19.295604-04:00",
         "callContext": {
-            "id": "1719963589",
+            "id": "1724428938",
             "tool": {
                 "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "internalPrompt": null,
@@ -179,7 +179,7 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1719963591",
+        "chatCompletionId": "1724428940",
         "usage": {},
         "chatRequest": {
             "model": "claude-3-5-sonnet-20240620",
@@ -211,85 +211,9 @@
         }
     },
     {
-        "time": "2024-07-02T19:39:50.324921-04:00",
+        "time": "2024-08-23T12:02:21.136785-04:00",
         "callContext": {
-            "id": "1719963589",
-            "tool": {
-                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "currentAgent": {},
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1719963591",
-        "usage": {},
-        "content": "Waiting for model response..."
-    },
-    {
-        "time": "2024-07-02T19:39:51.941234-04:00",
-        "callContext": {
-            "id": "1719963589",
-            "tool": {
-                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "currentAgent": {},
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1719963591",
-        "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\"question\": \"how are you doing\"}"
-    },
-    {
-        "time": "2024-07-02T19:39:51.941444-04:00",
-        "callContext": {
-            "id": "1719963589",
+            "id": "1724428938",
             "tool": {
                 "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "internalPrompt": null,
@@ -320,7 +244,7 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1719963591",
+        "chatCompletionId": "1724428940",
         "usage": {},
         "chatResponse": {
             "role": "assistant",
@@ -328,7 +252,7 @@
                 {
                     "toolCall": {
                         "index": 0,
-                        "id": "toolu_01SHRzoGuUEQtwBp2ktaqu7P",
+                        "id": "toolu_01XzHFJpwHD8hzowvAqGgfSz",
                         "function": {
                             "name": "bob",
                             "arguments": "{\"question\": \"how are you doing\"}"
@@ -340,9 +264,9 @@
         }
     },
     {
-        "time": "2024-07-02T19:39:51.941523-04:00",
+        "time": "2024-08-23T12:02:21.136848-04:00",
         "callContext": {
-            "id": "1719963589",
+            "id": "1724428938",
             "tool": {
                 "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "internalPrompt": null,
@@ -373,7 +297,7 @@
             "inputContext": null
         },
         "toolSubCalls": {
-            "toolu_01SHRzoGuUEQtwBp2ktaqu7P": {
+            "toolu_01XzHFJpwHD8hzowvAqGgfSz": {
                 "toolID": "testdata/BobAsShell/test.gpt:bob",
                 "input": "{\"question\": \"how are you doing\"}"
             }
@@ -382,9 +306,9 @@
         "usage": {}
     },
     {
-        "time": "2024-07-02T19:39:51.941567-04:00",
+        "time": "2024-08-23T12:02:21.136877-04:00",
         "callContext": {
-            "id": "toolu_01SHRzoGuUEQtwBp2ktaqu7P",
+            "id": "toolu_01XzHFJpwHD8hzowvAqGgfSz",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -399,7 +323,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "#!/bin/bash\n\necho \"Thanks for asking ${question}, I'm doing great fellow friendly AI tool!\"",
+                "instructions": "#!/bin/bash\n\necho \"Thanks for asking ${QUESTION}, I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/BobAsShell/test.gpt:bob",
                 "localTools": {
                     "": "testdata/BobAsShell/test.gpt:",
@@ -414,7 +338,7 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1719963589",
+            "parentID": "1724428938",
             "displayText": "Running bob from testdata/BobAsShell/test.gpt"
         },
         "type": "callStart",
@@ -422,9 +346,9 @@
         "content": "{\"question\": \"how are you doing\"}"
     },
     {
-        "time": "2024-07-02T19:39:51.942241-04:00",
+        "time": "2024-08-23T12:02:21.137223-04:00",
         "callContext": {
-            "id": "toolu_01SHRzoGuUEQtwBp2ktaqu7P",
+            "id": "toolu_01XzHFJpwHD8hzowvAqGgfSz",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -439,7 +363,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "#!/bin/bash\n\necho \"Thanks for asking ${question}, I'm doing great fellow friendly AI tool!\"",
+                "instructions": "#!/bin/bash\n\necho \"Thanks for asking ${QUESTION}, I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/BobAsShell/test.gpt:bob",
                 "localTools": {
                     "": "testdata/BobAsShell/test.gpt:",
@@ -454,11 +378,11 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1719963589",
+            "parentID": "1724428938",
             "displayText": "Running bob from testdata/BobAsShell/test.gpt"
         },
         "type": "callChat",
-        "chatCompletionId": "1719963592",
+        "chatCompletionId": "1724428941",
         "usage": {},
         "chatRequest": {
             "model": "",
@@ -466,9 +390,9 @@
         }
     },
     {
-        "time": "2024-07-02T19:39:51.945596-04:00",
+        "time": "2024-08-23T12:02:21.142624-04:00",
         "callContext": {
-            "id": "toolu_01SHRzoGuUEQtwBp2ktaqu7P",
+            "id": "toolu_01XzHFJpwHD8hzowvAqGgfSz",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -483,7 +407,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "#!/bin/bash\n\necho \"Thanks for asking ${question}, I'm doing great fellow friendly AI tool!\"",
+                "instructions": "#!/bin/bash\n\necho \"Thanks for asking ${QUESTION}, I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/BobAsShell/test.gpt:bob",
                 "localTools": {
                     "": "testdata/BobAsShell/test.gpt:",
@@ -498,61 +422,20 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1719963589",
-            "displayText": "Running bob from testdata/BobAsShell/test.gpt"
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1719963592",
-        "usage": {},
-        "content": "Thanks for asking how are you doing, I'm doing great fellow friendly AI tool!\n"
-    },
-    {
-        "time": "2024-07-02T19:39:51.945769-04:00",
-        "callContext": {
-            "id": "toolu_01SHRzoGuUEQtwBp2ktaqu7P",
-            "tool": {
-                "name": "bob",
-                "description": "I'm Bob, a friendly guy.",
-                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "question": {
-                            "description": "The question to ask Bob.",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "instructions": "#!/bin/bash\n\necho \"Thanks for asking ${question}, I'm doing great fellow friendly AI tool!\"",
-                "id": "testdata/BobAsShell/test.gpt:bob",
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 7
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "currentAgent": {},
-            "inputContext": null,
-            "toolName": "bob",
-            "parentID": "1719963589",
+            "parentID": "1724428938",
             "displayText": "Running bob from testdata/BobAsShell/test.gpt"
         },
         "type": "callChat",
-        "chatCompletionId": "1719963592",
+        "chatCompletionId": "1724428941",
         "usage": {},
         "chatResponse": {
             "usage": {}
         }
     },
     {
-        "time": "2024-07-02T19:39:51.945833-04:00",
+        "time": "2024-08-23T12:02:21.142691-04:00",
         "callContext": {
-            "id": "toolu_01SHRzoGuUEQtwBp2ktaqu7P",
+            "id": "toolu_01XzHFJpwHD8hzowvAqGgfSz",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -567,7 +450,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "#!/bin/bash\n\necho \"Thanks for asking ${question}, I'm doing great fellow friendly AI tool!\"",
+                "instructions": "#!/bin/bash\n\necho \"Thanks for asking ${QUESTION}, I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/BobAsShell/test.gpt:bob",
                 "localTools": {
                     "": "testdata/BobAsShell/test.gpt:",
@@ -582,7 +465,7 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1719963589",
+            "parentID": "1724428938",
             "displayText": "Running bob from testdata/BobAsShell/test.gpt"
         },
         "type": "callFinish",
@@ -590,9 +473,9 @@
         "content": "Thanks for asking how are you doing, I'm doing great fellow friendly AI tool!\n"
     },
     {
-        "time": "2024-07-02T19:39:51.945871-04:00",
+        "time": "2024-08-23T12:02:21.142723-04:00",
         "callContext": {
-            "id": "1719963589",
+            "id": "1724428938",
             "tool": {
                 "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "internalPrompt": null,
@@ -627,9 +510,9 @@
         "usage": {}
     },
     {
-        "time": "2024-07-02T19:39:52.112712-04:00",
+        "time": "2024-08-23T12:02:21.371211-04:00",
         "callContext": {
-            "id": "1719963589",
+            "id": "1724428938",
             "tool": {
                 "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "internalPrompt": null,
@@ -660,7 +543,7 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1719963593",
+        "chatCompletionId": "1724428942",
         "usage": {},
         "chatRequest": {
             "model": "claude-3-5-sonnet-20240620",
@@ -674,7 +557,7 @@
                     "content": "",
                     "tool_calls": [
                         {
-                            "id": "toolu_01SHRzoGuUEQtwBp2ktaqu7P",
+                            "id": "toolu_01XzHFJpwHD8hzowvAqGgfSz",
                             "type": "function",
                             "function": {
                                 "name": "bob",
@@ -687,7 +570,7 @@
                     "role": "tool",
                     "content": "Thanks for asking how are you doing, I'm doing great fellow friendly AI tool!\n",
                     "name": "bob",
-                    "tool_call_id": "toolu_01SHRzoGuUEQtwBp2ktaqu7P"
+                    "tool_call_id": "toolu_01XzHFJpwHD8hzowvAqGgfSz"
                 }
             ],
             "temperature": 0,
@@ -712,85 +595,9 @@
         }
     },
     {
-        "time": "2024-07-02T19:39:52.11309-04:00",
+        "time": "2024-08-23T12:02:23.102371-04:00",
         "callContext": {
-            "id": "1719963589",
-            "tool": {
-                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "currentAgent": {},
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1719963593",
-        "usage": {},
-        "content": "Waiting for model response..."
-    },
-    {
-        "time": "2024-07-02T19:39:53.567604-04:00",
-        "callContext": {
-            "id": "1719963589",
-            "tool": {
-                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "currentAgent": {},
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1719963593",
-        "usage": {},
-        "content": "Bob's reply to the question \"how are you doing\" is:\n\n\"Thanks for asking how are you doing, I'm doing great fellow friendly AI tool!\"\n\nI have repeated his reply exactly as requested."
-    },
-    {
-        "time": "2024-07-02T19:39:53.568556-04:00",
-        "callContext": {
-            "id": "1719963589",
+            "id": "1724428938",
             "tool": {
                 "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "internalPrompt": null,
@@ -821,22 +628,22 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1719963593",
+        "chatCompletionId": "1724428942",
         "usage": {},
         "chatResponse": {
             "role": "assistant",
             "content": [
                 {
-                    "text": "Bob's reply to the question \"how are you doing\" is:\n\n\"Thanks for asking how are you doing, I'm doing great fellow friendly AI tool!\"\n\nI have repeated his reply exactly as requested."
+                    "text": "Bob's reply was: \"Thanks for asking how are you doing, I'm doing great fellow friendly AI tool!\""
                 }
             ],
             "usage": {}
         }
     },
     {
-        "time": "2024-07-02T19:39:53.568602-04:00",
+        "time": "2024-08-23T12:02:23.102422-04:00",
         "callContext": {
-            "id": "1719963589",
+            "id": "1724428938",
             "tool": {
                 "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "internalPrompt": null,
@@ -868,10 +675,10 @@
         },
         "type": "callFinish",
         "usage": {},
-        "content": "Bob's reply to the question \"how are you doing\" is:\n\n\"Thanks for asking how are you doing, I'm doing great fellow friendly AI tool!\"\n\nI have repeated his reply exactly as requested."
+        "content": "Bob's reply was: \"Thanks for asking how are you doing, I'm doing great fellow friendly AI tool!\""
     },
     {
-        "time": "2024-07-02T19:39:53.568622-04:00",
+        "time": "2024-08-23T12:02:23.102441-04:00",
         "type": "runFinish",
         "usage": {}
     }

--- a/pkg/tests/smoke/testdata/BobAsShell/gpt-4-turbo-2024-04-09-expected.json
+++ b/pkg/tests/smoke/testdata/BobAsShell/gpt-4-turbo-2024-04-09-expected.json
@@ -1,13 +1,13 @@
 [
     {
-        "time": "2024-06-20T17:08:30.778302-04:00",
+        "time": "2024-08-23T12:02:28.827063-04:00",
         "type": "runStart",
         "usage": {}
     },
     {
-        "time": "2024-06-20T17:08:30.778582-04:00",
+        "time": "2024-08-23T12:02:28.827338-04:00",
         "callContext": {
-            "id": "1718917711",
+            "id": "1724428949",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
@@ -34,15 +34,16 @@
                 },
                 "workingDir": "testdata/BobAsShell"
             },
+            "currentAgent": {},
             "inputContext": null
         },
         "type": "callStart",
         "usage": {}
     },
     {
-        "time": "2024-06-20T17:08:30.981266-04:00",
+        "time": "2024-08-23T12:02:28.827374-04:00",
         "callContext": {
-            "id": "1718917711",
+            "id": "1724428949",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
@@ -69,10 +70,11 @@
                 },
                 "workingDir": "testdata/BobAsShell"
             },
+            "currentAgent": {},
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1718917712",
+        "chatCompletionId": "1724428950",
         "usage": {},
         "chatRequest": {
             "model": "gpt-4-turbo-2024-04-09",
@@ -104,9 +106,9 @@
         }
     },
     {
-        "time": "2024-06-20T17:08:30.981391-04:00",
+        "time": "2024-08-23T12:02:29.713394-04:00",
         "callContext": {
-            "id": "1718917711",
+            "id": "1724428949",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
@@ -133,454 +135,11 @@
                 },
                 "workingDir": "testdata/BobAsShell"
             },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917712",
-        "usage": {},
-        "content": "Waiting for model response..."
-    },
-    {
-        "time": "2024-06-20T17:08:32.232987-04:00",
-        "callContext": {
-            "id": "1718917711",
-            "tool": {
-                "modelName": "gpt-4-turbo-2024-04-09",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917712",
-        "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\""
-    },
-    {
-        "time": "2024-06-20T17:08:32.233265-04:00",
-        "callContext": {
-            "id": "1718917711",
-            "tool": {
-                "modelName": "gpt-4-turbo-2024-04-09",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917712",
-        "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\""
-    },
-    {
-        "time": "2024-06-20T17:08:32.344744-04:00",
-        "callContext": {
-            "id": "1718917711",
-            "tool": {
-                "modelName": "gpt-4-turbo-2024-04-09",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917712",
-        "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\""
-    },
-    {
-        "time": "2024-06-20T17:08:32.344882-04:00",
-        "callContext": {
-            "id": "1718917711",
-            "tool": {
-                "modelName": "gpt-4-turbo-2024-04-09",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917712",
-        "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\""
-    },
-    {
-        "time": "2024-06-20T17:08:32.361676-04:00",
-        "callContext": {
-            "id": "1718917711",
-            "tool": {
-                "modelName": "gpt-4-turbo-2024-04-09",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917712",
-        "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"how are"
-    },
-    {
-        "time": "2024-06-20T17:08:32.361793-04:00",
-        "callContext": {
-            "id": "1718917711",
-            "tool": {
-                "modelName": "gpt-4-turbo-2024-04-09",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917712",
-        "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"how are"
-    },
-    {
-        "time": "2024-06-20T17:08:32.440498-04:00",
-        "callContext": {
-            "id": "1718917711",
-            "tool": {
-                "modelName": "gpt-4-turbo-2024-04-09",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917712",
-        "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"how are you doing"
-    },
-    {
-        "time": "2024-06-20T17:08:32.440743-04:00",
-        "callContext": {
-            "id": "1718917711",
-            "tool": {
-                "modelName": "gpt-4-turbo-2024-04-09",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917712",
-        "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"how are you doing\"}"
-    },
-    {
-        "time": "2024-06-20T17:08:32.440798-04:00",
-        "callContext": {
-            "id": "1718917711",
-            "tool": {
-                "modelName": "gpt-4-turbo-2024-04-09",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917712",
-        "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"how are you doing\"}"
-    },
-    {
-        "time": "2024-06-20T17:08:32.440836-04:00",
-        "callContext": {
-            "id": "1718917711",
-            "tool": {
-                "modelName": "gpt-4-turbo-2024-04-09",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917712",
-        "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"how are you doing\"}"
-    },
-    {
-        "time": "2024-06-20T17:08:32.440873-04:00",
-        "callContext": {
-            "id": "1718917711",
-            "tool": {
-                "modelName": "gpt-4-turbo-2024-04-09",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917712",
-        "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"how are you doing\"}"
-    },
-    {
-        "time": "2024-06-20T17:08:32.441115-04:00",
-        "callContext": {
-            "id": "1718917711",
-            "tool": {
-                "modelName": "gpt-4-turbo-2024-04-09",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
+            "currentAgent": {},
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1718917712",
+        "chatCompletionId": "1724428950",
         "usage": {
             "promptTokens": 142,
             "completionTokens": 17,
@@ -592,7 +151,7 @@
                 {
                     "toolCall": {
                         "index": 0,
-                        "id": "call_slFgd2P2lMxXQoyrPbm2YsrQ",
+                        "id": "call_N8QA7cLBHO81vn2aMPl26ePU",
                         "function": {
                             "name": "bob",
                             "arguments": "{\"question\":\"how are you doing\"}"
@@ -608,9 +167,9 @@
         }
     },
     {
-        "time": "2024-06-20T17:08:32.441462-04:00",
+        "time": "2024-08-23T12:02:29.713517-04:00",
         "callContext": {
-            "id": "1718917711",
+            "id": "1724428949",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
@@ -637,10 +196,11 @@
                 },
                 "workingDir": "testdata/BobAsShell"
             },
+            "currentAgent": {},
             "inputContext": null
         },
         "toolSubCalls": {
-            "call_slFgd2P2lMxXQoyrPbm2YsrQ": {
+            "call_N8QA7cLBHO81vn2aMPl26ePU": {
                 "toolID": "testdata/BobAsShell/test.gpt:bob",
                 "input": "{\"question\":\"how are you doing\"}"
             }
@@ -649,9 +209,9 @@
         "usage": {}
     },
     {
-        "time": "2024-06-20T17:08:32.441542-04:00",
+        "time": "2024-08-23T12:02:29.713591-04:00",
         "callContext": {
-            "id": "call_slFgd2P2lMxXQoyrPbm2YsrQ",
+            "id": "call_N8QA7cLBHO81vn2aMPl26ePU",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -666,7 +226,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "#!/bin/bash\n\necho \"Thanks for asking ${question}, I'm doing great fellow friendly AI tool!\"",
+                "instructions": "#!/bin/bash\n\necho \"Thanks for asking ${QUESTION}, I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/BobAsShell/test.gpt:bob",
                 "localTools": {
                     "": "testdata/BobAsShell/test.gpt:",
@@ -678,9 +238,10 @@
                 },
                 "workingDir": "testdata/BobAsShell"
             },
+            "currentAgent": {},
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1718917711",
+            "parentID": "1724428949",
             "displayText": "Running bob from testdata/BobAsShell/test.gpt"
         },
         "type": "callStart",
@@ -688,9 +249,9 @@
         "content": "{\"question\":\"how are you doing\"}"
     },
     {
-        "time": "2024-06-20T17:08:32.442736-04:00",
+        "time": "2024-08-23T12:02:29.714186-04:00",
         "callContext": {
-            "id": "call_slFgd2P2lMxXQoyrPbm2YsrQ",
+            "id": "call_N8QA7cLBHO81vn2aMPl26ePU",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -705,7 +266,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "#!/bin/bash\n\necho \"Thanks for asking ${question}, I'm doing great fellow friendly AI tool!\"",
+                "instructions": "#!/bin/bash\n\necho \"Thanks for asking ${QUESTION}, I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/BobAsShell/test.gpt:bob",
                 "localTools": {
                     "": "testdata/BobAsShell/test.gpt:",
@@ -717,13 +278,14 @@
                 },
                 "workingDir": "testdata/BobAsShell"
             },
+            "currentAgent": {},
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1718917711",
+            "parentID": "1724428949",
             "displayText": "Running bob from testdata/BobAsShell/test.gpt"
         },
         "type": "callChat",
-        "chatCompletionId": "1718917713",
+        "chatCompletionId": "1724428951",
         "usage": {},
         "chatRequest": {
             "model": "",
@@ -731,9 +293,9 @@
         }
     },
     {
-        "time": "2024-06-20T17:08:32.448288-04:00",
+        "time": "2024-08-23T12:02:29.725933-04:00",
         "callContext": {
-            "id": "call_slFgd2P2lMxXQoyrPbm2YsrQ",
+            "id": "call_N8QA7cLBHO81vn2aMPl26ePU",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -748,7 +310,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "#!/bin/bash\n\necho \"Thanks for asking ${question}, I'm doing great fellow friendly AI tool!\"",
+                "instructions": "#!/bin/bash\n\necho \"Thanks for asking ${QUESTION}, I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/BobAsShell/test.gpt:bob",
                 "localTools": {
                     "": "testdata/BobAsShell/test.gpt:",
@@ -760,62 +322,23 @@
                 },
                 "workingDir": "testdata/BobAsShell"
             },
+            "currentAgent": {},
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1718917711",
-            "displayText": "Running bob from testdata/BobAsShell/test.gpt"
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917713",
-        "usage": {},
-        "content": "Thanks for asking how are you doing, I'm doing great fellow friendly AI tool!\n"
-    },
-    {
-        "time": "2024-06-20T17:08:32.448728-04:00",
-        "callContext": {
-            "id": "call_slFgd2P2lMxXQoyrPbm2YsrQ",
-            "tool": {
-                "name": "bob",
-                "description": "I'm Bob, a friendly guy.",
-                "modelName": "gpt-4-turbo-2024-04-09",
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "question": {
-                            "description": "The question to ask Bob.",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "instructions": "#!/bin/bash\n\necho \"Thanks for asking ${question}, I'm doing great fellow friendly AI tool!\"",
-                "id": "testdata/BobAsShell/test.gpt:bob",
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 7
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "inputContext": null,
-            "toolName": "bob",
-            "parentID": "1718917711",
+            "parentID": "1724428949",
             "displayText": "Running bob from testdata/BobAsShell/test.gpt"
         },
         "type": "callChat",
-        "chatCompletionId": "1718917713",
+        "chatCompletionId": "1724428951",
         "usage": {},
         "chatResponse": {
             "usage": {}
         }
     },
     {
-        "time": "2024-06-20T17:08:32.448906-04:00",
+        "time": "2024-08-23T12:02:29.726078-04:00",
         "callContext": {
-            "id": "call_slFgd2P2lMxXQoyrPbm2YsrQ",
+            "id": "call_N8QA7cLBHO81vn2aMPl26ePU",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -830,7 +353,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "#!/bin/bash\n\necho \"Thanks for asking ${question}, I'm doing great fellow friendly AI tool!\"",
+                "instructions": "#!/bin/bash\n\necho \"Thanks for asking ${QUESTION}, I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/BobAsShell/test.gpt:bob",
                 "localTools": {
                     "": "testdata/BobAsShell/test.gpt:",
@@ -842,9 +365,10 @@
                 },
                 "workingDir": "testdata/BobAsShell"
             },
+            "currentAgent": {},
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1718917711",
+            "parentID": "1724428949",
             "displayText": "Running bob from testdata/BobAsShell/test.gpt"
         },
         "type": "callFinish",
@@ -852,9 +376,9 @@
         "content": "Thanks for asking how are you doing, I'm doing great fellow friendly AI tool!\n"
     },
     {
-        "time": "2024-06-20T17:08:32.448977-04:00",
+        "time": "2024-08-23T12:02:29.726132-04:00",
         "callContext": {
-            "id": "1718917711",
+            "id": "1724428949",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
@@ -881,6 +405,7 @@
                 },
                 "workingDir": "testdata/BobAsShell"
             },
+            "currentAgent": {},
             "inputContext": null
         },
         "toolResults": 1,
@@ -888,9 +413,9 @@
         "usage": {}
     },
     {
-        "time": "2024-06-20T17:08:32.624086-04:00",
+        "time": "2024-08-23T12:02:29.726308-04:00",
         "callContext": {
-            "id": "1718917711",
+            "id": "1724428949",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
@@ -917,10 +442,11 @@
                 },
                 "workingDir": "testdata/BobAsShell"
             },
+            "currentAgent": {},
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1718917714",
+        "chatCompletionId": "1724428952",
         "usage": {},
         "chatRequest": {
             "model": "gpt-4-turbo-2024-04-09",
@@ -934,7 +460,7 @@
                     "content": "",
                     "tool_calls": [
                         {
-                            "id": "call_slFgd2P2lMxXQoyrPbm2YsrQ",
+                            "id": "call_N8QA7cLBHO81vn2aMPl26ePU",
                             "type": "function",
                             "function": {
                                 "name": "bob",
@@ -947,7 +473,7 @@
                     "role": "tool",
                     "content": "Thanks for asking how are you doing, I'm doing great fellow friendly AI tool!\n",
                     "name": "bob",
-                    "tool_call_id": "call_slFgd2P2lMxXQoyrPbm2YsrQ"
+                    "tool_call_id": "call_N8QA7cLBHO81vn2aMPl26ePU"
                 }
             ],
             "temperature": 0,
@@ -972,9 +498,9 @@
         }
     },
     {
-        "time": "2024-06-20T17:08:32.624367-04:00",
+        "time": "2024-08-23T12:02:30.671677-04:00",
         "callContext": {
-            "id": "1718917711",
+            "id": "1724428949",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
@@ -1001,491 +527,11 @@
                 },
                 "workingDir": "testdata/BobAsShell"
             },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917714",
-        "usage": {},
-        "content": "Waiting for model response..."
-    },
-    {
-        "time": "2024-06-20T17:08:33.020025-04:00",
-        "callContext": {
-            "id": "1718917711",
-            "tool": {
-                "modelName": "gpt-4-turbo-2024-04-09",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917714",
-        "usage": {},
-        "content": "I"
-    },
-    {
-        "time": "2024-06-20T17:08:33.020187-04:00",
-        "callContext": {
-            "id": "1718917711",
-            "tool": {
-                "modelName": "gpt-4-turbo-2024-04-09",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917714",
-        "usage": {},
-        "content": "I"
-    },
-    {
-        "time": "2024-06-20T17:08:33.09047-04:00",
-        "callContext": {
-            "id": "1718917711",
-            "tool": {
-                "modelName": "gpt-4-turbo-2024-04-09",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917714",
-        "usage": {},
-        "content": "I'm doing"
-    },
-    {
-        "time": "2024-06-20T17:08:33.090722-04:00",
-        "callContext": {
-            "id": "1718917711",
-            "tool": {
-                "modelName": "gpt-4-turbo-2024-04-09",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917714",
-        "usage": {},
-        "content": "I'm doing"
-    },
-    {
-        "time": "2024-06-20T17:08:33.150983-04:00",
-        "callContext": {
-            "id": "1718917711",
-            "tool": {
-                "modelName": "gpt-4-turbo-2024-04-09",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917714",
-        "usage": {},
-        "content": "I'm doing great fellow"
-    },
-    {
-        "time": "2024-06-20T17:08:33.151128-04:00",
-        "callContext": {
-            "id": "1718917711",
-            "tool": {
-                "modelName": "gpt-4-turbo-2024-04-09",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917714",
-        "usage": {},
-        "content": "I'm doing great fellow"
-    },
-    {
-        "time": "2024-06-20T17:08:33.26424-04:00",
-        "callContext": {
-            "id": "1718917711",
-            "tool": {
-                "modelName": "gpt-4-turbo-2024-04-09",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917714",
-        "usage": {},
-        "content": "I'm doing great fellow friendly AI"
-    },
-    {
-        "time": "2024-06-20T17:08:33.264352-04:00",
-        "callContext": {
-            "id": "1718917711",
-            "tool": {
-                "modelName": "gpt-4-turbo-2024-04-09",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917714",
-        "usage": {},
-        "content": "I'm doing great fellow friendly AI tool"
-    },
-    {
-        "time": "2024-06-20T17:08:33.264393-04:00",
-        "callContext": {
-            "id": "1718917711",
-            "tool": {
-                "modelName": "gpt-4-turbo-2024-04-09",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917714",
-        "usage": {},
-        "content": "I'm doing great fellow friendly AI tool"
-    },
-    {
-        "time": "2024-06-20T17:08:33.264427-04:00",
-        "callContext": {
-            "id": "1718917711",
-            "tool": {
-                "modelName": "gpt-4-turbo-2024-04-09",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917714",
-        "usage": {},
-        "content": "I'm doing great fellow friendly AI tool!"
-    },
-    {
-        "time": "2024-06-20T17:08:33.264492-04:00",
-        "callContext": {
-            "id": "1718917711",
-            "tool": {
-                "modelName": "gpt-4-turbo-2024-04-09",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917714",
-        "usage": {},
-        "content": "I'm doing great fellow friendly AI tool!"
-    },
-    {
-        "time": "2024-06-20T17:08:33.264575-04:00",
-        "callContext": {
-            "id": "1718917711",
-            "tool": {
-                "modelName": "gpt-4-turbo-2024-04-09",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917714",
-        "usage": {},
-        "content": "I'm doing great fellow friendly AI tool!"
-    },
-    {
-        "time": "2024-06-20T17:08:33.264897-04:00",
-        "callContext": {
-            "id": "1718917711",
-            "tool": {
-                "modelName": "gpt-4-turbo-2024-04-09",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
+            "currentAgent": {},
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1718917714",
+        "chatCompletionId": "1724428952",
         "usage": {
             "promptTokens": 183,
             "completionTokens": 10,
@@ -1506,9 +552,9 @@
         }
     },
     {
-        "time": "2024-06-20T17:08:33.264985-04:00",
+        "time": "2024-08-23T12:02:30.671782-04:00",
         "callContext": {
-            "id": "1718917711",
+            "id": "1724428949",
             "tool": {
                 "modelName": "gpt-4-turbo-2024-04-09",
                 "internalPrompt": null,
@@ -1535,6 +581,7 @@
                 },
                 "workingDir": "testdata/BobAsShell"
             },
+            "currentAgent": {},
             "inputContext": null
         },
         "type": "callFinish",
@@ -1542,7 +589,7 @@
         "content": "I'm doing great fellow friendly AI tool!"
     },
     {
-        "time": "2024-06-20T17:08:33.265021-04:00",
+        "time": "2024-08-23T12:02:30.671853-04:00",
         "type": "runFinish",
         "usage": {}
     }

--- a/pkg/tests/smoke/testdata/BobAsShell/gpt-4o-2024-05-13-expected.json
+++ b/pkg/tests/smoke/testdata/BobAsShell/gpt-4o-2024-05-13-expected.json
@@ -1,13 +1,13 @@
 [
     {
-        "time": "2024-06-20T16:58:14.093283-04:00",
+        "time": "2024-08-23T12:02:21.894088-04:00",
         "type": "runStart",
         "usage": {}
     },
     {
-        "time": "2024-06-20T16:58:14.093568-04:00",
+        "time": "2024-08-23T12:02:21.894448-04:00",
         "callContext": {
-            "id": "1718917095",
+            "id": "1724428942",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
@@ -34,15 +34,16 @@
                 },
                 "workingDir": "testdata/BobAsShell"
             },
+            "currentAgent": {},
             "inputContext": null
         },
         "type": "callStart",
         "usage": {}
     },
     {
-        "time": "2024-06-20T16:58:14.31069-04:00",
+        "time": "2024-08-23T12:02:21.894496-04:00",
         "callContext": {
-            "id": "1718917095",
+            "id": "1724428942",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
@@ -69,10 +70,11 @@
                 },
                 "workingDir": "testdata/BobAsShell"
             },
+            "currentAgent": {},
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1718917096",
+        "chatCompletionId": "1724428943",
         "usage": {},
         "chatRequest": {
             "model": "gpt-4o-2024-05-13",
@@ -104,9 +106,9 @@
         }
     },
     {
-        "time": "2024-06-20T16:58:14.311071-04:00",
+        "time": "2024-08-23T12:02:22.83529-04:00",
         "callContext": {
-            "id": "1718917095",
+            "id": "1724428942",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
@@ -133,454 +135,11 @@
                 },
                 "workingDir": "testdata/BobAsShell"
             },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917096",
-        "usage": {},
-        "content": "Waiting for model response..."
-    },
-    {
-        "time": "2024-06-20T16:58:14.807492-04:00",
-        "callContext": {
-            "id": "1718917095",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917096",
-        "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\""
-    },
-    {
-        "time": "2024-06-20T16:58:14.807779-04:00",
-        "callContext": {
-            "id": "1718917095",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917096",
-        "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\""
-    },
-    {
-        "time": "2024-06-20T16:58:14.832551-04:00",
-        "callContext": {
-            "id": "1718917095",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917096",
-        "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\""
-    },
-    {
-        "time": "2024-06-20T16:58:14.832684-04:00",
-        "callContext": {
-            "id": "1718917095",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917096",
-        "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\""
-    },
-    {
-        "time": "2024-06-20T16:58:14.865368-04:00",
-        "callContext": {
-            "id": "1718917095",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917096",
-        "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"how are"
-    },
-    {
-        "time": "2024-06-20T16:58:14.865484-04:00",
-        "callContext": {
-            "id": "1718917095",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917096",
-        "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"how are"
-    },
-    {
-        "time": "2024-06-20T16:58:14.899511-04:00",
-        "callContext": {
-            "id": "1718917095",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917096",
-        "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"how are you doing"
-    },
-    {
-        "time": "2024-06-20T16:58:14.899668-04:00",
-        "callContext": {
-            "id": "1718917095",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917096",
-        "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"how are you doing"
-    },
-    {
-        "time": "2024-06-20T16:58:14.900883-04:00",
-        "callContext": {
-            "id": "1718917095",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917096",
-        "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"how are you doing\"}"
-    },
-    {
-        "time": "2024-06-20T16:58:14.900938-04:00",
-        "callContext": {
-            "id": "1718917095",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917096",
-        "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"how are you doing\"}"
-    },
-    {
-        "time": "2024-06-20T16:58:14.900969-04:00",
-        "callContext": {
-            "id": "1718917095",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917096",
-        "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\"question\":\"how are you doing\"}"
-    },
-    {
-        "time": "2024-06-20T16:58:14.901222-04:00",
-        "callContext": {
-            "id": "1718917095",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
+            "currentAgent": {},
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1718917096",
+        "chatCompletionId": "1724428943",
         "usage": {
             "promptTokens": 138,
             "completionTokens": 17,
@@ -592,7 +151,7 @@
                 {
                     "toolCall": {
                         "index": 0,
-                        "id": "call_PGLxooO6eBPt3eSEBCMkuWYN",
+                        "id": "call_pB38ObWgS96V6gFLrkCcw1pu",
                         "function": {
                             "name": "bob",
                             "arguments": "{\"question\":\"how are you doing\"}"
@@ -608,9 +167,9 @@
         }
     },
     {
-        "time": "2024-06-20T16:58:14.901521-04:00",
+        "time": "2024-08-23T12:02:22.835575-04:00",
         "callContext": {
-            "id": "1718917095",
+            "id": "1724428942",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
@@ -637,10 +196,11 @@
                 },
                 "workingDir": "testdata/BobAsShell"
             },
+            "currentAgent": {},
             "inputContext": null
         },
         "toolSubCalls": {
-            "call_PGLxooO6eBPt3eSEBCMkuWYN": {
+            "call_pB38ObWgS96V6gFLrkCcw1pu": {
                 "toolID": "testdata/BobAsShell/test.gpt:bob",
                 "input": "{\"question\":\"how are you doing\"}"
             }
@@ -649,9 +209,9 @@
         "usage": {}
     },
     {
-        "time": "2024-06-20T16:58:14.901599-04:00",
+        "time": "2024-08-23T12:02:22.835716-04:00",
         "callContext": {
-            "id": "call_PGLxooO6eBPt3eSEBCMkuWYN",
+            "id": "call_pB38ObWgS96V6gFLrkCcw1pu",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -666,7 +226,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "#!/bin/bash\n\necho \"Thanks for asking ${question}, I'm doing great fellow friendly AI tool!\"",
+                "instructions": "#!/bin/bash\n\necho \"Thanks for asking ${QUESTION}, I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/BobAsShell/test.gpt:bob",
                 "localTools": {
                     "": "testdata/BobAsShell/test.gpt:",
@@ -678,9 +238,10 @@
                 },
                 "workingDir": "testdata/BobAsShell"
             },
+            "currentAgent": {},
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1718917095",
+            "parentID": "1724428942",
             "displayText": "Running bob from testdata/BobAsShell/test.gpt"
         },
         "type": "callStart",
@@ -688,9 +249,9 @@
         "content": "{\"question\":\"how are you doing\"}"
     },
     {
-        "time": "2024-06-20T16:58:14.90268-04:00",
+        "time": "2024-08-23T12:02:22.836811-04:00",
         "callContext": {
-            "id": "call_PGLxooO6eBPt3eSEBCMkuWYN",
+            "id": "call_pB38ObWgS96V6gFLrkCcw1pu",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -705,7 +266,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "#!/bin/bash\n\necho \"Thanks for asking ${question}, I'm doing great fellow friendly AI tool!\"",
+                "instructions": "#!/bin/bash\n\necho \"Thanks for asking ${QUESTION}, I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/BobAsShell/test.gpt:bob",
                 "localTools": {
                     "": "testdata/BobAsShell/test.gpt:",
@@ -717,13 +278,14 @@
                 },
                 "workingDir": "testdata/BobAsShell"
             },
+            "currentAgent": {},
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1718917095",
+            "parentID": "1724428942",
             "displayText": "Running bob from testdata/BobAsShell/test.gpt"
         },
         "type": "callChat",
-        "chatCompletionId": "1718917097",
+        "chatCompletionId": "1724428944",
         "usage": {},
         "chatRequest": {
             "model": "",
@@ -731,9 +293,9 @@
         }
     },
     {
-        "time": "2024-06-20T16:58:14.908538-04:00",
+        "time": "2024-08-23T12:02:22.847861-04:00",
         "callContext": {
-            "id": "call_PGLxooO6eBPt3eSEBCMkuWYN",
+            "id": "call_pB38ObWgS96V6gFLrkCcw1pu",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -748,7 +310,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "#!/bin/bash\n\necho \"Thanks for asking ${question}, I'm doing great fellow friendly AI tool!\"",
+                "instructions": "#!/bin/bash\n\necho \"Thanks for asking ${QUESTION}, I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/BobAsShell/test.gpt:bob",
                 "localTools": {
                     "": "testdata/BobAsShell/test.gpt:",
@@ -760,62 +322,23 @@
                 },
                 "workingDir": "testdata/BobAsShell"
             },
+            "currentAgent": {},
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1718917095",
-            "displayText": "Running bob from testdata/BobAsShell/test.gpt"
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917097",
-        "usage": {},
-        "content": "Thanks for asking how are you doing, I'm doing great fellow friendly AI tool!\n"
-    },
-    {
-        "time": "2024-06-20T16:58:14.908991-04:00",
-        "callContext": {
-            "id": "call_PGLxooO6eBPt3eSEBCMkuWYN",
-            "tool": {
-                "name": "bob",
-                "description": "I'm Bob, a friendly guy.",
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "question": {
-                            "description": "The question to ask Bob.",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "instructions": "#!/bin/bash\n\necho \"Thanks for asking ${question}, I'm doing great fellow friendly AI tool!\"",
-                "id": "testdata/BobAsShell/test.gpt:bob",
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 7
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "inputContext": null,
-            "toolName": "bob",
-            "parentID": "1718917095",
+            "parentID": "1724428942",
             "displayText": "Running bob from testdata/BobAsShell/test.gpt"
         },
         "type": "callChat",
-        "chatCompletionId": "1718917097",
+        "chatCompletionId": "1724428944",
         "usage": {},
         "chatResponse": {
             "usage": {}
         }
     },
     {
-        "time": "2024-06-20T16:58:14.909126-04:00",
+        "time": "2024-08-23T12:02:22.848037-04:00",
         "callContext": {
-            "id": "call_PGLxooO6eBPt3eSEBCMkuWYN",
+            "id": "call_pB38ObWgS96V6gFLrkCcw1pu",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -830,7 +353,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "#!/bin/bash\n\necho \"Thanks for asking ${question}, I'm doing great fellow friendly AI tool!\"",
+                "instructions": "#!/bin/bash\n\necho \"Thanks for asking ${QUESTION}, I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/BobAsShell/test.gpt:bob",
                 "localTools": {
                     "": "testdata/BobAsShell/test.gpt:",
@@ -842,9 +365,10 @@
                 },
                 "workingDir": "testdata/BobAsShell"
             },
+            "currentAgent": {},
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1718917095",
+            "parentID": "1724428942",
             "displayText": "Running bob from testdata/BobAsShell/test.gpt"
         },
         "type": "callFinish",
@@ -852,9 +376,9 @@
         "content": "Thanks for asking how are you doing, I'm doing great fellow friendly AI tool!\n"
     },
     {
-        "time": "2024-06-20T16:58:14.909293-04:00",
+        "time": "2024-08-23T12:02:22.848097-04:00",
         "callContext": {
-            "id": "1718917095",
+            "id": "1724428942",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
@@ -881,6 +405,7 @@
                 },
                 "workingDir": "testdata/BobAsShell"
             },
+            "currentAgent": {},
             "inputContext": null
         },
         "toolResults": 1,
@@ -888,9 +413,9 @@
         "usage": {}
     },
     {
-        "time": "2024-06-20T16:58:15.10962-04:00",
+        "time": "2024-08-23T12:02:22.848264-04:00",
         "callContext": {
-            "id": "1718917095",
+            "id": "1724428942",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
@@ -917,10 +442,11 @@
                 },
                 "workingDir": "testdata/BobAsShell"
             },
+            "currentAgent": {},
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1718917098",
+        "chatCompletionId": "1724428945",
         "usage": {},
         "chatRequest": {
             "model": "gpt-4o-2024-05-13",
@@ -934,7 +460,7 @@
                     "content": "",
                     "tool_calls": [
                         {
-                            "id": "call_PGLxooO6eBPt3eSEBCMkuWYN",
+                            "id": "call_pB38ObWgS96V6gFLrkCcw1pu",
                             "type": "function",
                             "function": {
                                 "name": "bob",
@@ -947,7 +473,7 @@
                     "role": "tool",
                     "content": "Thanks for asking how are you doing, I'm doing great fellow friendly AI tool!\n",
                     "name": "bob",
-                    "tool_call_id": "call_PGLxooO6eBPt3eSEBCMkuWYN"
+                    "tool_call_id": "call_pB38ObWgS96V6gFLrkCcw1pu"
                 }
             ],
             "temperature": 0,
@@ -972,9 +498,9 @@
         }
     },
     {
-        "time": "2024-06-20T16:58:15.110087-04:00",
+        "time": "2024-08-23T12:02:23.374142-04:00",
         "callContext": {
-            "id": "1718917095",
+            "id": "1724428942",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
@@ -1001,750 +527,11 @@
                 },
                 "workingDir": "testdata/BobAsShell"
             },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917098",
-        "usage": {},
-        "content": "Waiting for model response..."
-    },
-    {
-        "time": "2024-06-20T16:58:15.629792-04:00",
-        "callContext": {
-            "id": "1718917095",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917098",
-        "usage": {},
-        "content": "Thanks"
-    },
-    {
-        "time": "2024-06-20T16:58:15.629968-04:00",
-        "callContext": {
-            "id": "1718917095",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917098",
-        "usage": {},
-        "content": "Thanks"
-    },
-    {
-        "time": "2024-06-20T16:58:15.749206-04:00",
-        "callContext": {
-            "id": "1718917095",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917098",
-        "usage": {},
-        "content": "Thanks for"
-    },
-    {
-        "time": "2024-06-20T16:58:15.749324-04:00",
-        "callContext": {
-            "id": "1718917095",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917098",
-        "usage": {},
-        "content": "Thanks for asking"
-    },
-    {
-        "time": "2024-06-20T16:58:15.780062-04:00",
-        "callContext": {
-            "id": "1718917095",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917098",
-        "usage": {},
-        "content": "Thanks for asking how are"
-    },
-    {
-        "time": "2024-06-20T16:58:15.780171-04:00",
-        "callContext": {
-            "id": "1718917095",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917098",
-        "usage": {},
-        "content": "Thanks for asking how are you"
-    },
-    {
-        "time": "2024-06-20T16:58:15.780293-04:00",
-        "callContext": {
-            "id": "1718917095",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917098",
-        "usage": {},
-        "content": "Thanks for asking how are you doing"
-    },
-    {
-        "time": "2024-06-20T16:58:15.780335-04:00",
-        "callContext": {
-            "id": "1718917095",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917098",
-        "usage": {},
-        "content": "Thanks for asking how are you doing"
-    },
-    {
-        "time": "2024-06-20T16:58:15.780406-04:00",
-        "callContext": {
-            "id": "1718917095",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917098",
-        "usage": {},
-        "content": "Thanks for asking how are you doing, I'm"
-    },
-    {
-        "time": "2024-06-20T16:58:15.780445-04:00",
-        "callContext": {
-            "id": "1718917095",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917098",
-        "usage": {},
-        "content": "Thanks for asking how are you doing, I'm"
-    },
-    {
-        "time": "2024-06-20T16:58:15.780477-04:00",
-        "callContext": {
-            "id": "1718917095",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917098",
-        "usage": {},
-        "content": "Thanks for asking how are you doing, I'm doing"
-    },
-    {
-        "time": "2024-06-20T16:58:15.780511-04:00",
-        "callContext": {
-            "id": "1718917095",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917098",
-        "usage": {},
-        "content": "Thanks for asking how are you doing, I'm doing great"
-    },
-    {
-        "time": "2024-06-20T16:58:15.816742-04:00",
-        "callContext": {
-            "id": "1718917095",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917098",
-        "usage": {},
-        "content": "Thanks for asking how are you doing, I'm doing great fellow friendly"
-    },
-    {
-        "time": "2024-06-20T16:58:15.816889-04:00",
-        "callContext": {
-            "id": "1718917095",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917098",
-        "usage": {},
-        "content": "Thanks for asking how are you doing, I'm doing great fellow friendly"
-    },
-    {
-        "time": "2024-06-20T16:58:15.859699-04:00",
-        "callContext": {
-            "id": "1718917095",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917098",
-        "usage": {},
-        "content": "Thanks for asking how are you doing, I'm doing great fellow friendly AI tool"
-    },
-    {
-        "time": "2024-06-20T16:58:15.859764-04:00",
-        "callContext": {
-            "id": "1718917095",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917098",
-        "usage": {},
-        "content": "Thanks for asking how are you doing, I'm doing great fellow friendly AI tool!"
-    },
-    {
-        "time": "2024-06-20T16:58:15.859784-04:00",
-        "callContext": {
-            "id": "1718917095",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917098",
-        "usage": {},
-        "content": "Thanks for asking how are you doing, I'm doing great fellow friendly AI tool!"
-    },
-    {
-        "time": "2024-06-20T16:58:15.859841-04:00",
-        "callContext": {
-            "id": "1718917095",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917098",
-        "usage": {},
-        "content": "Thanks for asking how are you doing, I'm doing great fellow friendly AI tool!"
-    },
-    {
-        "time": "2024-06-20T16:58:15.85986-04:00",
-        "callContext": {
-            "id": "1718917095",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1718917098",
-        "usage": {},
-        "content": "Thanks for asking how are you doing, I'm doing great fellow friendly AI tool!"
-    },
-    {
-        "time": "2024-06-20T16:58:15.860819-04:00",
-        "callContext": {
-            "id": "1718917095",
-            "tool": {
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
+            "currentAgent": {},
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1718917098",
+        "chatCompletionId": "1724428945",
         "usage": {
             "promptTokens": 178,
             "completionTokens": 17,
@@ -1765,9 +552,9 @@
         }
     },
     {
-        "time": "2024-06-20T16:58:15.860872-04:00",
+        "time": "2024-08-23T12:02:23.37416-04:00",
         "callContext": {
-            "id": "1718917095",
+            "id": "1724428942",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
@@ -1794,6 +581,7 @@
                 },
                 "workingDir": "testdata/BobAsShell"
             },
+            "currentAgent": {},
             "inputContext": null
         },
         "type": "callFinish",
@@ -1801,7 +589,7 @@
         "content": "Thanks for asking how are you doing, I'm doing great fellow friendly AI tool!"
     },
     {
-        "time": "2024-06-20T16:58:15.860919-04:00",
+        "time": "2024-08-23T12:02:23.374173-04:00",
         "type": "runFinish",
         "usage": {}
     }

--- a/pkg/tests/smoke/testdata/BobAsShell/gpt-4o-2024-08-06-expected.json
+++ b/pkg/tests/smoke/testdata/BobAsShell/gpt-4o-2024-08-06-expected.json
@@ -1,38 +1,38 @@
 [
     {
-        "time": "2024-08-23T10:57:23.621143-04:00",
+        "time": "2024-08-23T10:47:06.912223-04:00",
         "type": "runStart",
         "usage": {}
     },
     {
-        "time": "2024-08-23T10:57:23.62178-04:00",
+        "time": "2024-08-23T10:47:06.912642-04:00",
         "callContext": {
-            "id": "1724425044",
+            "id": "1724424427",
             "tool": {
-                "modelName": "gpt-4-turbo-2024-04-09",
+                "modelName": "gpt-4o-2024-08-06",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
                 "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
+                "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
                         {
                             "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
+                            "toolID": "testdata/BobAsShell/test.gpt:bob"
                         }
                     ]
                 },
                 "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
+                    "": "testdata/BobAsShell/test.gpt:",
+                    "bob": "testdata/BobAsShell/test.gpt:bob"
                 },
                 "source": {
-                    "location": "testdata/Bob/test.gpt",
+                    "location": "testdata/BobAsShell/test.gpt",
                     "lineNo": 1
                 },
-                "workingDir": "testdata/Bob"
+                "workingDir": "testdata/BobAsShell"
             },
             "currentAgent": {},
             "inputContext": null
@@ -41,43 +41,43 @@
         "usage": {}
     },
     {
-        "time": "2024-08-23T10:57:23.621807-04:00",
+        "time": "2024-08-23T10:47:06.912689-04:00",
         "callContext": {
-            "id": "1724425044",
+            "id": "1724424427",
             "tool": {
-                "modelName": "gpt-4-turbo-2024-04-09",
+                "modelName": "gpt-4o-2024-08-06",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
                 "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
+                "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
                         {
                             "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
+                            "toolID": "testdata/BobAsShell/test.gpt:bob"
                         }
                     ]
                 },
                 "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
+                    "": "testdata/BobAsShell/test.gpt:",
+                    "bob": "testdata/BobAsShell/test.gpt:bob"
                 },
                 "source": {
-                    "location": "testdata/Bob/test.gpt",
+                    "location": "testdata/BobAsShell/test.gpt",
                     "lineNo": 1
                 },
-                "workingDir": "testdata/Bob"
+                "workingDir": "testdata/BobAsShell"
             },
             "currentAgent": {},
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1724425045",
+        "chatCompletionId": "1724424428",
         "usage": {},
         "chatRequest": {
-            "model": "gpt-4-turbo-2024-04-09",
+            "model": "gpt-4o-2024-08-06",
             "messages": [
                 {
                     "role": "system",
@@ -106,44 +106,44 @@
         }
     },
     {
-        "time": "2024-08-23T10:57:24.816101-04:00",
+        "time": "2024-08-23T10:47:07.441483-04:00",
         "callContext": {
-            "id": "1724425044",
+            "id": "1724424427",
             "tool": {
-                "modelName": "gpt-4-turbo-2024-04-09",
+                "modelName": "gpt-4o-2024-08-06",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
                 "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
+                "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
                         {
                             "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
+                            "toolID": "testdata/BobAsShell/test.gpt:bob"
                         }
                     ]
                 },
                 "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
+                    "": "testdata/BobAsShell/test.gpt:",
+                    "bob": "testdata/BobAsShell/test.gpt:bob"
                 },
                 "source": {
-                    "location": "testdata/Bob/test.gpt",
+                    "location": "testdata/BobAsShell/test.gpt",
                     "lineNo": 1
                 },
-                "workingDir": "testdata/Bob"
+                "workingDir": "testdata/BobAsShell"
             },
             "currentAgent": {},
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1724425045",
+        "chatCompletionId": "1724424428",
         "usage": {
-            "promptTokens": 142,
+            "promptTokens": 138,
             "completionTokens": 17,
-            "totalTokens": 159
+            "totalTokens": 155
         },
         "chatResponse": {
             "role": "assistant",
@@ -151,7 +151,7 @@
                 {
                     "toolCall": {
                         "index": 0,
-                        "id": "call_GuCVVGT6CDEdsFWn13k880S2",
+                        "id": "call_NjCLsJjY7PegUkXOqx5DA0o0",
                         "function": {
                             "name": "bob",
                             "arguments": "{\"question\":\"how are you doing\"}"
@@ -160,48 +160,48 @@
                 }
             ],
             "usage": {
-                "promptTokens": 142,
+                "promptTokens": 138,
                 "completionTokens": 17,
-                "totalTokens": 159
+                "totalTokens": 155
             }
         }
     },
     {
-        "time": "2024-08-23T10:57:24.81638-04:00",
+        "time": "2024-08-23T10:47:07.441781-04:00",
         "callContext": {
-            "id": "1724425044",
+            "id": "1724424427",
             "tool": {
-                "modelName": "gpt-4-turbo-2024-04-09",
+                "modelName": "gpt-4o-2024-08-06",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
                 "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
+                "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
                         {
                             "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
+                            "toolID": "testdata/BobAsShell/test.gpt:bob"
                         }
                     ]
                 },
                 "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
+                    "": "testdata/BobAsShell/test.gpt:",
+                    "bob": "testdata/BobAsShell/test.gpt:bob"
                 },
                 "source": {
-                    "location": "testdata/Bob/test.gpt",
+                    "location": "testdata/BobAsShell/test.gpt",
                     "lineNo": 1
                 },
-                "workingDir": "testdata/Bob"
+                "workingDir": "testdata/BobAsShell"
             },
             "currentAgent": {},
             "inputContext": null
         },
         "toolSubCalls": {
-            "call_GuCVVGT6CDEdsFWn13k880S2": {
-                "toolID": "testdata/Bob/test.gpt:bob",
+            "call_NjCLsJjY7PegUkXOqx5DA0o0": {
+                "toolID": "testdata/BobAsShell/test.gpt:bob",
                 "input": "{\"question\":\"how are you doing\"}"
             }
         },
@@ -209,13 +209,13 @@
         "usage": {}
     },
     {
-        "time": "2024-08-23T10:57:24.816559-04:00",
+        "time": "2024-08-23T10:47:07.441904-04:00",
         "callContext": {
-            "id": "call_GuCVVGT6CDEdsFWn13k880S2",
+            "id": "call_NjCLsJjY7PegUkXOqx5DA0o0",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
-                "modelName": "gpt-4-turbo-2024-04-09",
+                "modelName": "gpt-4o-2024-08-06",
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -226,35 +226,36 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${QUESTION}\", I'm doing great fellow friendly AI tool!\"",
-                "id": "testdata/Bob/test.gpt:bob",
+                "instructions": "#!/bin/bash\n\necho \"Thanks for asking ${QUESTION}, I'm doing great fellow friendly AI tool!\"",
+                "id": "testdata/BobAsShell/test.gpt:bob",
                 "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
+                    "": "testdata/BobAsShell/test.gpt:",
+                    "bob": "testdata/BobAsShell/test.gpt:bob"
                 },
                 "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 6
+                    "location": "testdata/BobAsShell/test.gpt",
+                    "lineNo": 7
                 },
-                "workingDir": "testdata/Bob"
+                "workingDir": "testdata/BobAsShell"
             },
             "currentAgent": {},
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1724425044"
+            "parentID": "1724424427",
+            "displayText": "Running bob from testdata/BobAsShell/test.gpt"
         },
         "type": "callStart",
         "usage": {},
         "content": "{\"question\":\"how are you doing\"}"
     },
     {
-        "time": "2024-08-23T10:57:24.818507-04:00",
+        "time": "2024-08-23T10:47:07.443055-04:00",
         "callContext": {
-            "id": "call_GuCVVGT6CDEdsFWn13k880S2",
+            "id": "call_NjCLsJjY7PegUkXOqx5DA0o0",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
-                "modelName": "gpt-4-turbo-2024-04-09",
+                "modelName": "gpt-4o-2024-08-06",
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -265,49 +266,40 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${QUESTION}\", I'm doing great fellow friendly AI tool!\"",
-                "id": "testdata/Bob/test.gpt:bob",
+                "instructions": "#!/bin/bash\n\necho \"Thanks for asking ${QUESTION}, I'm doing great fellow friendly AI tool!\"",
+                "id": "testdata/BobAsShell/test.gpt:bob",
                 "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
+                    "": "testdata/BobAsShell/test.gpt:",
+                    "bob": "testdata/BobAsShell/test.gpt:bob"
                 },
                 "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 6
+                    "location": "testdata/BobAsShell/test.gpt",
+                    "lineNo": 7
                 },
-                "workingDir": "testdata/Bob"
+                "workingDir": "testdata/BobAsShell"
             },
             "currentAgent": {},
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1724425044"
+            "parentID": "1724424427",
+            "displayText": "Running bob from testdata/BobAsShell/test.gpt"
         },
         "type": "callChat",
-        "chatCompletionId": "1724425046",
+        "chatCompletionId": "1724424429",
         "usage": {},
         "chatRequest": {
-            "model": "gpt-4-turbo-2024-04-09",
-            "messages": [
-                {
-                    "role": "system",
-                    "content": "\nYou are task oriented system.\nYou receive input from a user, process the input from the given instructions, and then output the result.\nYour objective is to provide consistent and correct results.\nYou do not need to explain the steps taken, only provide the result to the given instructions.\nYou are referred to as a tool.\nYou don't move to the next step until you have a result.\n\nWhen asked how I am doing, respond with exactly \"Thanks for asking \"${QUESTION}\", I'm doing great fellow friendly AI tool!\""
-                },
-                {
-                    "role": "user",
-                    "content": "{\"question\":\"how are you doing\"}"
-                }
-            ],
-            "temperature": 0
+            "model": "",
+            "messages": null
         }
     },
     {
-        "time": "2024-08-23T10:57:25.978016-04:00",
+        "time": "2024-08-23T10:47:07.453557-04:00",
         "callContext": {
-            "id": "call_GuCVVGT6CDEdsFWn13k880S2",
+            "id": "call_NjCLsJjY7PegUkXOqx5DA0o0",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
-                "modelName": "gpt-4-turbo-2024-04-09",
+                "modelName": "gpt-4o-2024-08-06",
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -318,52 +310,39 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${QUESTION}\", I'm doing great fellow friendly AI tool!\"",
-                "id": "testdata/Bob/test.gpt:bob",
+                "instructions": "#!/bin/bash\n\necho \"Thanks for asking ${QUESTION}, I'm doing great fellow friendly AI tool!\"",
+                "id": "testdata/BobAsShell/test.gpt:bob",
                 "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
+                    "": "testdata/BobAsShell/test.gpt:",
+                    "bob": "testdata/BobAsShell/test.gpt:bob"
                 },
                 "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 6
+                    "location": "testdata/BobAsShell/test.gpt",
+                    "lineNo": 7
                 },
-                "workingDir": "testdata/Bob"
+                "workingDir": "testdata/BobAsShell"
             },
             "currentAgent": {},
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1724425044"
+            "parentID": "1724424427",
+            "displayText": "Running bob from testdata/BobAsShell/test.gpt"
         },
         "type": "callChat",
-        "chatCompletionId": "1724425046",
-        "usage": {
-            "promptTokens": 124,
-            "completionTokens": 18,
-            "totalTokens": 142
-        },
+        "chatCompletionId": "1724424429",
+        "usage": {},
         "chatResponse": {
-            "role": "assistant",
-            "content": [
-                {
-                    "text": "Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI tool!"
-                }
-            ],
-            "usage": {
-                "promptTokens": 124,
-                "completionTokens": 18,
-                "totalTokens": 142
-            }
+            "usage": {}
         }
     },
     {
-        "time": "2024-08-23T10:57:25.978152-04:00",
+        "time": "2024-08-23T10:47:07.453768-04:00",
         "callContext": {
-            "id": "call_GuCVVGT6CDEdsFWn13k880S2",
+            "id": "call_NjCLsJjY7PegUkXOqx5DA0o0",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
-                "modelName": "gpt-4-turbo-2024-04-09",
+                "modelName": "gpt-4o-2024-08-06",
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -374,56 +353,57 @@
                     },
                     "type": "object"
                 },
-                "instructions": "When asked how I am doing, respond with exactly \"Thanks for asking \"${QUESTION}\", I'm doing great fellow friendly AI tool!\"",
-                "id": "testdata/Bob/test.gpt:bob",
+                "instructions": "#!/bin/bash\n\necho \"Thanks for asking ${QUESTION}, I'm doing great fellow friendly AI tool!\"",
+                "id": "testdata/BobAsShell/test.gpt:bob",
                 "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
+                    "": "testdata/BobAsShell/test.gpt:",
+                    "bob": "testdata/BobAsShell/test.gpt:bob"
                 },
                 "source": {
-                    "location": "testdata/Bob/test.gpt",
-                    "lineNo": 6
+                    "location": "testdata/BobAsShell/test.gpt",
+                    "lineNo": 7
                 },
-                "workingDir": "testdata/Bob"
+                "workingDir": "testdata/BobAsShell"
             },
             "currentAgent": {},
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1724425044"
+            "parentID": "1724424427",
+            "displayText": "Running bob from testdata/BobAsShell/test.gpt"
         },
         "type": "callFinish",
         "usage": {},
-        "content": "Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI tool!"
+        "content": "Thanks for asking how are you doing, I'm doing great fellow friendly AI tool!\n"
     },
     {
-        "time": "2024-08-23T10:57:25.978236-04:00",
+        "time": "2024-08-23T10:47:07.453868-04:00",
         "callContext": {
-            "id": "1724425044",
+            "id": "1724424427",
             "tool": {
-                "modelName": "gpt-4-turbo-2024-04-09",
+                "modelName": "gpt-4o-2024-08-06",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
                 "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
+                "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
                         {
                             "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
+                            "toolID": "testdata/BobAsShell/test.gpt:bob"
                         }
                     ]
                 },
                 "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
+                    "": "testdata/BobAsShell/test.gpt:",
+                    "bob": "testdata/BobAsShell/test.gpt:bob"
                 },
                 "source": {
-                    "location": "testdata/Bob/test.gpt",
+                    "location": "testdata/BobAsShell/test.gpt",
                     "lineNo": 1
                 },
-                "workingDir": "testdata/Bob"
+                "workingDir": "testdata/BobAsShell"
             },
             "currentAgent": {},
             "inputContext": null
@@ -433,43 +413,43 @@
         "usage": {}
     },
     {
-        "time": "2024-08-23T10:57:25.980293-04:00",
+        "time": "2024-08-23T10:47:07.453942-04:00",
         "callContext": {
-            "id": "1724425044",
+            "id": "1724424427",
             "tool": {
-                "modelName": "gpt-4-turbo-2024-04-09",
+                "modelName": "gpt-4o-2024-08-06",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
                 "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
+                "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
                         {
                             "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
+                            "toolID": "testdata/BobAsShell/test.gpt:bob"
                         }
                     ]
                 },
                 "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
+                    "": "testdata/BobAsShell/test.gpt:",
+                    "bob": "testdata/BobAsShell/test.gpt:bob"
                 },
                 "source": {
-                    "location": "testdata/Bob/test.gpt",
+                    "location": "testdata/BobAsShell/test.gpt",
                     "lineNo": 1
                 },
-                "workingDir": "testdata/Bob"
+                "workingDir": "testdata/BobAsShell"
             },
             "currentAgent": {},
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1724425047",
+        "chatCompletionId": "1724424430",
         "usage": {},
         "chatRequest": {
-            "model": "gpt-4-turbo-2024-04-09",
+            "model": "gpt-4o-2024-08-06",
             "messages": [
                 {
                     "role": "system",
@@ -480,7 +460,7 @@
                     "content": "",
                     "tool_calls": [
                         {
-                            "id": "call_GuCVVGT6CDEdsFWn13k880S2",
+                            "id": "call_NjCLsJjY7PegUkXOqx5DA0o0",
                             "type": "function",
                             "function": {
                                 "name": "bob",
@@ -491,9 +471,9 @@
                 },
                 {
                     "role": "tool",
-                    "content": "Thanks for asking \"how are you doing\", I'm doing great fellow friendly AI tool!",
+                    "content": "Thanks for asking how are you doing, I'm doing great fellow friendly AI tool!\n",
                     "name": "bob",
-                    "tool_call_id": "call_GuCVVGT6CDEdsFWn13k880S2"
+                    "tool_call_id": "call_NjCLsJjY7PegUkXOqx5DA0o0"
                 }
             ],
             "temperature": 0,
@@ -518,98 +498,98 @@
         }
     },
     {
-        "time": "2024-08-23T10:57:26.937038-04:00",
+        "time": "2024-08-23T10:47:07.950943-04:00",
         "callContext": {
-            "id": "1724425044",
+            "id": "1724424427",
             "tool": {
-                "modelName": "gpt-4-turbo-2024-04-09",
+                "modelName": "gpt-4o-2024-08-06",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
                 "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
+                "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
                         {
                             "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
+                            "toolID": "testdata/BobAsShell/test.gpt:bob"
                         }
                     ]
                 },
                 "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
+                    "": "testdata/BobAsShell/test.gpt:",
+                    "bob": "testdata/BobAsShell/test.gpt:bob"
                 },
                 "source": {
-                    "location": "testdata/Bob/test.gpt",
+                    "location": "testdata/BobAsShell/test.gpt",
                     "lineNo": 1
                 },
-                "workingDir": "testdata/Bob"
+                "workingDir": "testdata/BobAsShell"
             },
             "currentAgent": {},
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1724425047",
+        "chatCompletionId": "1724424430",
         "usage": {
-            "promptTokens": 184,
-            "completionTokens": 10,
-            "totalTokens": 194
+            "promptTokens": 178,
+            "completionTokens": 17,
+            "totalTokens": 195
         },
         "chatResponse": {
             "role": "assistant",
             "content": [
                 {
-                    "text": "I'm doing great fellow friendly AI tool!"
+                    "text": "Thanks for asking how are you doing, I'm doing great fellow friendly AI tool!"
                 }
             ],
             "usage": {
-                "promptTokens": 184,
-                "completionTokens": 10,
-                "totalTokens": 194
+                "promptTokens": 178,
+                "completionTokens": 17,
+                "totalTokens": 195
             }
         }
     },
     {
-        "time": "2024-08-23T10:57:26.937115-04:00",
+        "time": "2024-08-23T10:47:07.951019-04:00",
         "callContext": {
-            "id": "1724425044",
+            "id": "1724424427",
             "tool": {
-                "modelName": "gpt-4-turbo-2024-04-09",
+                "modelName": "gpt-4o-2024-08-06",
                 "internalPrompt": null,
                 "tools": [
                     "bob"
                 ],
                 "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/Bob/test.gpt:",
+                "id": "testdata/BobAsShell/test.gpt:",
                 "toolMapping": {
                     "bob": [
                         {
                             "reference": "bob",
-                            "toolID": "testdata/Bob/test.gpt:bob"
+                            "toolID": "testdata/BobAsShell/test.gpt:bob"
                         }
                     ]
                 },
                 "localTools": {
-                    "": "testdata/Bob/test.gpt:",
-                    "bob": "testdata/Bob/test.gpt:bob"
+                    "": "testdata/BobAsShell/test.gpt:",
+                    "bob": "testdata/BobAsShell/test.gpt:bob"
                 },
                 "source": {
-                    "location": "testdata/Bob/test.gpt",
+                    "location": "testdata/BobAsShell/test.gpt",
                     "lineNo": 1
                 },
-                "workingDir": "testdata/Bob"
+                "workingDir": "testdata/BobAsShell"
             },
             "currentAgent": {},
             "inputContext": null
         },
         "type": "callFinish",
         "usage": {},
-        "content": "I'm doing great fellow friendly AI tool!"
+        "content": "Thanks for asking how are you doing, I'm doing great fellow friendly AI tool!"
     },
     {
-        "time": "2024-08-23T10:57:26.937179-04:00",
+        "time": "2024-08-23T10:47:07.951093-04:00",
         "type": "runFinish",
         "usage": {}
     }

--- a/pkg/tests/smoke/testdata/BobAsShell/mistral-large-2402-expected.json
+++ b/pkg/tests/smoke/testdata/BobAsShell/mistral-large-2402-expected.json
@@ -1,13 +1,13 @@
 [
     {
-        "time": "2024-07-03T10:53:05.993864-04:00",
+        "time": "2024-08-23T12:02:07.951538-04:00",
         "type": "runStart",
         "usage": {}
     },
     {
-        "time": "2024-07-03T10:53:05.99419-04:00",
+        "time": "2024-08-23T12:02:07.951742-04:00",
         "callContext": {
-            "id": "1720018386",
+            "id": "1724428928",
             "tool": {
                 "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
                 "internalPrompt": null,
@@ -41,14 +41,14 @@
         "usage": {}
     },
     {
-        "time": "2024-07-03T10:53:06.366435-04:00",
+        "time": "2024-08-23T12:02:08.65216-04:00",
         "type": "runStart",
         "usage": {}
     },
     {
-        "time": "2024-07-03T10:53:06.366952-04:00",
+        "time": "2024-08-23T12:02:08.65229-04:00",
         "callContext": {
-            "id": "1720018387",
+            "id": "1724428929",
             "tool": {
                 "name": "Mistral La Plateforme Provider",
                 "description": "Model provider for Mistral models running on La Plateforme",
@@ -59,30 +59,30 @@
                     "github.com/gptscript-ai/credential as github.com/gptscript-ai/mistral-laplateforme-provider/credential with \"Please enter your Mistral La Plateforme API Key\" as message and token as field and \"MISTRAL_API_KEY\" as env"
                 ],
                 "instructions": "#!sys.daemon /usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/main.py",
-                "id": "https://raw.githubusercontent.com/gptscript-ai/mistral-laplateforme-provider/cbf1aeb6db495b9b6223984651d29ac511d2748d/tool.gpt:Mistral La Plateforme Provider",
+                "id": "https://raw.githubusercontent.com/gptscript-ai/mistral-laplateforme-provider/aa4353e7d1de7e90e1078bfbc88526266e587a64/tool.gpt:Mistral La Plateforme Provider",
                 "toolMapping": {
                     "github.com/gptscript-ai/credential as github.com/gptscript-ai/mistral-laplateforme-provider/credential with \"Please enter your Mistral La Plateforme API Key\" as message and token as field and \"MISTRAL_API_KEY\" as env": [
                         {
                             "reference": "github.com/gptscript-ai/credential as github.com/gptscript-ai/mistral-laplateforme-provider/credential with \"Please enter your Mistral La Plateforme API Key\" as message and token as field and \"MISTRAL_API_KEY\" as env",
-                            "toolID": "https://raw.githubusercontent.com/gptscript-ai/credential/651dfad6e7cf3a385ef408afa93ce522c10f8508/tool.gpt:token"
+                            "toolID": "https://raw.githubusercontent.com/gptscript-ai/credential/37e5f870e195b896438c0bc35867403a42f82e89/tool.gpt:token"
                         }
                     ]
                 },
                 "localTools": {
-                    "mistral la plateforme provider": "https://raw.githubusercontent.com/gptscript-ai/mistral-laplateforme-provider/cbf1aeb6db495b9b6223984651d29ac511d2748d/tool.gpt:Mistral La Plateforme Provider"
+                    "mistral la plateforme provider": "https://raw.githubusercontent.com/gptscript-ai/mistral-laplateforme-provider/aa4353e7d1de7e90e1078bfbc88526266e587a64/tool.gpt:Mistral La Plateforme Provider"
                 },
                 "source": {
-                    "location": "https://raw.githubusercontent.com/gptscript-ai/mistral-laplateforme-provider/cbf1aeb6db495b9b6223984651d29ac511d2748d/tool.gpt",
+                    "location": "https://raw.githubusercontent.com/gptscript-ai/mistral-laplateforme-provider/aa4353e7d1de7e90e1078bfbc88526266e587a64/tool.gpt",
                     "lineNo": 1,
                     "repo": {
                         "VCS": "git",
                         "Root": "https://github.com/gptscript-ai/mistral-laplateforme-provider.git",
                         "Path": "/",
                         "Name": "tool.gpt",
-                        "Revision": "cbf1aeb6db495b9b6223984651d29ac511d2748d"
+                        "Revision": "aa4353e7d1de7e90e1078bfbc88526266e587a64"
                     }
                 },
-                "workingDir": "https://raw.githubusercontent.com/gptscript-ai/mistral-laplateforme-provider/cbf1aeb6db495b9b6223984651d29ac511d2748d"
+                "workingDir": "https://raw.githubusercontent.com/gptscript-ai/mistral-laplateforme-provider/aa4353e7d1de7e90e1078bfbc88526266e587a64"
             },
             "currentAgent": {},
             "inputContext": null,
@@ -93,9 +93,9 @@
         "usage": {}
     },
     {
-        "time": "2024-07-03T10:53:07.383203-04:00",
+        "time": "2024-08-23T12:02:09.659962-04:00",
         "callContext": {
-            "id": "1720018387",
+            "id": "1724428929",
             "tool": {
                 "name": "Mistral La Plateforme Provider",
                 "description": "Model provider for Mistral models running on La Plateforme",
@@ -106,30 +106,30 @@
                     "github.com/gptscript-ai/credential as github.com/gptscript-ai/mistral-laplateforme-provider/credential with \"Please enter your Mistral La Plateforme API Key\" as message and token as field and \"MISTRAL_API_KEY\" as env"
                 ],
                 "instructions": "#!sys.daemon /usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/main.py",
-                "id": "https://raw.githubusercontent.com/gptscript-ai/mistral-laplateforme-provider/cbf1aeb6db495b9b6223984651d29ac511d2748d/tool.gpt:Mistral La Plateforme Provider",
+                "id": "https://raw.githubusercontent.com/gptscript-ai/mistral-laplateforme-provider/aa4353e7d1de7e90e1078bfbc88526266e587a64/tool.gpt:Mistral La Plateforme Provider",
                 "toolMapping": {
                     "github.com/gptscript-ai/credential as github.com/gptscript-ai/mistral-laplateforme-provider/credential with \"Please enter your Mistral La Plateforme API Key\" as message and token as field and \"MISTRAL_API_KEY\" as env": [
                         {
                             "reference": "github.com/gptscript-ai/credential as github.com/gptscript-ai/mistral-laplateforme-provider/credential with \"Please enter your Mistral La Plateforme API Key\" as message and token as field and \"MISTRAL_API_KEY\" as env",
-                            "toolID": "https://raw.githubusercontent.com/gptscript-ai/credential/651dfad6e7cf3a385ef408afa93ce522c10f8508/tool.gpt:token"
+                            "toolID": "https://raw.githubusercontent.com/gptscript-ai/credential/37e5f870e195b896438c0bc35867403a42f82e89/tool.gpt:token"
                         }
                     ]
                 },
                 "localTools": {
-                    "mistral la plateforme provider": "https://raw.githubusercontent.com/gptscript-ai/mistral-laplateforme-provider/cbf1aeb6db495b9b6223984651d29ac511d2748d/tool.gpt:Mistral La Plateforme Provider"
+                    "mistral la plateforme provider": "https://raw.githubusercontent.com/gptscript-ai/mistral-laplateforme-provider/aa4353e7d1de7e90e1078bfbc88526266e587a64/tool.gpt:Mistral La Plateforme Provider"
                 },
                 "source": {
-                    "location": "https://raw.githubusercontent.com/gptscript-ai/mistral-laplateforme-provider/cbf1aeb6db495b9b6223984651d29ac511d2748d/tool.gpt",
+                    "location": "https://raw.githubusercontent.com/gptscript-ai/mistral-laplateforme-provider/aa4353e7d1de7e90e1078bfbc88526266e587a64/tool.gpt",
                     "lineNo": 1,
                     "repo": {
                         "VCS": "git",
                         "Root": "https://github.com/gptscript-ai/mistral-laplateforme-provider.git",
                         "Path": "/",
                         "Name": "tool.gpt",
-                        "Revision": "cbf1aeb6db495b9b6223984651d29ac511d2748d"
+                        "Revision": "aa4353e7d1de7e90e1078bfbc88526266e587a64"
                     }
                 },
-                "workingDir": "https://raw.githubusercontent.com/gptscript-ai/mistral-laplateforme-provider/cbf1aeb6db495b9b6223984651d29ac511d2748d"
+                "workingDir": "https://raw.githubusercontent.com/gptscript-ai/mistral-laplateforme-provider/aa4353e7d1de7e90e1078bfbc88526266e587a64"
             },
             "currentAgent": {},
             "inputContext": null,
@@ -138,17 +138,17 @@
         },
         "type": "callFinish",
         "usage": {},
-        "content": "http://127.0.0.1:10798"
+        "content": "http://127.0.0.1:10532"
     },
     {
-        "time": "2024-07-03T10:53:07.383553-04:00",
+        "time": "2024-08-23T12:02:09.66007-04:00",
         "type": "runFinish",
         "usage": {}
     },
     {
-        "time": "2024-07-03T10:53:07.383621-04:00",
+        "time": "2024-08-23T12:02:09.660117-04:00",
         "callContext": {
-            "id": "1720018386",
+            "id": "1724428928",
             "tool": {
                 "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
                 "internalPrompt": null,
@@ -179,7 +179,7 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1720018388",
+        "chatCompletionId": "1724428930",
         "usage": {},
         "chatRequest": {
             "model": "mistral-large-2402",
@@ -211,122 +211,9 @@
         }
     },
     {
-        "time": "2024-07-03T10:53:07.384109-04:00",
+        "time": "2024-08-23T12:02:11.140706-04:00",
         "callContext": {
-            "id": "1720018386",
-            "tool": {
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "currentAgent": {},
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018388",
-        "usage": {},
-        "content": "Waiting for model response..."
-    },
-    {
-        "time": "2024-07-03T10:53:07.670442-04:00",
-        "callContext": {
-            "id": "1720018386",
-            "tool": {
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "currentAgent": {},
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018388",
-        "usage": {}
-    },
-    {
-        "time": "2024-07-03T10:53:08.283965-04:00",
-        "callContext": {
-            "id": "1720018386",
-            "tool": {
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "currentAgent": {},
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018388",
-        "usage": {},
-        "content": "\u003ctool call\u003e bob -\u003e {\"question\": \"how are you doing\"}"
-    },
-    {
-        "time": "2024-07-03T10:53:08.284275-04:00",
-        "callContext": {
-            "id": "1720018386",
+            "id": "1724428928",
             "tool": {
                 "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
                 "internalPrompt": null,
@@ -357,7 +244,7 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1720018388",
+        "chatCompletionId": "1724428930",
         "usage": {
             "promptTokens": 188,
             "completionTokens": 23,
@@ -369,7 +256,7 @@
                 {
                     "toolCall": {
                         "index": 0,
-                        "id": "K9FVJPqm6",
+                        "id": "r1wQzUugN",
                         "function": {
                             "name": "bob",
                             "arguments": "{\"question\": \"how are you doing\"}"
@@ -385,9 +272,9 @@
         }
     },
     {
-        "time": "2024-07-03T10:53:08.285881-04:00",
+        "time": "2024-08-23T12:02:11.140968-04:00",
         "callContext": {
-            "id": "1720018386",
+            "id": "1724428928",
             "tool": {
                 "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
                 "internalPrompt": null,
@@ -418,7 +305,7 @@
             "inputContext": null
         },
         "toolSubCalls": {
-            "K9FVJPqm6": {
+            "r1wQzUugN": {
                 "toolID": "testdata/BobAsShell/test.gpt:bob",
                 "input": "{\"question\": \"how are you doing\"}"
             }
@@ -427,9 +314,9 @@
         "usage": {}
     },
     {
-        "time": "2024-07-03T10:53:08.286454-04:00",
+        "time": "2024-08-23T12:02:11.141094-04:00",
         "callContext": {
-            "id": "K9FVJPqm6",
+            "id": "r1wQzUugN",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -444,7 +331,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "#!/bin/bash\n\necho \"Thanks for asking ${question}, I'm doing great fellow friendly AI tool!\"",
+                "instructions": "#!/bin/bash\n\necho \"Thanks for asking ${QUESTION}, I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/BobAsShell/test.gpt:bob",
                 "localTools": {
                     "": "testdata/BobAsShell/test.gpt:",
@@ -459,7 +346,7 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1720018386",
+            "parentID": "1724428928",
             "displayText": "Running bob from testdata/BobAsShell/test.gpt"
         },
         "type": "callStart",
@@ -467,9 +354,9 @@
         "content": "{\"question\": \"how are you doing\"}"
     },
     {
-        "time": "2024-07-03T10:53:08.287602-04:00",
+        "time": "2024-08-23T12:02:11.141978-04:00",
         "callContext": {
-            "id": "K9FVJPqm6",
+            "id": "r1wQzUugN",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -484,7 +371,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "#!/bin/bash\n\necho \"Thanks for asking ${question}, I'm doing great fellow friendly AI tool!\"",
+                "instructions": "#!/bin/bash\n\necho \"Thanks for asking ${QUESTION}, I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/BobAsShell/test.gpt:bob",
                 "localTools": {
                     "": "testdata/BobAsShell/test.gpt:",
@@ -499,11 +386,11 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1720018386",
+            "parentID": "1724428928",
             "displayText": "Running bob from testdata/BobAsShell/test.gpt"
         },
         "type": "callChat",
-        "chatCompletionId": "1720018389",
+        "chatCompletionId": "1724428931",
         "usage": {},
         "chatRequest": {
             "model": "",
@@ -511,9 +398,9 @@
         }
     },
     {
-        "time": "2024-07-03T10:53:08.295318-04:00",
+        "time": "2024-08-23T12:02:11.153328-04:00",
         "callContext": {
-            "id": "K9FVJPqm6",
+            "id": "r1wQzUugN",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -528,7 +415,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "#!/bin/bash\n\necho \"Thanks for asking ${question}, I'm doing great fellow friendly AI tool!\"",
+                "instructions": "#!/bin/bash\n\necho \"Thanks for asking ${QUESTION}, I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/BobAsShell/test.gpt:bob",
                 "localTools": {
                     "": "testdata/BobAsShell/test.gpt:",
@@ -543,61 +430,20 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1720018386",
-            "displayText": "Running bob from testdata/BobAsShell/test.gpt"
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018389",
-        "usage": {},
-        "content": "Thanks for asking how are you doing, I'm doing great fellow friendly AI tool!\n"
-    },
-    {
-        "time": "2024-07-03T10:53:08.295753-04:00",
-        "callContext": {
-            "id": "K9FVJPqm6",
-            "tool": {
-                "name": "bob",
-                "description": "I'm Bob, a friendly guy.",
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "question": {
-                            "description": "The question to ask Bob.",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "instructions": "#!/bin/bash\n\necho \"Thanks for asking ${question}, I'm doing great fellow friendly AI tool!\"",
-                "id": "testdata/BobAsShell/test.gpt:bob",
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 7
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "currentAgent": {},
-            "inputContext": null,
-            "toolName": "bob",
-            "parentID": "1720018386",
+            "parentID": "1724428928",
             "displayText": "Running bob from testdata/BobAsShell/test.gpt"
         },
         "type": "callChat",
-        "chatCompletionId": "1720018389",
+        "chatCompletionId": "1724428931",
         "usage": {},
         "chatResponse": {
             "usage": {}
         }
     },
     {
-        "time": "2024-07-03T10:53:08.29586-04:00",
+        "time": "2024-08-23T12:02:11.153471-04:00",
         "callContext": {
-            "id": "K9FVJPqm6",
+            "id": "r1wQzUugN",
             "tool": {
                 "name": "bob",
                 "description": "I'm Bob, a friendly guy.",
@@ -612,7 +458,7 @@
                     },
                     "type": "object"
                 },
-                "instructions": "#!/bin/bash\n\necho \"Thanks for asking ${question}, I'm doing great fellow friendly AI tool!\"",
+                "instructions": "#!/bin/bash\n\necho \"Thanks for asking ${QUESTION}, I'm doing great fellow friendly AI tool!\"",
                 "id": "testdata/BobAsShell/test.gpt:bob",
                 "localTools": {
                     "": "testdata/BobAsShell/test.gpt:",
@@ -627,7 +473,7 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "bob",
-            "parentID": "1720018386",
+            "parentID": "1724428928",
             "displayText": "Running bob from testdata/BobAsShell/test.gpt"
         },
         "type": "callFinish",
@@ -635,9 +481,9 @@
         "content": "Thanks for asking how are you doing, I'm doing great fellow friendly AI tool!\n"
     },
     {
-        "time": "2024-07-03T10:53:08.295955-04:00",
+        "time": "2024-08-23T12:02:11.153544-04:00",
         "callContext": {
-            "id": "1720018386",
+            "id": "1724428928",
             "tool": {
                 "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
                 "internalPrompt": null,
@@ -672,9 +518,9 @@
         "usage": {}
     },
     {
-        "time": "2024-07-03T10:53:08.467884-04:00",
+        "time": "2024-08-23T12:02:11.41447-04:00",
         "callContext": {
-            "id": "1720018386",
+            "id": "1724428928",
             "tool": {
                 "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
                 "internalPrompt": null,
@@ -705,7 +551,7 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1720018390",
+        "chatCompletionId": "1724428932",
         "usage": {},
         "chatRequest": {
             "model": "mistral-large-2402",
@@ -719,7 +565,7 @@
                     "content": "",
                     "tool_calls": [
                         {
-                            "id": "K9FVJPqm6",
+                            "id": "r1wQzUugN",
                             "type": "function",
                             "function": {
                                 "name": "bob",
@@ -732,7 +578,7 @@
                     "role": "tool",
                     "content": "Thanks for asking how are you doing, I'm doing great fellow friendly AI tool!\n",
                     "name": "bob",
-                    "tool_call_id": "K9FVJPqm6"
+                    "tool_call_id": "r1wQzUugN"
                 }
             ],
             "temperature": 0,
@@ -757,958 +603,9 @@
         }
     },
     {
-        "time": "2024-07-03T10:53:08.468218-04:00",
+        "time": "2024-08-23T12:02:12.424283-04:00",
         "callContext": {
-            "id": "1720018386",
-            "tool": {
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "currentAgent": {},
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018390",
-        "usage": {},
-        "content": "Waiting for model response..."
-    },
-    {
-        "time": "2024-07-03T10:53:08.755588-04:00",
-        "callContext": {
-            "id": "1720018386",
-            "tool": {
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "currentAgent": {},
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018390",
-        "usage": {}
-    },
-    {
-        "time": "2024-07-03T10:53:08.756052-04:00",
-        "callContext": {
-            "id": "1720018386",
-            "tool": {
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "currentAgent": {},
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018390",
-        "usage": {},
-        "content": "Bob"
-    },
-    {
-        "time": "2024-07-03T10:53:08.792872-04:00",
-        "callContext": {
-            "id": "1720018386",
-            "tool": {
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "currentAgent": {},
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018390",
-        "usage": {},
-        "content": "Bob said"
-    },
-    {
-        "time": "2024-07-03T10:53:08.843651-04:00",
-        "callContext": {
-            "id": "1720018386",
-            "tool": {
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "currentAgent": {},
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018390",
-        "usage": {},
-        "content": "Bob said,"
-    },
-    {
-        "time": "2024-07-03T10:53:08.890513-04:00",
-        "callContext": {
-            "id": "1720018386",
-            "tool": {
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "currentAgent": {},
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018390",
-        "usage": {},
-        "content": "Bob said, \""
-    },
-    {
-        "time": "2024-07-03T10:53:08.940592-04:00",
-        "callContext": {
-            "id": "1720018386",
-            "tool": {
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "currentAgent": {},
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018390",
-        "usage": {},
-        "content": "Bob said, \"Thanks"
-    },
-    {
-        "time": "2024-07-03T10:53:08.979075-04:00",
-        "callContext": {
-            "id": "1720018386",
-            "tool": {
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "currentAgent": {},
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018390",
-        "usage": {},
-        "content": "Bob said, \"Thanks for"
-    },
-    {
-        "time": "2024-07-03T10:53:09.026193-04:00",
-        "callContext": {
-            "id": "1720018386",
-            "tool": {
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "currentAgent": {},
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018390",
-        "usage": {},
-        "content": "Bob said, \"Thanks for asking"
-    },
-    {
-        "time": "2024-07-03T10:53:09.082478-04:00",
-        "callContext": {
-            "id": "1720018386",
-            "tool": {
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "currentAgent": {},
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018390",
-        "usage": {},
-        "content": "Bob said, \"Thanks for asking how"
-    },
-    {
-        "time": "2024-07-03T10:53:09.120629-04:00",
-        "callContext": {
-            "id": "1720018386",
-            "tool": {
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "currentAgent": {},
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018390",
-        "usage": {},
-        "content": "Bob said, \"Thanks for asking how are"
-    },
-    {
-        "time": "2024-07-03T10:53:09.169561-04:00",
-        "callContext": {
-            "id": "1720018386",
-            "tool": {
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "currentAgent": {},
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018390",
-        "usage": {},
-        "content": "Bob said, \"Thanks for asking how are you"
-    },
-    {
-        "time": "2024-07-03T10:53:09.216601-04:00",
-        "callContext": {
-            "id": "1720018386",
-            "tool": {
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "currentAgent": {},
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018390",
-        "usage": {},
-        "content": "Bob said, \"Thanks for asking how are you doing"
-    },
-    {
-        "time": "2024-07-03T10:53:09.261113-04:00",
-        "callContext": {
-            "id": "1720018386",
-            "tool": {
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "currentAgent": {},
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018390",
-        "usage": {},
-        "content": "Bob said, \"Thanks for asking how are you doing,"
-    },
-    {
-        "time": "2024-07-03T10:53:09.306429-04:00",
-        "callContext": {
-            "id": "1720018386",
-            "tool": {
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "currentAgent": {},
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018390",
-        "usage": {},
-        "content": "Bob said, \"Thanks for asking how are you doing, I"
-    },
-    {
-        "time": "2024-07-03T10:53:09.354951-04:00",
-        "callContext": {
-            "id": "1720018386",
-            "tool": {
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "currentAgent": {},
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018390",
-        "usage": {},
-        "content": "Bob said, \"Thanks for asking how are you doing, I'"
-    },
-    {
-        "time": "2024-07-03T10:53:09.401888-04:00",
-        "callContext": {
-            "id": "1720018386",
-            "tool": {
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "currentAgent": {},
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018390",
-        "usage": {},
-        "content": "Bob said, \"Thanks for asking how are you doing, I'm"
-    },
-    {
-        "time": "2024-07-03T10:53:09.448467-04:00",
-        "callContext": {
-            "id": "1720018386",
-            "tool": {
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "currentAgent": {},
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018390",
-        "usage": {},
-        "content": "Bob said, \"Thanks for asking how are you doing, I'm doing"
-    },
-    {
-        "time": "2024-07-03T10:53:09.493586-04:00",
-        "callContext": {
-            "id": "1720018386",
-            "tool": {
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "currentAgent": {},
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018390",
-        "usage": {},
-        "content": "Bob said, \"Thanks for asking how are you doing, I'm doing great"
-    },
-    {
-        "time": "2024-07-03T10:53:09.537745-04:00",
-        "callContext": {
-            "id": "1720018386",
-            "tool": {
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "currentAgent": {},
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018390",
-        "usage": {},
-        "content": "Bob said, \"Thanks for asking how are you doing, I'm doing great fellow"
-    },
-    {
-        "time": "2024-07-03T10:53:09.585266-04:00",
-        "callContext": {
-            "id": "1720018386",
-            "tool": {
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "currentAgent": {},
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018390",
-        "usage": {},
-        "content": "Bob said, \"Thanks for asking how are you doing, I'm doing great fellow friendly"
-    },
-    {
-        "time": "2024-07-03T10:53:09.63097-04:00",
-        "callContext": {
-            "id": "1720018386",
-            "tool": {
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "currentAgent": {},
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018390",
-        "usage": {},
-        "content": "Bob said, \"Thanks for asking how are you doing, I'm doing great fellow friendly AI"
-    },
-    {
-        "time": "2024-07-03T10:53:09.678117-04:00",
-        "callContext": {
-            "id": "1720018386",
-            "tool": {
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "currentAgent": {},
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018390",
-        "usage": {},
-        "content": "Bob said, \"Thanks for asking how are you doing, I'm doing great fellow friendly AI tool"
-    },
-    {
-        "time": "2024-07-03T10:53:09.726398-04:00",
-        "callContext": {
-            "id": "1720018386",
-            "tool": {
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "currentAgent": {},
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018390",
-        "usage": {},
-        "content": "Bob said, \"Thanks for asking how are you doing, I'm doing great fellow friendly AI tool!\""
-    },
-    {
-        "time": "2024-07-03T10:53:09.773449-04:00",
-        "callContext": {
-            "id": "1720018386",
-            "tool": {
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "tools": [
-                    "bob"
-                ],
-                "instructions": "Ask Bob \"how are you doing\" and repeat his reply exactly.",
-                "id": "testdata/BobAsShell/test.gpt:",
-                "toolMapping": {
-                    "bob": [
-                        {
-                            "reference": "bob",
-                            "toolID": "testdata/BobAsShell/test.gpt:bob"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/BobAsShell/test.gpt:",
-                    "bob": "testdata/BobAsShell/test.gpt:bob"
-                },
-                "source": {
-                    "location": "testdata/BobAsShell/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/BobAsShell"
-            },
-            "currentAgent": {},
-            "inputContext": null
-        },
-        "type": "callProgress",
-        "chatCompletionId": "1720018390",
-        "usage": {},
-        "content": "Bob said, \"Thanks for asking how are you doing, I'm doing great fellow friendly AI tool!\""
-    },
-    {
-        "time": "2024-07-03T10:53:09.774342-04:00",
-        "callContext": {
-            "id": "1720018386",
+            "id": "1724428928",
             "tool": {
                 "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
                 "internalPrompt": null,
@@ -1739,7 +636,7 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1720018390",
+        "chatCompletionId": "1724428932",
         "usage": {
             "promptTokens": 247,
             "completionTokens": 22,
@@ -1760,9 +657,9 @@
         }
     },
     {
-        "time": "2024-07-03T10:53:09.774431-04:00",
+        "time": "2024-08-23T12:02:12.42432-04:00",
         "callContext": {
-            "id": "1720018386",
+            "id": "1724428928",
             "tool": {
                 "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
                 "internalPrompt": null,
@@ -1797,7 +694,7 @@
         "content": "Bob said, \"Thanks for asking how are you doing, I'm doing great fellow friendly AI tool!\""
     },
     {
-        "time": "2024-07-03T10:53:09.774496-04:00",
+        "time": "2024-08-23T12:02:12.424439-04:00",
         "type": "runFinish",
         "usage": {}
     }

--- a/pkg/tests/smoke/testdata/SamplesReadme/claude-3-5-sonnet-20240620-expected.json
+++ b/pkg/tests/smoke/testdata/SamplesReadme/claude-3-5-sonnet-20240620-expected.json
@@ -1,0 +1,3871 @@
+[
+    {
+        "time": "2024-08-06T12:05:32.225085-04:00",
+        "type": "runStart",
+        "usage": {}
+    },
+    {
+        "time": "2024-08-06T12:05:32.226098-04:00",
+        "callContext": {
+            "id": "1722960333",
+            "tool": {
+                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
+                "internalPrompt": null,
+                "tools": [
+                    "sys.find",
+                    "sys.read",
+                    "summary"
+                ],
+                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "id": "testdata/SamplesReadme/test.gpt:",
+                "toolMapping": {
+                    "summary": [
+                        {
+                            "reference": "summary",
+                            "toolID": "testdata/SamplesReadme/test.gpt:summary"
+                        }
+                    ],
+                    "sys.find": [
+                        {
+                            "reference": "sys.find",
+                            "toolID": "sys.find"
+                        }
+                    ],
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 1
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null
+        },
+        "type": "callStart",
+        "usage": {}
+    },
+    {
+        "time": "2024-08-06T12:05:32.894044-04:00",
+        "type": "runStart",
+        "usage": {}
+    },
+    {
+        "time": "2024-08-06T12:05:32.894378-04:00",
+        "callContext": {
+            "id": "1722960334",
+            "tool": {
+                "name": "Anthropic Claude3 Model Provider",
+                "description": "Model provider for Anthropic hosted Claude3 models",
+                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
+                "modelProvider": true,
+                "internalPrompt": null,
+                "credentials": [
+                    "github.com/gptscript-ai/credential as github.com/gptscript-ai/claude3-anthropic-provider/credential with \"Please enter your Anthropic API Key\" as message and token as field and \"ANTHROPIC_API_KEY\" as env"
+                ],
+                "instructions": "#!sys.daemon /usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/main.py",
+                "id": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/ee5c02a9aeca5a1cbffcf569751e37432bfe0344/tool.gpt:Anthropic Claude3 Model Provider",
+                "toolMapping": {
+                    "github.com/gptscript-ai/credential as github.com/gptscript-ai/claude3-anthropic-provider/credential with \"Please enter your Anthropic API Key\" as message and token as field and \"ANTHROPIC_API_KEY\" as env": [
+                        {
+                            "reference": "github.com/gptscript-ai/credential as github.com/gptscript-ai/claude3-anthropic-provider/credential with \"Please enter your Anthropic API Key\" as message and token as field and \"ANTHROPIC_API_KEY\" as env",
+                            "toolID": "https://raw.githubusercontent.com/gptscript-ai/credential/37e5f870e195b896438c0bc35867403a42f82e89/tool.gpt:token"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "anthropic claude3 model provider": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/ee5c02a9aeca5a1cbffcf569751e37432bfe0344/tool.gpt:Anthropic Claude3 Model Provider"
+                },
+                "source": {
+                    "location": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/ee5c02a9aeca5a1cbffcf569751e37432bfe0344/tool.gpt",
+                    "lineNo": 1,
+                    "repo": {
+                        "VCS": "git",
+                        "Root": "https://github.com/gptscript-ai/claude3-anthropic-provider.git",
+                        "Path": "/",
+                        "Name": "tool.gpt",
+                        "Revision": "ee5c02a9aeca5a1cbffcf569751e37432bfe0344"
+                    }
+                },
+                "workingDir": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/ee5c02a9aeca5a1cbffcf569751e37432bfe0344"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolCategory": "provider",
+            "displayText": "Running sys.daemon"
+        },
+        "type": "callStart",
+        "usage": {}
+    },
+    {
+        "time": "2024-08-06T12:05:33.911076-04:00",
+        "callContext": {
+            "id": "1722960334",
+            "tool": {
+                "name": "Anthropic Claude3 Model Provider",
+                "description": "Model provider for Anthropic hosted Claude3 models",
+                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
+                "modelProvider": true,
+                "internalPrompt": null,
+                "credentials": [
+                    "github.com/gptscript-ai/credential as github.com/gptscript-ai/claude3-anthropic-provider/credential with \"Please enter your Anthropic API Key\" as message and token as field and \"ANTHROPIC_API_KEY\" as env"
+                ],
+                "instructions": "#!sys.daemon /usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/main.py",
+                "id": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/ee5c02a9aeca5a1cbffcf569751e37432bfe0344/tool.gpt:Anthropic Claude3 Model Provider",
+                "toolMapping": {
+                    "github.com/gptscript-ai/credential as github.com/gptscript-ai/claude3-anthropic-provider/credential with \"Please enter your Anthropic API Key\" as message and token as field and \"ANTHROPIC_API_KEY\" as env": [
+                        {
+                            "reference": "github.com/gptscript-ai/credential as github.com/gptscript-ai/claude3-anthropic-provider/credential with \"Please enter your Anthropic API Key\" as message and token as field and \"ANTHROPIC_API_KEY\" as env",
+                            "toolID": "https://raw.githubusercontent.com/gptscript-ai/credential/37e5f870e195b896438c0bc35867403a42f82e89/tool.gpt:token"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "anthropic claude3 model provider": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/ee5c02a9aeca5a1cbffcf569751e37432bfe0344/tool.gpt:Anthropic Claude3 Model Provider"
+                },
+                "source": {
+                    "location": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/ee5c02a9aeca5a1cbffcf569751e37432bfe0344/tool.gpt",
+                    "lineNo": 1,
+                    "repo": {
+                        "VCS": "git",
+                        "Root": "https://github.com/gptscript-ai/claude3-anthropic-provider.git",
+                        "Path": "/",
+                        "Name": "tool.gpt",
+                        "Revision": "ee5c02a9aeca5a1cbffcf569751e37432bfe0344"
+                    }
+                },
+                "workingDir": "https://raw.githubusercontent.com/gptscript-ai/claude3-anthropic-provider/ee5c02a9aeca5a1cbffcf569751e37432bfe0344"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolCategory": "provider",
+            "displayText": "Running sys.daemon"
+        },
+        "type": "callFinish",
+        "usage": {},
+        "content": "http://127.0.0.1:10598"
+    },
+    {
+        "time": "2024-08-06T12:05:33.911294-04:00",
+        "type": "runFinish",
+        "usage": {}
+    },
+    {
+        "time": "2024-08-06T12:05:33.911369-04:00",
+        "callContext": {
+            "id": "1722960333",
+            "tool": {
+                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
+                "internalPrompt": null,
+                "tools": [
+                    "sys.find",
+                    "sys.read",
+                    "summary"
+                ],
+                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "id": "testdata/SamplesReadme/test.gpt:",
+                "toolMapping": {
+                    "summary": [
+                        {
+                            "reference": "summary",
+                            "toolID": "testdata/SamplesReadme/test.gpt:summary"
+                        }
+                    ],
+                    "sys.find": [
+                        {
+                            "reference": "sys.find",
+                            "toolID": "sys.find"
+                        }
+                    ],
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 1
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722960335",
+        "usage": {},
+        "chatRequest": {
+            "model": "claude-3-5-sonnet-20240620",
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file."
+                }
+            ],
+            "temperature": 0,
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "find",
+                        "description": "Traverse a directory looking for files that match a pattern in the style of the unix find command",
+                        "parameters": {
+                            "properties": {
+                                "directory": {
+                                    "description": "The directory to search in. The current directory \".\" will be used as the default if no argument is passed",
+                                    "type": "string"
+                                },
+                                "pattern": {
+                                    "description": "The file pattern to look for. The pattern is a traditional unix glob format with * matching any character and ? matching a single character",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                },
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "read",
+                        "description": "Reads the contents of a file",
+                        "parameters": {
+                            "properties": {
+                                "filename": {
+                                    "description": "The name of the file to read",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                },
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "summary",
+                        "description": "Summarize a gpt file",
+                        "parameters": {
+                            "properties": {
+                                "file": {
+                                    "description": "filename to summarize",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    {
+        "time": "2024-08-06T12:05:37.827865-04:00",
+        "callContext": {
+            "id": "1722960333",
+            "tool": {
+                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
+                "internalPrompt": null,
+                "tools": [
+                    "sys.find",
+                    "sys.read",
+                    "summary"
+                ],
+                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "id": "testdata/SamplesReadme/test.gpt:",
+                "toolMapping": {
+                    "summary": [
+                        {
+                            "reference": "summary",
+                            "toolID": "testdata/SamplesReadme/test.gpt:summary"
+                        }
+                    ],
+                    "sys.find": [
+                        {
+                            "reference": "sys.find",
+                            "toolID": "sys.find"
+                        }
+                    ],
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 1
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722960335",
+        "usage": {},
+        "chatResponse": {
+            "role": "assistant",
+            "content": [
+                {
+                    "toolCall": {
+                        "index": 0,
+                        "id": "toolu_01LdSKcXyjdbBRxDeM1c9FC1",
+                        "function": {
+                            "name": "find",
+                            "arguments": "{\"directory\": \"testdata\", \"pattern\": \"*.gpt\"}"
+                        }
+                    }
+                }
+            ],
+            "usage": {}
+        }
+    },
+    {
+        "time": "2024-08-06T12:05:37.82796-04:00",
+        "callContext": {
+            "id": "1722960333",
+            "tool": {
+                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
+                "internalPrompt": null,
+                "tools": [
+                    "sys.find",
+                    "sys.read",
+                    "summary"
+                ],
+                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "id": "testdata/SamplesReadme/test.gpt:",
+                "toolMapping": {
+                    "summary": [
+                        {
+                            "reference": "summary",
+                            "toolID": "testdata/SamplesReadme/test.gpt:summary"
+                        }
+                    ],
+                    "sys.find": [
+                        {
+                            "reference": "sys.find",
+                            "toolID": "sys.find"
+                        }
+                    ],
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 1
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null
+        },
+        "toolSubCalls": {
+            "toolu_01LdSKcXyjdbBRxDeM1c9FC1": {
+                "toolID": "sys.find",
+                "input": "{\"directory\": \"testdata\", \"pattern\": \"*.gpt\"}"
+            }
+        },
+        "type": "callSubCalls",
+        "usage": {}
+    },
+    {
+        "time": "2024-08-06T12:05:37.828009-04:00",
+        "callContext": {
+            "id": "toolu_01LdSKcXyjdbBRxDeM1c9FC1",
+            "tool": {
+                "name": "sys.find",
+                "description": "Traverse a directory looking for files that match a pattern in the style of the unix find command",
+                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "directory": {
+                            "description": "The directory to search in. The current directory \".\" will be used as the default if no argument is passed",
+                            "type": "string"
+                        },
+                        "pattern": {
+                            "description": "The file pattern to look for. The pattern is a traditional unix glob format with * matching any character and ? matching a single character",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "instructions": "#!sys.find",
+                "id": "sys.find",
+                "source": {}
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "sys.find",
+            "parentID": "1722960333",
+            "displayText": "Finding `*.gpt` in `testdata`"
+        },
+        "type": "callStart",
+        "usage": {},
+        "content": "{\"directory\": \"testdata\", \"pattern\": \"*.gpt\"}"
+    },
+    {
+        "time": "2024-08-06T12:05:37.828079-04:00",
+        "callContext": {
+            "id": "toolu_01LdSKcXyjdbBRxDeM1c9FC1",
+            "tool": {
+                "name": "sys.find",
+                "description": "Traverse a directory looking for files that match a pattern in the style of the unix find command",
+                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "directory": {
+                            "description": "The directory to search in. The current directory \".\" will be used as the default if no argument is passed",
+                            "type": "string"
+                        },
+                        "pattern": {
+                            "description": "The file pattern to look for. The pattern is a traditional unix glob format with * matching any character and ? matching a single character",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "instructions": "#!sys.find",
+                "id": "sys.find",
+                "source": {}
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "sys.find",
+            "parentID": "1722960333",
+            "displayText": "Finding `*.gpt` in `testdata`"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722960336",
+        "usage": {},
+        "chatRequest": {
+            "model": "",
+            "messages": null
+        }
+    },
+    {
+        "time": "2024-08-06T12:05:37.828287-04:00",
+        "callContext": {
+            "id": "toolu_01LdSKcXyjdbBRxDeM1c9FC1",
+            "tool": {
+                "name": "sys.find",
+                "description": "Traverse a directory looking for files that match a pattern in the style of the unix find command",
+                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "directory": {
+                            "description": "The directory to search in. The current directory \".\" will be used as the default if no argument is passed",
+                            "type": "string"
+                        },
+                        "pattern": {
+                            "description": "The file pattern to look for. The pattern is a traditional unix glob format with * matching any character and ? matching a single character",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "instructions": "#!sys.find",
+                "id": "sys.find",
+                "source": {}
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "sys.find",
+            "parentID": "1722960333",
+            "displayText": "Finding `*.gpt` in `testdata`"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722960336",
+        "usage": {},
+        "chatResponse": {
+            "usage": {}
+        }
+    },
+    {
+        "time": "2024-08-06T12:05:37.82832-04:00",
+        "callContext": {
+            "id": "toolu_01LdSKcXyjdbBRxDeM1c9FC1",
+            "tool": {
+                "name": "sys.find",
+                "description": "Traverse a directory looking for files that match a pattern in the style of the unix find command",
+                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "directory": {
+                            "description": "The directory to search in. The current directory \".\" will be used as the default if no argument is passed",
+                            "type": "string"
+                        },
+                        "pattern": {
+                            "description": "The file pattern to look for. The pattern is a traditional unix glob format with * matching any character and ? matching a single character",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "instructions": "#!sys.find",
+                "id": "sys.find",
+                "source": {}
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "sys.find",
+            "parentID": "1722960333",
+            "displayText": "Finding `*.gpt` in `testdata`"
+        },
+        "type": "callFinish",
+        "usage": {},
+        "content": "testdata/Bob/test.gpt\ntestdata/BobAsShell/test.gpt\ntestdata/SamplesReadme/test.gpt"
+    },
+    {
+        "time": "2024-08-06T12:05:37.828345-04:00",
+        "callContext": {
+            "id": "1722960333",
+            "tool": {
+                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
+                "internalPrompt": null,
+                "tools": [
+                    "sys.find",
+                    "sys.read",
+                    "summary"
+                ],
+                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "id": "testdata/SamplesReadme/test.gpt:",
+                "toolMapping": {
+                    "summary": [
+                        {
+                            "reference": "summary",
+                            "toolID": "testdata/SamplesReadme/test.gpt:summary"
+                        }
+                    ],
+                    "sys.find": [
+                        {
+                            "reference": "sys.find",
+                            "toolID": "sys.find"
+                        }
+                    ],
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 1
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null
+        },
+        "toolResults": 1,
+        "type": "callContinue",
+        "usage": {}
+    },
+    {
+        "time": "2024-08-06T12:05:38.016257-04:00",
+        "callContext": {
+            "id": "1722960333",
+            "tool": {
+                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
+                "internalPrompt": null,
+                "tools": [
+                    "sys.find",
+                    "sys.read",
+                    "summary"
+                ],
+                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "id": "testdata/SamplesReadme/test.gpt:",
+                "toolMapping": {
+                    "summary": [
+                        {
+                            "reference": "summary",
+                            "toolID": "testdata/SamplesReadme/test.gpt:summary"
+                        }
+                    ],
+                    "sys.find": [
+                        {
+                            "reference": "sys.find",
+                            "toolID": "sys.find"
+                        }
+                    ],
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 1
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722960337",
+        "usage": {},
+        "chatRequest": {
+            "model": "claude-3-5-sonnet-20240620",
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file."
+                },
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "toolu_01LdSKcXyjdbBRxDeM1c9FC1",
+                            "type": "function",
+                            "function": {
+                                "name": "find",
+                                "arguments": "{\"directory\": \"testdata\", \"pattern\": \"*.gpt\"}"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "role": "tool",
+                    "content": "testdata/Bob/test.gpt\ntestdata/BobAsShell/test.gpt\ntestdata/SamplesReadme/test.gpt",
+                    "name": "find",
+                    "tool_call_id": "toolu_01LdSKcXyjdbBRxDeM1c9FC1"
+                }
+            ],
+            "temperature": 0,
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "find",
+                        "description": "Traverse a directory looking for files that match a pattern in the style of the unix find command",
+                        "parameters": {
+                            "properties": {
+                                "directory": {
+                                    "description": "The directory to search in. The current directory \".\" will be used as the default if no argument is passed",
+                                    "type": "string"
+                                },
+                                "pattern": {
+                                    "description": "The file pattern to look for. The pattern is a traditional unix glob format with * matching any character and ? matching a single character",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                },
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "read",
+                        "description": "Reads the contents of a file",
+                        "parameters": {
+                            "properties": {
+                                "filename": {
+                                    "description": "The name of the file to read",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                },
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "summary",
+                        "description": "Summarize a gpt file",
+                        "parameters": {
+                            "properties": {
+                                "file": {
+                                    "description": "filename to summarize",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    {
+        "time": "2024-08-06T12:05:40.239488-04:00",
+        "callContext": {
+            "id": "1722960333",
+            "tool": {
+                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
+                "internalPrompt": null,
+                "tools": [
+                    "sys.find",
+                    "sys.read",
+                    "summary"
+                ],
+                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "id": "testdata/SamplesReadme/test.gpt:",
+                "toolMapping": {
+                    "summary": [
+                        {
+                            "reference": "summary",
+                            "toolID": "testdata/SamplesReadme/test.gpt:summary"
+                        }
+                    ],
+                    "sys.find": [
+                        {
+                            "reference": "sys.find",
+                            "toolID": "sys.find"
+                        }
+                    ],
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 1
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null
+        },
+        "toolSubCalls": {
+            "toolu_01GA1t6HhRTq4pzvRH6XNNkx": {
+                "toolID": "testdata/SamplesReadme/test.gpt:summary",
+                "input": "{\"file\": \"testdata/Bob/test.gpt\"}"
+            }
+        },
+        "type": "callSubCalls",
+        "usage": {}
+    },
+    {
+        "time": "2024-08-06T12:05:40.23949-04:00",
+        "callContext": {
+            "id": "1722960333",
+            "tool": {
+                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
+                "internalPrompt": null,
+                "tools": [
+                    "sys.find",
+                    "sys.read",
+                    "summary"
+                ],
+                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "id": "testdata/SamplesReadme/test.gpt:",
+                "toolMapping": {
+                    "summary": [
+                        {
+                            "reference": "summary",
+                            "toolID": "testdata/SamplesReadme/test.gpt:summary"
+                        }
+                    ],
+                    "sys.find": [
+                        {
+                            "reference": "sys.find",
+                            "toolID": "sys.find"
+                        }
+                    ],
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 1
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722960337",
+        "usage": {},
+        "chatResponse": {
+            "role": "assistant",
+            "content": [
+                {
+                    "toolCall": {
+                        "index": 0,
+                        "id": "toolu_01GA1t6HhRTq4pzvRH6XNNkx",
+                        "function": {
+                            "name": "summary",
+                            "arguments": "{\"file\": \"testdata/Bob/test.gpt\"}"
+                        }
+                    }
+                }
+            ],
+            "usage": {}
+        }
+    },
+    {
+        "time": "2024-08-06T12:05:40.239549-04:00",
+        "callContext": {
+            "id": "toolu_01GA1t6HhRTq4pzvRH6XNNkx",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
+                "temperature": 0.7,
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722960333"
+        },
+        "type": "callStart",
+        "usage": {},
+        "content": "{\"file\": \"testdata/Bob/test.gpt\"}"
+    },
+    {
+        "time": "2024-08-06T12:05:40.486174-04:00",
+        "callContext": {
+            "id": "toolu_01GA1t6HhRTq4pzvRH6XNNkx",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
+                "temperature": 0.7,
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722960333"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722960338",
+        "usage": {},
+        "chatRequest": {
+            "model": "claude-3-5-sonnet-20240620",
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate."
+                },
+                {
+                    "role": "user",
+                    "content": "{\"file\": \"testdata/Bob/test.gpt\"}"
+                }
+            ],
+            "temperature": 0.7,
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "read",
+                        "description": "Reads the contents of a file",
+                        "parameters": {
+                            "properties": {
+                                "filename": {
+                                    "description": "The name of the file to read",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    {
+        "time": "2024-08-06T12:05:43.852168-04:00",
+        "callContext": {
+            "id": "toolu_01GA1t6HhRTq4pzvRH6XNNkx",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
+                "temperature": 0.7,
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722960333"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722960338",
+        "usage": {},
+        "chatResponse": {
+            "role": "assistant",
+            "content": [
+                {
+                    "toolCall": {
+                        "index": 0,
+                        "id": "toolu_01KhwrAvNEskbWRCFZBrn5co",
+                        "function": {
+                            "name": "read",
+                            "arguments": "{\"filename\": \"testdata/Bob/test.gpt\"}"
+                        }
+                    }
+                }
+            ],
+            "usage": {}
+        }
+    },
+    {
+        "time": "2024-08-06T12:05:43.852236-04:00",
+        "callContext": {
+            "id": "toolu_01GA1t6HhRTq4pzvRH6XNNkx",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
+                "temperature": 0.7,
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722960333"
+        },
+        "toolSubCalls": {
+            "toolu_01KhwrAvNEskbWRCFZBrn5co": {
+                "toolID": "sys.read",
+                "input": "{\"filename\": \"testdata/Bob/test.gpt\"}"
+            }
+        },
+        "type": "callSubCalls",
+        "usage": {}
+    },
+    {
+        "time": "2024-08-06T12:05:43.852279-04:00",
+        "callContext": {
+            "id": "toolu_01KhwrAvNEskbWRCFZBrn5co",
+            "tool": {
+                "name": "sys.read",
+                "description": "Reads the contents of a file",
+                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "filename": {
+                            "description": "The name of the file to read",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "instructions": "#!sys.read",
+                "id": "sys.read",
+                "source": {}
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "sys.read",
+            "parentID": "toolu_01GA1t6HhRTq4pzvRH6XNNkx",
+            "displayText": "Reading `testdata/Bob/test.gpt`"
+        },
+        "type": "callStart",
+        "usage": {},
+        "content": "{\"filename\": \"testdata/Bob/test.gpt\"}"
+    },
+    {
+        "time": "2024-08-06T12:05:43.852343-04:00",
+        "callContext": {
+            "id": "toolu_01KhwrAvNEskbWRCFZBrn5co",
+            "tool": {
+                "name": "sys.read",
+                "description": "Reads the contents of a file",
+                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "filename": {
+                            "description": "The name of the file to read",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "instructions": "#!sys.read",
+                "id": "sys.read",
+                "source": {}
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "sys.read",
+            "parentID": "toolu_01GA1t6HhRTq4pzvRH6XNNkx",
+            "displayText": "Reading `testdata/Bob/test.gpt`"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722960339",
+        "usage": {},
+        "chatRequest": {
+            "model": "",
+            "messages": null
+        }
+    },
+    {
+        "time": "2024-08-06T12:05:43.852425-04:00",
+        "callContext": {
+            "id": "toolu_01KhwrAvNEskbWRCFZBrn5co",
+            "tool": {
+                "name": "sys.read",
+                "description": "Reads the contents of a file",
+                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "filename": {
+                            "description": "The name of the file to read",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "instructions": "#!sys.read",
+                "id": "sys.read",
+                "source": {}
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "sys.read",
+            "parentID": "toolu_01GA1t6HhRTq4pzvRH6XNNkx",
+            "displayText": "Reading `testdata/Bob/test.gpt`"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722960339",
+        "usage": {},
+        "chatResponse": {
+            "usage": {}
+        }
+    },
+    {
+        "time": "2024-08-06T12:05:43.852462-04:00",
+        "callContext": {
+            "id": "toolu_01KhwrAvNEskbWRCFZBrn5co",
+            "tool": {
+                "name": "sys.read",
+                "description": "Reads the contents of a file",
+                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "filename": {
+                            "description": "The name of the file to read",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "instructions": "#!sys.read",
+                "id": "sys.read",
+                "source": {}
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "sys.read",
+            "parentID": "toolu_01GA1t6HhRTq4pzvRH6XNNkx",
+            "displayText": "Reading `testdata/Bob/test.gpt`"
+        },
+        "type": "callFinish",
+        "usage": {},
+        "content": "tools: bob\n\nAsk Bob \"how are you doing\" and repeat his reply exactly.\n\n---\nname: bob\ndescription: I'm Bob, a friendly guy.\nargs: question: The question to ask Bob.\n\nWhen asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"\n"
+    },
+    {
+        "time": "2024-08-06T12:05:43.852484-04:00",
+        "callContext": {
+            "id": "toolu_01GA1t6HhRTq4pzvRH6XNNkx",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
+                "temperature": 0.7,
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722960333"
+        },
+        "toolResults": 1,
+        "type": "callContinue",
+        "usage": {}
+    },
+    {
+        "time": "2024-08-06T12:05:44.274147-04:00",
+        "callContext": {
+            "id": "toolu_01GA1t6HhRTq4pzvRH6XNNkx",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
+                "temperature": 0.7,
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722960333"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722960340",
+        "usage": {},
+        "chatRequest": {
+            "model": "claude-3-5-sonnet-20240620",
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate."
+                },
+                {
+                    "role": "user",
+                    "content": "{\"file\": \"testdata/Bob/test.gpt\"}"
+                },
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "toolu_01KhwrAvNEskbWRCFZBrn5co",
+                            "type": "function",
+                            "function": {
+                                "name": "read",
+                                "arguments": "{\"filename\": \"testdata/Bob/test.gpt\"}"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "role": "tool",
+                    "content": "tools: bob\n\nAsk Bob \"how are you doing\" and repeat his reply exactly.\n\n---\nname: bob\ndescription: I'm Bob, a friendly guy.\nargs: question: The question to ask Bob.\n\nWhen asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"\n",
+                    "name": "read",
+                    "tool_call_id": "toolu_01KhwrAvNEskbWRCFZBrn5co"
+                }
+            ],
+            "temperature": 0.7,
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "read",
+                        "description": "Reads the contents of a file",
+                        "parameters": {
+                            "properties": {
+                                "filename": {
+                                    "description": "The name of the file to read",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    {
+        "time": "2024-08-06T12:05:53.297643-04:00",
+        "callContext": {
+            "id": "toolu_01GA1t6HhRTq4pzvRH6XNNkx",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
+                "temperature": 0.7,
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722960333"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722960340",
+        "usage": {},
+        "chatResponse": {
+            "role": "assistant",
+            "content": [
+                {
+                    "text": "Thank you for providing the GPTScript file. I've read its contents, and I'll briefly describe what it contains and the technique it's demonstrating.\n\nThe GPTScript file contains a simple script that demonstrates the use of a custom AI tool or agent named \"Bob\". Here's a breakdown of the file's contents and the technique it's showcasing:\n\n1. Content Description:\n   - The script defines a tool called \"bob\" in the tools section.\n   - It includes a main instruction to ask Bob \"how are you doing\" and repeat his reply exactly.\n   - The \"bob\" tool is defined with a name, description, and an argument called \"question\".\n   - Bob is programmed to respond in a specific way when asked how he's doing.\n\n2. Technique Demonstration:\n   The script is demonstrating a few key concepts in AI automation and scripting:\n\n   a) Custom Tool Creation: It shows how to define a custom AI tool or agent (in this case, \"Bob\") with specific behaviors and responses.\n   \n   b) Parameterized Responses: The script showcases how to create a tool that can take an input (the \"question\" argument) and incorporate it into a predefined response template.\n   \n   c) Scripted Interactions: It demonstrates how to script a simple interaction with an AI tool, including asking a specific question and handling the response.\n   \n   d) Template-based Replies: Bob's response is templated, showing how to create consistent yet personalized responses by inserting a variable (${question}) into a fixed string.\n\nIn essence, this GPTScript file is a simple example of creating and interacting with a custom AI agent within an automation framework. It shows how one might script basic conversational interactions and define specific behaviors for AI tools or personas in a larger automation system."
+                }
+            ],
+            "usage": {}
+        }
+    },
+    {
+        "time": "2024-08-06T12:05:53.297743-04:00",
+        "callContext": {
+            "id": "toolu_01GA1t6HhRTq4pzvRH6XNNkx",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
+                "temperature": 0.7,
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722960333"
+        },
+        "type": "callFinish",
+        "usage": {},
+        "content": "Thank you for providing the GPTScript file. I've read its contents, and I'll briefly describe what it contains and the technique it's demonstrating.\n\nThe GPTScript file contains a simple script that demonstrates the use of a custom AI tool or agent named \"Bob\". Here's a breakdown of the file's contents and the technique it's showcasing:\n\n1. Content Description:\n   - The script defines a tool called \"bob\" in the tools section.\n   - It includes a main instruction to ask Bob \"how are you doing\" and repeat his reply exactly.\n   - The \"bob\" tool is defined with a name, description, and an argument called \"question\".\n   - Bob is programmed to respond in a specific way when asked how he's doing.\n\n2. Technique Demonstration:\n   The script is demonstrating a few key concepts in AI automation and scripting:\n\n   a) Custom Tool Creation: It shows how to define a custom AI tool or agent (in this case, \"Bob\") with specific behaviors and responses.\n   \n   b) Parameterized Responses: The script showcases how to create a tool that can take an input (the \"question\" argument) and incorporate it into a predefined response template.\n   \n   c) Scripted Interactions: It demonstrates how to script a simple interaction with an AI tool, including asking a specific question and handling the response.\n   \n   d) Template-based Replies: Bob's response is templated, showing how to create consistent yet personalized responses by inserting a variable (${question}) into a fixed string.\n\nIn essence, this GPTScript file is a simple example of creating and interacting with a custom AI agent within an automation framework. It shows how one might script basic conversational interactions and define specific behaviors for AI tools or personas in a larger automation system."
+    },
+    {
+        "time": "2024-08-06T12:05:53.298113-04:00",
+        "callContext": {
+            "id": "1722960333",
+            "tool": {
+                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
+                "internalPrompt": null,
+                "tools": [
+                    "sys.find",
+                    "sys.read",
+                    "summary"
+                ],
+                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "id": "testdata/SamplesReadme/test.gpt:",
+                "toolMapping": {
+                    "summary": [
+                        {
+                            "reference": "summary",
+                            "toolID": "testdata/SamplesReadme/test.gpt:summary"
+                        }
+                    ],
+                    "sys.find": [
+                        {
+                            "reference": "sys.find",
+                            "toolID": "sys.find"
+                        }
+                    ],
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 1
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null
+        },
+        "toolResults": 1,
+        "type": "callContinue",
+        "usage": {}
+    },
+    {
+        "time": "2024-08-06T12:05:53.49392-04:00",
+        "callContext": {
+            "id": "1722960333",
+            "tool": {
+                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
+                "internalPrompt": null,
+                "tools": [
+                    "sys.find",
+                    "sys.read",
+                    "summary"
+                ],
+                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "id": "testdata/SamplesReadme/test.gpt:",
+                "toolMapping": {
+                    "summary": [
+                        {
+                            "reference": "summary",
+                            "toolID": "testdata/SamplesReadme/test.gpt:summary"
+                        }
+                    ],
+                    "sys.find": [
+                        {
+                            "reference": "sys.find",
+                            "toolID": "sys.find"
+                        }
+                    ],
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 1
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722960341",
+        "usage": {},
+        "chatRequest": {
+            "model": "claude-3-5-sonnet-20240620",
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file."
+                },
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "toolu_01LdSKcXyjdbBRxDeM1c9FC1",
+                            "type": "function",
+                            "function": {
+                                "name": "find",
+                                "arguments": "{\"directory\": \"testdata\", \"pattern\": \"*.gpt\"}"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "role": "tool",
+                    "content": "testdata/Bob/test.gpt\ntestdata/BobAsShell/test.gpt\ntestdata/SamplesReadme/test.gpt",
+                    "name": "find",
+                    "tool_call_id": "toolu_01LdSKcXyjdbBRxDeM1c9FC1"
+                },
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "toolu_01GA1t6HhRTq4pzvRH6XNNkx",
+                            "type": "function",
+                            "function": {
+                                "name": "summary",
+                                "arguments": "{\"file\": \"testdata/Bob/test.gpt\"}"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "role": "tool",
+                    "content": "Thank you for providing the GPTScript file. I've read its contents, and I'll briefly describe what it contains and the technique it's demonstrating.\n\nThe GPTScript file contains a simple script that demonstrates the use of a custom AI tool or agent named \"Bob\". Here's a breakdown of the file's contents and the technique it's showcasing:\n\n1. Content Description:\n   - The script defines a tool called \"bob\" in the tools section.\n   - It includes a main instruction to ask Bob \"how are you doing\" and repeat his reply exactly.\n   - The \"bob\" tool is defined with a name, description, and an argument called \"question\".\n   - Bob is programmed to respond in a specific way when asked how he's doing.\n\n2. Technique Demonstration:\n   The script is demonstrating a few key concepts in AI automation and scripting:\n\n   a) Custom Tool Creation: It shows how to define a custom AI tool or agent (in this case, \"Bob\") with specific behaviors and responses.\n   \n   b) Parameterized Responses: The script showcases how to create a tool that can take an input (the \"question\" argument) and incorporate it into a predefined response template.\n   \n   c) Scripted Interactions: It demonstrates how to script a simple interaction with an AI tool, including asking a specific question and handling the response.\n   \n   d) Template-based Replies: Bob's response is templated, showing how to create consistent yet personalized responses by inserting a variable (${question}) into a fixed string.\n\nIn essence, this GPTScript file is a simple example of creating and interacting with a custom AI agent within an automation framework. It shows how one might script basic conversational interactions and define specific behaviors for AI tools or personas in a larger automation system.",
+                    "name": "summary",
+                    "tool_call_id": "toolu_01GA1t6HhRTq4pzvRH6XNNkx"
+                }
+            ],
+            "temperature": 0,
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "find",
+                        "description": "Traverse a directory looking for files that match a pattern in the style of the unix find command",
+                        "parameters": {
+                            "properties": {
+                                "directory": {
+                                    "description": "The directory to search in. The current directory \".\" will be used as the default if no argument is passed",
+                                    "type": "string"
+                                },
+                                "pattern": {
+                                    "description": "The file pattern to look for. The pattern is a traditional unix glob format with * matching any character and ? matching a single character",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                },
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "read",
+                        "description": "Reads the contents of a file",
+                        "parameters": {
+                            "properties": {
+                                "filename": {
+                                    "description": "The name of the file to read",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                },
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "summary",
+                        "description": "Summarize a gpt file",
+                        "parameters": {
+                            "properties": {
+                                "file": {
+                                    "description": "filename to summarize",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    {
+        "time": "2024-08-06T12:05:55.636946-04:00",
+        "callContext": {
+            "id": "1722960333",
+            "tool": {
+                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
+                "internalPrompt": null,
+                "tools": [
+                    "sys.find",
+                    "sys.read",
+                    "summary"
+                ],
+                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "id": "testdata/SamplesReadme/test.gpt:",
+                "toolMapping": {
+                    "summary": [
+                        {
+                            "reference": "summary",
+                            "toolID": "testdata/SamplesReadme/test.gpt:summary"
+                        }
+                    ],
+                    "sys.find": [
+                        {
+                            "reference": "sys.find",
+                            "toolID": "sys.find"
+                        }
+                    ],
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 1
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null
+        },
+        "toolSubCalls": {
+            "toolu_01VTsZPAxCf1sJusFUoqHtgR": {
+                "toolID": "testdata/SamplesReadme/test.gpt:summary",
+                "input": "{\"file\": \"testdata/BobAsShell/test.gpt\"}"
+            }
+        },
+        "type": "callSubCalls",
+        "usage": {}
+    },
+    {
+        "time": "2024-08-06T12:05:55.636958-04:00",
+        "callContext": {
+            "id": "1722960333",
+            "tool": {
+                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
+                "internalPrompt": null,
+                "tools": [
+                    "sys.find",
+                    "sys.read",
+                    "summary"
+                ],
+                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "id": "testdata/SamplesReadme/test.gpt:",
+                "toolMapping": {
+                    "summary": [
+                        {
+                            "reference": "summary",
+                            "toolID": "testdata/SamplesReadme/test.gpt:summary"
+                        }
+                    ],
+                    "sys.find": [
+                        {
+                            "reference": "sys.find",
+                            "toolID": "sys.find"
+                        }
+                    ],
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 1
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722960341",
+        "usage": {},
+        "chatResponse": {
+            "role": "assistant",
+            "content": [
+                {
+                    "toolCall": {
+                        "index": 0,
+                        "id": "toolu_01VTsZPAxCf1sJusFUoqHtgR",
+                        "function": {
+                            "name": "summary",
+                            "arguments": "{\"file\": \"testdata/BobAsShell/test.gpt\"}"
+                        }
+                    }
+                }
+            ],
+            "usage": {}
+        }
+    },
+    {
+        "time": "2024-08-06T12:05:55.637002-04:00",
+        "callContext": {
+            "id": "toolu_01VTsZPAxCf1sJusFUoqHtgR",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
+                "temperature": 0.7,
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722960333"
+        },
+        "type": "callStart",
+        "usage": {},
+        "content": "{\"file\": \"testdata/BobAsShell/test.gpt\"}"
+    },
+    {
+        "time": "2024-08-06T12:05:55.806829-04:00",
+        "callContext": {
+            "id": "toolu_01VTsZPAxCf1sJusFUoqHtgR",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
+                "temperature": 0.7,
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722960333"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722960342",
+        "usage": {},
+        "chatRequest": {
+            "model": "claude-3-5-sonnet-20240620",
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate."
+                },
+                {
+                    "role": "user",
+                    "content": "{\"file\": \"testdata/BobAsShell/test.gpt\"}"
+                }
+            ],
+            "temperature": 0.7,
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "read",
+                        "description": "Reads the contents of a file",
+                        "parameters": {
+                            "properties": {
+                                "filename": {
+                                    "description": "The name of the file to read",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    {
+        "time": "2024-08-06T12:05:58.795512-04:00",
+        "callContext": {
+            "id": "toolu_01VTsZPAxCf1sJusFUoqHtgR",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
+                "temperature": 0.7,
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722960333"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722960342",
+        "usage": {},
+        "chatResponse": {
+            "role": "assistant",
+            "content": [
+                {
+                    "toolCall": {
+                        "index": 0,
+                        "id": "toolu_01Ph36AMoyPFtJyoSSh3fkPX",
+                        "function": {
+                            "name": "read",
+                            "arguments": "{\"filename\": \"testdata/BobAsShell/test.gpt\"}"
+                        }
+                    }
+                }
+            ],
+            "usage": {}
+        }
+    },
+    {
+        "time": "2024-08-06T12:05:58.795554-04:00",
+        "callContext": {
+            "id": "toolu_01VTsZPAxCf1sJusFUoqHtgR",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
+                "temperature": 0.7,
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722960333"
+        },
+        "toolSubCalls": {
+            "toolu_01Ph36AMoyPFtJyoSSh3fkPX": {
+                "toolID": "sys.read",
+                "input": "{\"filename\": \"testdata/BobAsShell/test.gpt\"}"
+            }
+        },
+        "type": "callSubCalls",
+        "usage": {}
+    },
+    {
+        "time": "2024-08-06T12:05:58.795591-04:00",
+        "callContext": {
+            "id": "toolu_01Ph36AMoyPFtJyoSSh3fkPX",
+            "tool": {
+                "name": "sys.read",
+                "description": "Reads the contents of a file",
+                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "filename": {
+                            "description": "The name of the file to read",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "instructions": "#!sys.read",
+                "id": "sys.read",
+                "source": {}
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "sys.read",
+            "parentID": "toolu_01VTsZPAxCf1sJusFUoqHtgR",
+            "displayText": "Reading `testdata/BobAsShell/test.gpt`"
+        },
+        "type": "callStart",
+        "usage": {},
+        "content": "{\"filename\": \"testdata/BobAsShell/test.gpt\"}"
+    },
+    {
+        "time": "2024-08-06T12:05:58.795642-04:00",
+        "callContext": {
+            "id": "toolu_01Ph36AMoyPFtJyoSSh3fkPX",
+            "tool": {
+                "name": "sys.read",
+                "description": "Reads the contents of a file",
+                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "filename": {
+                            "description": "The name of the file to read",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "instructions": "#!sys.read",
+                "id": "sys.read",
+                "source": {}
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "sys.read",
+            "parentID": "toolu_01VTsZPAxCf1sJusFUoqHtgR",
+            "displayText": "Reading `testdata/BobAsShell/test.gpt`"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722960343",
+        "usage": {},
+        "chatRequest": {
+            "model": "",
+            "messages": null
+        }
+    },
+    {
+        "time": "2024-08-06T12:05:58.795709-04:00",
+        "callContext": {
+            "id": "toolu_01Ph36AMoyPFtJyoSSh3fkPX",
+            "tool": {
+                "name": "sys.read",
+                "description": "Reads the contents of a file",
+                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "filename": {
+                            "description": "The name of the file to read",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "instructions": "#!sys.read",
+                "id": "sys.read",
+                "source": {}
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "sys.read",
+            "parentID": "toolu_01VTsZPAxCf1sJusFUoqHtgR",
+            "displayText": "Reading `testdata/BobAsShell/test.gpt`"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722960343",
+        "usage": {},
+        "chatResponse": {
+            "usage": {}
+        }
+    },
+    {
+        "time": "2024-08-06T12:05:58.795729-04:00",
+        "callContext": {
+            "id": "toolu_01Ph36AMoyPFtJyoSSh3fkPX",
+            "tool": {
+                "name": "sys.read",
+                "description": "Reads the contents of a file",
+                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "filename": {
+                            "description": "The name of the file to read",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "instructions": "#!sys.read",
+                "id": "sys.read",
+                "source": {}
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "sys.read",
+            "parentID": "toolu_01VTsZPAxCf1sJusFUoqHtgR",
+            "displayText": "Reading `testdata/BobAsShell/test.gpt`"
+        },
+        "type": "callFinish",
+        "usage": {},
+        "content": "\ntools: bob\n\nAsk Bob \"how are you doing\" and repeat his reply exactly.\n\n---\nname: bob\ndescription: I'm Bob, a friendly guy.\nargs: question: The question to ask Bob.\n\n#!/bin/bash\n\necho \"Thanks for asking ${question}, I'm doing great fellow friendly AI tool!\"\n"
+    },
+    {
+        "time": "2024-08-06T12:05:58.795747-04:00",
+        "callContext": {
+            "id": "toolu_01VTsZPAxCf1sJusFUoqHtgR",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
+                "temperature": 0.7,
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722960333"
+        },
+        "toolResults": 1,
+        "type": "callContinue",
+        "usage": {}
+    },
+    {
+        "time": "2024-08-06T12:05:59.059914-04:00",
+        "callContext": {
+            "id": "toolu_01VTsZPAxCf1sJusFUoqHtgR",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
+                "temperature": 0.7,
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722960333"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722960344",
+        "usage": {},
+        "chatRequest": {
+            "model": "claude-3-5-sonnet-20240620",
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate."
+                },
+                {
+                    "role": "user",
+                    "content": "{\"file\": \"testdata/BobAsShell/test.gpt\"}"
+                },
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "toolu_01Ph36AMoyPFtJyoSSh3fkPX",
+                            "type": "function",
+                            "function": {
+                                "name": "read",
+                                "arguments": "{\"filename\": \"testdata/BobAsShell/test.gpt\"}"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "role": "tool",
+                    "content": "\ntools: bob\n\nAsk Bob \"how are you doing\" and repeat his reply exactly.\n\n---\nname: bob\ndescription: I'm Bob, a friendly guy.\nargs: question: The question to ask Bob.\n\n#!/bin/bash\n\necho \"Thanks for asking ${question}, I'm doing great fellow friendly AI tool!\"\n",
+                    "name": "read",
+                    "tool_call_id": "toolu_01Ph36AMoyPFtJyoSSh3fkPX"
+                }
+            ],
+            "temperature": 0.7,
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "read",
+                        "description": "Reads the contents of a file",
+                        "parameters": {
+                            "properties": {
+                                "filename": {
+                                    "description": "The name of the file to read",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    {
+        "time": "2024-08-06T12:06:07.091565-04:00",
+        "callContext": {
+            "id": "toolu_01VTsZPAxCf1sJusFUoqHtgR",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
+                "temperature": 0.7,
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722960333"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722960344",
+        "usage": {},
+        "chatResponse": {
+            "role": "assistant",
+            "content": [
+                {
+                    "text": "I have read the contents of the file \"testdata/BobAsShell/test.gpt\". This is a sample GPTScript file that demonstrates a simple interaction with a custom AI tool named \"Bob\". Let me briefly describe the contents and the technique it's trying to demonstrate:\n\n1. Contents of the GPTScript file:\n   - The file starts by declaring the tool it will use: \"bob\"\n   - It then provides an instruction to ask Bob \"how are you doing\" and repeat his reply exactly.\n   - After that, there's a section that defines the \"bob\" tool:\n     - It gives Bob a name and a brief description\n     - It specifies that Bob takes one argument: \"question\"\n     - The implementation of Bob is written in Bash script\n\n2. Technique being demonstrated:\n   This GPTScript file is demonstrating the technique of creating and using a custom AI tool within the GPTScript environment. Specifically, it shows:\n\n   a. Tool Declaration: How to declare a tool that will be used in the script.\n   b. Tool Definition: How to define a custom tool, including its name, description, and parameters.\n   c. Tool Implementation: How to implement the functionality of a tool using a different programming language (in this case, Bash).\n   d. Tool Usage: How to use the defined tool within the GPTScript by providing instructions to interact with it.\n\nThe script creates a simple conversational AI named Bob, implemented as a Bash script, which responds to questions in a friendly manner. This demonstrates how GPTScript can integrate external scripts or programs as AI tools, allowing for flexible and extensible AI automation workflows."
+                }
+            ],
+            "usage": {}
+        }
+    },
+    {
+        "time": "2024-08-06T12:06:07.091589-04:00",
+        "callContext": {
+            "id": "toolu_01VTsZPAxCf1sJusFUoqHtgR",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
+                "temperature": 0.7,
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722960333"
+        },
+        "type": "callFinish",
+        "usage": {},
+        "content": "I have read the contents of the file \"testdata/BobAsShell/test.gpt\". This is a sample GPTScript file that demonstrates a simple interaction with a custom AI tool named \"Bob\". Let me briefly describe the contents and the technique it's trying to demonstrate:\n\n1. Contents of the GPTScript file:\n   - The file starts by declaring the tool it will use: \"bob\"\n   - It then provides an instruction to ask Bob \"how are you doing\" and repeat his reply exactly.\n   - After that, there's a section that defines the \"bob\" tool:\n     - It gives Bob a name and a brief description\n     - It specifies that Bob takes one argument: \"question\"\n     - The implementation of Bob is written in Bash script\n\n2. Technique being demonstrated:\n   This GPTScript file is demonstrating the technique of creating and using a custom AI tool within the GPTScript environment. Specifically, it shows:\n\n   a. Tool Declaration: How to declare a tool that will be used in the script.\n   b. Tool Definition: How to define a custom tool, including its name, description, and parameters.\n   c. Tool Implementation: How to implement the functionality of a tool using a different programming language (in this case, Bash).\n   d. Tool Usage: How to use the defined tool within the GPTScript by providing instructions to interact with it.\n\nThe script creates a simple conversational AI named Bob, implemented as a Bash script, which responds to questions in a friendly manner. This demonstrates how GPTScript can integrate external scripts or programs as AI tools, allowing for flexible and extensible AI automation workflows."
+    },
+    {
+        "time": "2024-08-06T12:06:07.09162-04:00",
+        "callContext": {
+            "id": "1722960333",
+            "tool": {
+                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
+                "internalPrompt": null,
+                "tools": [
+                    "sys.find",
+                    "sys.read",
+                    "summary"
+                ],
+                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "id": "testdata/SamplesReadme/test.gpt:",
+                "toolMapping": {
+                    "summary": [
+                        {
+                            "reference": "summary",
+                            "toolID": "testdata/SamplesReadme/test.gpt:summary"
+                        }
+                    ],
+                    "sys.find": [
+                        {
+                            "reference": "sys.find",
+                            "toolID": "sys.find"
+                        }
+                    ],
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 1
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null
+        },
+        "toolResults": 1,
+        "type": "callContinue",
+        "usage": {}
+    },
+    {
+        "time": "2024-08-06T12:06:07.414741-04:00",
+        "callContext": {
+            "id": "1722960333",
+            "tool": {
+                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
+                "internalPrompt": null,
+                "tools": [
+                    "sys.find",
+                    "sys.read",
+                    "summary"
+                ],
+                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "id": "testdata/SamplesReadme/test.gpt:",
+                "toolMapping": {
+                    "summary": [
+                        {
+                            "reference": "summary",
+                            "toolID": "testdata/SamplesReadme/test.gpt:summary"
+                        }
+                    ],
+                    "sys.find": [
+                        {
+                            "reference": "sys.find",
+                            "toolID": "sys.find"
+                        }
+                    ],
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 1
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722960345",
+        "usage": {},
+        "chatRequest": {
+            "model": "claude-3-5-sonnet-20240620",
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file."
+                },
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "toolu_01LdSKcXyjdbBRxDeM1c9FC1",
+                            "type": "function",
+                            "function": {
+                                "name": "find",
+                                "arguments": "{\"directory\": \"testdata\", \"pattern\": \"*.gpt\"}"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "role": "tool",
+                    "content": "testdata/Bob/test.gpt\ntestdata/BobAsShell/test.gpt\ntestdata/SamplesReadme/test.gpt",
+                    "name": "find",
+                    "tool_call_id": "toolu_01LdSKcXyjdbBRxDeM1c9FC1"
+                },
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "toolu_01GA1t6HhRTq4pzvRH6XNNkx",
+                            "type": "function",
+                            "function": {
+                                "name": "summary",
+                                "arguments": "{\"file\": \"testdata/Bob/test.gpt\"}"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "role": "tool",
+                    "content": "Thank you for providing the GPTScript file. I've read its contents, and I'll briefly describe what it contains and the technique it's demonstrating.\n\nThe GPTScript file contains a simple script that demonstrates the use of a custom AI tool or agent named \"Bob\". Here's a breakdown of the file's contents and the technique it's showcasing:\n\n1. Content Description:\n   - The script defines a tool called \"bob\" in the tools section.\n   - It includes a main instruction to ask Bob \"how are you doing\" and repeat his reply exactly.\n   - The \"bob\" tool is defined with a name, description, and an argument called \"question\".\n   - Bob is programmed to respond in a specific way when asked how he's doing.\n\n2. Technique Demonstration:\n   The script is demonstrating a few key concepts in AI automation and scripting:\n\n   a) Custom Tool Creation: It shows how to define a custom AI tool or agent (in this case, \"Bob\") with specific behaviors and responses.\n   \n   b) Parameterized Responses: The script showcases how to create a tool that can take an input (the \"question\" argument) and incorporate it into a predefined response template.\n   \n   c) Scripted Interactions: It demonstrates how to script a simple interaction with an AI tool, including asking a specific question and handling the response.\n   \n   d) Template-based Replies: Bob's response is templated, showing how to create consistent yet personalized responses by inserting a variable (${question}) into a fixed string.\n\nIn essence, this GPTScript file is a simple example of creating and interacting with a custom AI agent within an automation framework. It shows how one might script basic conversational interactions and define specific behaviors for AI tools or personas in a larger automation system.",
+                    "name": "summary",
+                    "tool_call_id": "toolu_01GA1t6HhRTq4pzvRH6XNNkx"
+                },
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "toolu_01VTsZPAxCf1sJusFUoqHtgR",
+                            "type": "function",
+                            "function": {
+                                "name": "summary",
+                                "arguments": "{\"file\": \"testdata/BobAsShell/test.gpt\"}"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "role": "tool",
+                    "content": "I have read the contents of the file \"testdata/BobAsShell/test.gpt\". This is a sample GPTScript file that demonstrates a simple interaction with a custom AI tool named \"Bob\". Let me briefly describe the contents and the technique it's trying to demonstrate:\n\n1. Contents of the GPTScript file:\n   - The file starts by declaring the tool it will use: \"bob\"\n   - It then provides an instruction to ask Bob \"how are you doing\" and repeat his reply exactly.\n   - After that, there's a section that defines the \"bob\" tool:\n     - It gives Bob a name and a brief description\n     - It specifies that Bob takes one argument: \"question\"\n     - The implementation of Bob is written in Bash script\n\n2. Technique being demonstrated:\n   This GPTScript file is demonstrating the technique of creating and using a custom AI tool within the GPTScript environment. Specifically, it shows:\n\n   a. Tool Declaration: How to declare a tool that will be used in the script.\n   b. Tool Definition: How to define a custom tool, including its name, description, and parameters.\n   c. Tool Implementation: How to implement the functionality of a tool using a different programming language (in this case, Bash).\n   d. Tool Usage: How to use the defined tool within the GPTScript by providing instructions to interact with it.\n\nThe script creates a simple conversational AI named Bob, implemented as a Bash script, which responds to questions in a friendly manner. This demonstrates how GPTScript can integrate external scripts or programs as AI tools, allowing for flexible and extensible AI automation workflows.",
+                    "name": "summary",
+                    "tool_call_id": "toolu_01VTsZPAxCf1sJusFUoqHtgR"
+                }
+            ],
+            "temperature": 0,
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "find",
+                        "description": "Traverse a directory looking for files that match a pattern in the style of the unix find command",
+                        "parameters": {
+                            "properties": {
+                                "directory": {
+                                    "description": "The directory to search in. The current directory \".\" will be used as the default if no argument is passed",
+                                    "type": "string"
+                                },
+                                "pattern": {
+                                    "description": "The file pattern to look for. The pattern is a traditional unix glob format with * matching any character and ? matching a single character",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                },
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "read",
+                        "description": "Reads the contents of a file",
+                        "parameters": {
+                            "properties": {
+                                "filename": {
+                                    "description": "The name of the file to read",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                },
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "summary",
+                        "description": "Summarize a gpt file",
+                        "parameters": {
+                            "properties": {
+                                "file": {
+                                    "description": "filename to summarize",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    {
+        "time": "2024-08-06T12:06:09.627418-04:00",
+        "callContext": {
+            "id": "1722960333",
+            "tool": {
+                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
+                "internalPrompt": null,
+                "tools": [
+                    "sys.find",
+                    "sys.read",
+                    "summary"
+                ],
+                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "id": "testdata/SamplesReadme/test.gpt:",
+                "toolMapping": {
+                    "summary": [
+                        {
+                            "reference": "summary",
+                            "toolID": "testdata/SamplesReadme/test.gpt:summary"
+                        }
+                    ],
+                    "sys.find": [
+                        {
+                            "reference": "sys.find",
+                            "toolID": "sys.find"
+                        }
+                    ],
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 1
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null
+        },
+        "toolSubCalls": {
+            "toolu_01CtiU6WoJfeRsjPKomxvZQr": {
+                "toolID": "testdata/SamplesReadme/test.gpt:summary",
+                "input": "{\"file\": \"testdata/SamplesReadme/test.gpt\"}"
+            }
+        },
+        "type": "callSubCalls",
+        "usage": {}
+    },
+    {
+        "time": "2024-08-06T12:06:09.627424-04:00",
+        "callContext": {
+            "id": "1722960333",
+            "tool": {
+                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
+                "internalPrompt": null,
+                "tools": [
+                    "sys.find",
+                    "sys.read",
+                    "summary"
+                ],
+                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "id": "testdata/SamplesReadme/test.gpt:",
+                "toolMapping": {
+                    "summary": [
+                        {
+                            "reference": "summary",
+                            "toolID": "testdata/SamplesReadme/test.gpt:summary"
+                        }
+                    ],
+                    "sys.find": [
+                        {
+                            "reference": "sys.find",
+                            "toolID": "sys.find"
+                        }
+                    ],
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 1
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722960345",
+        "usage": {},
+        "chatResponse": {
+            "role": "assistant",
+            "content": [
+                {
+                    "toolCall": {
+                        "index": 0,
+                        "id": "toolu_01CtiU6WoJfeRsjPKomxvZQr",
+                        "function": {
+                            "name": "summary",
+                            "arguments": "{\"file\": \"testdata/SamplesReadme/test.gpt\"}"
+                        }
+                    }
+                }
+            ],
+            "usage": {}
+        }
+    },
+    {
+        "time": "2024-08-06T12:06:09.627488-04:00",
+        "callContext": {
+            "id": "toolu_01CtiU6WoJfeRsjPKomxvZQr",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
+                "temperature": 0.7,
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722960333"
+        },
+        "type": "callStart",
+        "usage": {},
+        "content": "{\"file\": \"testdata/SamplesReadme/test.gpt\"}"
+    },
+    {
+        "time": "2024-08-06T12:06:09.9307-04:00",
+        "callContext": {
+            "id": "toolu_01CtiU6WoJfeRsjPKomxvZQr",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
+                "temperature": 0.7,
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722960333"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722960346",
+        "usage": {},
+        "chatRequest": {
+            "model": "claude-3-5-sonnet-20240620",
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate."
+                },
+                {
+                    "role": "user",
+                    "content": "{\"file\": \"testdata/SamplesReadme/test.gpt\"}"
+                }
+            ],
+            "temperature": 0.7,
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "read",
+                        "description": "Reads the contents of a file",
+                        "parameters": {
+                            "properties": {
+                                "filename": {
+                                    "description": "The name of the file to read",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    {
+        "time": "2024-08-06T12:06:12.392264-04:00",
+        "callContext": {
+            "id": "toolu_01CtiU6WoJfeRsjPKomxvZQr",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
+                "temperature": 0.7,
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722960333"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722960346",
+        "usage": {},
+        "chatResponse": {
+            "role": "assistant",
+            "content": [
+                {
+                    "toolCall": {
+                        "index": 0,
+                        "id": "toolu_018fvDQyfKTcLfUtv2SYkDSf",
+                        "function": {
+                            "name": "read",
+                            "arguments": "{\"filename\": \"testdata/SamplesReadme/test.gpt\"}"
+                        }
+                    }
+                }
+            ],
+            "usage": {}
+        }
+    },
+    {
+        "time": "2024-08-06T12:06:12.392317-04:00",
+        "callContext": {
+            "id": "toolu_01CtiU6WoJfeRsjPKomxvZQr",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
+                "temperature": 0.7,
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722960333"
+        },
+        "toolSubCalls": {
+            "toolu_018fvDQyfKTcLfUtv2SYkDSf": {
+                "toolID": "sys.read",
+                "input": "{\"filename\": \"testdata/SamplesReadme/test.gpt\"}"
+            }
+        },
+        "type": "callSubCalls",
+        "usage": {}
+    },
+    {
+        "time": "2024-08-06T12:06:12.392356-04:00",
+        "callContext": {
+            "id": "toolu_018fvDQyfKTcLfUtv2SYkDSf",
+            "tool": {
+                "name": "sys.read",
+                "description": "Reads the contents of a file",
+                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "filename": {
+                            "description": "The name of the file to read",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "instructions": "#!sys.read",
+                "id": "sys.read",
+                "source": {}
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "sys.read",
+            "parentID": "toolu_01CtiU6WoJfeRsjPKomxvZQr",
+            "displayText": "Reading `testdata/SamplesReadme/test.gpt`"
+        },
+        "type": "callStart",
+        "usage": {},
+        "content": "{\"filename\": \"testdata/SamplesReadme/test.gpt\"}"
+    },
+    {
+        "time": "2024-08-06T12:06:12.392409-04:00",
+        "callContext": {
+            "id": "toolu_018fvDQyfKTcLfUtv2SYkDSf",
+            "tool": {
+                "name": "sys.read",
+                "description": "Reads the contents of a file",
+                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "filename": {
+                            "description": "The name of the file to read",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "instructions": "#!sys.read",
+                "id": "sys.read",
+                "source": {}
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "sys.read",
+            "parentID": "toolu_01CtiU6WoJfeRsjPKomxvZQr",
+            "displayText": "Reading `testdata/SamplesReadme/test.gpt`"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722960347",
+        "usage": {},
+        "chatRequest": {
+            "model": "",
+            "messages": null
+        }
+    },
+    {
+        "time": "2024-08-06T12:06:12.392481-04:00",
+        "callContext": {
+            "id": "toolu_018fvDQyfKTcLfUtv2SYkDSf",
+            "tool": {
+                "name": "sys.read",
+                "description": "Reads the contents of a file",
+                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "filename": {
+                            "description": "The name of the file to read",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "instructions": "#!sys.read",
+                "id": "sys.read",
+                "source": {}
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "sys.read",
+            "parentID": "toolu_01CtiU6WoJfeRsjPKomxvZQr",
+            "displayText": "Reading `testdata/SamplesReadme/test.gpt`"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722960347",
+        "usage": {},
+        "chatResponse": {
+            "usage": {}
+        }
+    },
+    {
+        "time": "2024-08-06T12:06:12.392502-04:00",
+        "callContext": {
+            "id": "toolu_018fvDQyfKTcLfUtv2SYkDSf",
+            "tool": {
+                "name": "sys.read",
+                "description": "Reads the contents of a file",
+                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "filename": {
+                            "description": "The name of the file to read",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "instructions": "#!sys.read",
+                "id": "sys.read",
+                "source": {}
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "sys.read",
+            "parentID": "toolu_01CtiU6WoJfeRsjPKomxvZQr",
+            "displayText": "Reading `testdata/SamplesReadme/test.gpt`"
+        },
+        "type": "callFinish",
+        "usage": {},
+        "content": "tools: sys.find, sys.read, summary\n\nGenerate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.\n\n---\nname: summary\ndescription: Summarize a gpt file\nargs: file: filename to summarize\ntools: sys.read\ntemperature: 0.7\n\nRead ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.\n"
+    },
+    {
+        "time": "2024-08-06T12:06:12.392523-04:00",
+        "callContext": {
+            "id": "toolu_01CtiU6WoJfeRsjPKomxvZQr",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
+                "temperature": 0.7,
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722960333"
+        },
+        "toolResults": 1,
+        "type": "callContinue",
+        "usage": {}
+    },
+    {
+        "time": "2024-08-06T12:06:12.613886-04:00",
+        "callContext": {
+            "id": "toolu_01CtiU6WoJfeRsjPKomxvZQr",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
+                "temperature": 0.7,
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722960333"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722960348",
+        "usage": {},
+        "chatRequest": {
+            "model": "claude-3-5-sonnet-20240620",
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate."
+                },
+                {
+                    "role": "user",
+                    "content": "{\"file\": \"testdata/SamplesReadme/test.gpt\"}"
+                },
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "toolu_018fvDQyfKTcLfUtv2SYkDSf",
+                            "type": "function",
+                            "function": {
+                                "name": "read",
+                                "arguments": "{\"filename\": \"testdata/SamplesReadme/test.gpt\"}"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "role": "tool",
+                    "content": "tools: sys.find, sys.read, summary\n\nGenerate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.\n\n---\nname: summary\ndescription: Summarize a gpt file\nargs: file: filename to summarize\ntools: sys.read\ntemperature: 0.7\n\nRead ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.\n",
+                    "name": "read",
+                    "tool_call_id": "toolu_018fvDQyfKTcLfUtv2SYkDSf"
+                }
+            ],
+            "temperature": 0.7,
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "read",
+                        "description": "Reads the contents of a file",
+                        "parameters": {
+                            "properties": {
+                                "filename": {
+                                    "description": "The name of the file to read",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    {
+        "time": "2024-08-06T12:06:21.557353-04:00",
+        "callContext": {
+            "id": "toolu_01CtiU6WoJfeRsjPKomxvZQr",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
+                "temperature": 0.7,
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722960333"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722960348",
+        "usage": {},
+        "chatResponse": {
+            "role": "assistant",
+            "content": [
+                {
+                    "text": "Based on the contents of the file \"testdata/SamplesReadme/test.gpt\", I can provide you with a brief description of its contents and the technique it's trying to demonstrate:\n\nThe GPTScript file contains a script designed to generate a readme that provides a consolidated summary of each sample *.gpt file in a \"testdata\" directory. Here's a breakdown of its contents and techniques:\n\n1. Tools Used:\n   - sys.find: Likely used to locate the *.gpt files in the testdata directory.\n   - sys.read: Used to read the contents of each found file.\n   - summary: A custom tool defined within the script.\n\n2. Main Objective:\n   The script aims to create a readme with summaries of each sample GPTScript file, including links to the referenced files.\n\n3. Custom Tool Definition:\n   The script defines a custom tool called \"summary\" with the following properties:\n   - Name: summary\n   - Description: Summarize a gpt file\n   - Arguments: file (filename to summarize)\n   - Tools used: sys.read\n   - Temperature: 0.7 (controlling the randomness of the AI's output)\n\n4. Summarization Technique:\n   The \"summary\" tool reads a specified GPTScript file and then asks an AI to briefly describe the contents of the file and explain what technique the file is trying to demonstrate.\n\n5. AI Prompt:\n   The script includes a prompt for the AI, instructing it to read the specified file, describe its contents, and explain the demonstrated technique.\n\nThe main technique this GPTScript file is demonstrating is the creation of a custom tool (\"summary\") that can be used to automatically generate summaries of other GPTScript files. This approach allows for the systematic documentation of a collection of script samples, which can be particularly useful for maintaining a library of GPTScript examples or for creating user documentation."
+                }
+            ],
+            "usage": {}
+        }
+    },
+    {
+        "time": "2024-08-06T12:06:21.557382-04:00",
+        "callContext": {
+            "id": "toolu_01CtiU6WoJfeRsjPKomxvZQr",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
+                "temperature": 0.7,
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722960333"
+        },
+        "type": "callFinish",
+        "usage": {},
+        "content": "Based on the contents of the file \"testdata/SamplesReadme/test.gpt\", I can provide you with a brief description of its contents and the technique it's trying to demonstrate:\n\nThe GPTScript file contains a script designed to generate a readme that provides a consolidated summary of each sample *.gpt file in a \"testdata\" directory. Here's a breakdown of its contents and techniques:\n\n1. Tools Used:\n   - sys.find: Likely used to locate the *.gpt files in the testdata directory.\n   - sys.read: Used to read the contents of each found file.\n   - summary: A custom tool defined within the script.\n\n2. Main Objective:\n   The script aims to create a readme with summaries of each sample GPTScript file, including links to the referenced files.\n\n3. Custom Tool Definition:\n   The script defines a custom tool called \"summary\" with the following properties:\n   - Name: summary\n   - Description: Summarize a gpt file\n   - Arguments: file (filename to summarize)\n   - Tools used: sys.read\n   - Temperature: 0.7 (controlling the randomness of the AI's output)\n\n4. Summarization Technique:\n   The \"summary\" tool reads a specified GPTScript file and then asks an AI to briefly describe the contents of the file and explain what technique the file is trying to demonstrate.\n\n5. AI Prompt:\n   The script includes a prompt for the AI, instructing it to read the specified file, describe its contents, and explain the demonstrated technique.\n\nThe main technique this GPTScript file is demonstrating is the creation of a custom tool (\"summary\") that can be used to automatically generate summaries of other GPTScript files. This approach allows for the systematic documentation of a collection of script samples, which can be particularly useful for maintaining a library of GPTScript examples or for creating user documentation."
+    },
+    {
+        "time": "2024-08-06T12:06:21.557426-04:00",
+        "callContext": {
+            "id": "1722960333",
+            "tool": {
+                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
+                "internalPrompt": null,
+                "tools": [
+                    "sys.find",
+                    "sys.read",
+                    "summary"
+                ],
+                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "id": "testdata/SamplesReadme/test.gpt:",
+                "toolMapping": {
+                    "summary": [
+                        {
+                            "reference": "summary",
+                            "toolID": "testdata/SamplesReadme/test.gpt:summary"
+                        }
+                    ],
+                    "sys.find": [
+                        {
+                            "reference": "sys.find",
+                            "toolID": "sys.find"
+                        }
+                    ],
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 1
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null
+        },
+        "toolResults": 1,
+        "type": "callContinue",
+        "usage": {}
+    },
+    {
+        "time": "2024-08-06T12:06:21.787875-04:00",
+        "callContext": {
+            "id": "1722960333",
+            "tool": {
+                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
+                "internalPrompt": null,
+                "tools": [
+                    "sys.find",
+                    "sys.read",
+                    "summary"
+                ],
+                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "id": "testdata/SamplesReadme/test.gpt:",
+                "toolMapping": {
+                    "summary": [
+                        {
+                            "reference": "summary",
+                            "toolID": "testdata/SamplesReadme/test.gpt:summary"
+                        }
+                    ],
+                    "sys.find": [
+                        {
+                            "reference": "sys.find",
+                            "toolID": "sys.find"
+                        }
+                    ],
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 1
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722960349",
+        "usage": {},
+        "chatRequest": {
+            "model": "claude-3-5-sonnet-20240620",
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file."
+                },
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "toolu_01LdSKcXyjdbBRxDeM1c9FC1",
+                            "type": "function",
+                            "function": {
+                                "name": "find",
+                                "arguments": "{\"directory\": \"testdata\", \"pattern\": \"*.gpt\"}"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "role": "tool",
+                    "content": "testdata/Bob/test.gpt\ntestdata/BobAsShell/test.gpt\ntestdata/SamplesReadme/test.gpt",
+                    "name": "find",
+                    "tool_call_id": "toolu_01LdSKcXyjdbBRxDeM1c9FC1"
+                },
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "toolu_01GA1t6HhRTq4pzvRH6XNNkx",
+                            "type": "function",
+                            "function": {
+                                "name": "summary",
+                                "arguments": "{\"file\": \"testdata/Bob/test.gpt\"}"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "role": "tool",
+                    "content": "Thank you for providing the GPTScript file. I've read its contents, and I'll briefly describe what it contains and the technique it's demonstrating.\n\nThe GPTScript file contains a simple script that demonstrates the use of a custom AI tool or agent named \"Bob\". Here's a breakdown of the file's contents and the technique it's showcasing:\n\n1. Content Description:\n   - The script defines a tool called \"bob\" in the tools section.\n   - It includes a main instruction to ask Bob \"how are you doing\" and repeat his reply exactly.\n   - The \"bob\" tool is defined with a name, description, and an argument called \"question\".\n   - Bob is programmed to respond in a specific way when asked how he's doing.\n\n2. Technique Demonstration:\n   The script is demonstrating a few key concepts in AI automation and scripting:\n\n   a) Custom Tool Creation: It shows how to define a custom AI tool or agent (in this case, \"Bob\") with specific behaviors and responses.\n   \n   b) Parameterized Responses: The script showcases how to create a tool that can take an input (the \"question\" argument) and incorporate it into a predefined response template.\n   \n   c) Scripted Interactions: It demonstrates how to script a simple interaction with an AI tool, including asking a specific question and handling the response.\n   \n   d) Template-based Replies: Bob's response is templated, showing how to create consistent yet personalized responses by inserting a variable (${question}) into a fixed string.\n\nIn essence, this GPTScript file is a simple example of creating and interacting with a custom AI agent within an automation framework. It shows how one might script basic conversational interactions and define specific behaviors for AI tools or personas in a larger automation system.",
+                    "name": "summary",
+                    "tool_call_id": "toolu_01GA1t6HhRTq4pzvRH6XNNkx"
+                },
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "toolu_01VTsZPAxCf1sJusFUoqHtgR",
+                            "type": "function",
+                            "function": {
+                                "name": "summary",
+                                "arguments": "{\"file\": \"testdata/BobAsShell/test.gpt\"}"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "role": "tool",
+                    "content": "I have read the contents of the file \"testdata/BobAsShell/test.gpt\". This is a sample GPTScript file that demonstrates a simple interaction with a custom AI tool named \"Bob\". Let me briefly describe the contents and the technique it's trying to demonstrate:\n\n1. Contents of the GPTScript file:\n   - The file starts by declaring the tool it will use: \"bob\"\n   - It then provides an instruction to ask Bob \"how are you doing\" and repeat his reply exactly.\n   - After that, there's a section that defines the \"bob\" tool:\n     - It gives Bob a name and a brief description\n     - It specifies that Bob takes one argument: \"question\"\n     - The implementation of Bob is written in Bash script\n\n2. Technique being demonstrated:\n   This GPTScript file is demonstrating the technique of creating and using a custom AI tool within the GPTScript environment. Specifically, it shows:\n\n   a. Tool Declaration: How to declare a tool that will be used in the script.\n   b. Tool Definition: How to define a custom tool, including its name, description, and parameters.\n   c. Tool Implementation: How to implement the functionality of a tool using a different programming language (in this case, Bash).\n   d. Tool Usage: How to use the defined tool within the GPTScript by providing instructions to interact with it.\n\nThe script creates a simple conversational AI named Bob, implemented as a Bash script, which responds to questions in a friendly manner. This demonstrates how GPTScript can integrate external scripts or programs as AI tools, allowing for flexible and extensible AI automation workflows.",
+                    "name": "summary",
+                    "tool_call_id": "toolu_01VTsZPAxCf1sJusFUoqHtgR"
+                },
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "toolu_01CtiU6WoJfeRsjPKomxvZQr",
+                            "type": "function",
+                            "function": {
+                                "name": "summary",
+                                "arguments": "{\"file\": \"testdata/SamplesReadme/test.gpt\"}"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "role": "tool",
+                    "content": "Based on the contents of the file \"testdata/SamplesReadme/test.gpt\", I can provide you with a brief description of its contents and the technique it's trying to demonstrate:\n\nThe GPTScript file contains a script designed to generate a readme that provides a consolidated summary of each sample *.gpt file in a \"testdata\" directory. Here's a breakdown of its contents and techniques:\n\n1. Tools Used:\n   - sys.find: Likely used to locate the *.gpt files in the testdata directory.\n   - sys.read: Used to read the contents of each found file.\n   - summary: A custom tool defined within the script.\n\n2. Main Objective:\n   The script aims to create a readme with summaries of each sample GPTScript file, including links to the referenced files.\n\n3. Custom Tool Definition:\n   The script defines a custom tool called \"summary\" with the following properties:\n   - Name: summary\n   - Description: Summarize a gpt file\n   - Arguments: file (filename to summarize)\n   - Tools used: sys.read\n   - Temperature: 0.7 (controlling the randomness of the AI's output)\n\n4. Summarization Technique:\n   The \"summary\" tool reads a specified GPTScript file and then asks an AI to briefly describe the contents of the file and explain what technique the file is trying to demonstrate.\n\n5. AI Prompt:\n   The script includes a prompt for the AI, instructing it to read the specified file, describe its contents, and explain the demonstrated technique.\n\nThe main technique this GPTScript file is demonstrating is the creation of a custom tool (\"summary\") that can be used to automatically generate summaries of other GPTScript files. This approach allows for the systematic documentation of a collection of script samples, which can be particularly useful for maintaining a library of GPTScript examples or for creating user documentation.",
+                    "name": "summary",
+                    "tool_call_id": "toolu_01CtiU6WoJfeRsjPKomxvZQr"
+                }
+            ],
+            "temperature": 0,
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "find",
+                        "description": "Traverse a directory looking for files that match a pattern in the style of the unix find command",
+                        "parameters": {
+                            "properties": {
+                                "directory": {
+                                    "description": "The directory to search in. The current directory \".\" will be used as the default if no argument is passed",
+                                    "type": "string"
+                                },
+                                "pattern": {
+                                    "description": "The file pattern to look for. The pattern is a traditional unix glob format with * matching any character and ? matching a single character",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                },
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "read",
+                        "description": "Reads the contents of a file",
+                        "parameters": {
+                            "properties": {
+                                "filename": {
+                                    "description": "The name of the file to read",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                },
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "summary",
+                        "description": "Summarize a gpt file",
+                        "parameters": {
+                            "properties": {
+                                "file": {
+                                    "description": "filename to summarize",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    {
+        "time": "2024-08-06T12:06:33.603142-04:00",
+        "callContext": {
+            "id": "1722960333",
+            "tool": {
+                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
+                "internalPrompt": null,
+                "tools": [
+                    "sys.find",
+                    "sys.read",
+                    "summary"
+                ],
+                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "id": "testdata/SamplesReadme/test.gpt:",
+                "toolMapping": {
+                    "summary": [
+                        {
+                            "reference": "summary",
+                            "toolID": "testdata/SamplesReadme/test.gpt:summary"
+                        }
+                    ],
+                    "sys.find": [
+                        {
+                            "reference": "sys.find",
+                            "toolID": "sys.find"
+                        }
+                    ],
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 1
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722960349",
+        "usage": {},
+        "chatResponse": {
+            "role": "assistant",
+            "content": [
+                {
+                    "text": "Based on the summaries of the GPTScript files found in the testdata directory, I'll now generate a README that provides a consolidated summary of each sample *.gpt file, including links to the referenced files:\n\n# Sample GPTScript Files README\n\nThis README provides a summary of the sample GPTScript files found in the testdata directory. Each entry includes a brief description of the file's contents and the technique it demonstrates, along with a link to the file.\n\n## [testdata/Bob/test.gpt](testdata/Bob/test.gpt)\n\nThis GPTScript file demonstrates the creation and use of a custom AI tool named \"Bob\". \n\n**Key Features:**\n- Defines a custom tool called \"bob\" with a specific behavior\n- Shows how to create parameterized responses\n- Demonstrates scripted interactions with an AI tool\n- Illustrates the use of template-based replies\n\n**Technique Demonstrated:** The script showcases how to create a simple conversational AI agent within an automation framework, including defining specific behaviors and scripting basic interactions.\n\n## [testdata/BobAsShell/test.gpt](testdata/BobAsShell/test.gpt)\n\nThis GPTScript file demonstrates the integration of an external script (in this case, a Bash script) as a custom AI tool named \"Bob\".\n\n**Key Features:**\n- Declares and defines a custom tool \"bob\"\n- Implements the tool's functionality using Bash script\n- Shows how to interact with the custom tool within GPTScript\n\n**Technique Demonstrated:** This script illustrates how GPTScript can integrate external scripts or programs as AI tools, allowing for flexible and extensible AI automation workflows.\n\n## [testdata/SamplesReadme/test.gpt](testdata/SamplesReadme/test.gpt)\n\nThis GPTScript file is designed to generate a readme that summarizes other GPTScript files in a directory.\n\n**Key Features:**\n- Uses system tools (sys.find, sys.read) to locate and read GPTScript files\n- Defines a custom \"summary\" tool for file summarization\n- Demonstrates how to create documentation for a collection of scripts\n\n**Technique Demonstrated:** The script showcases the creation of a custom tool for automatic documentation generation, which can be useful for maintaining a library of GPTScript examples or creating user documentation.\n\nThis README provides an overview of the sample GPTScript files, demonstrating various techniques from simple AI interactions to more complex automation and documentation tasks. Each sample illustrates different aspects of working with GPTScript, offering valuable examples for users learning to create their own AI-powered automation scripts."
+                }
+            ],
+            "usage": {}
+        }
+    },
+    {
+        "time": "2024-08-06T12:06:33.603177-04:00",
+        "callContext": {
+            "id": "1722960333",
+            "tool": {
+                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
+                "internalPrompt": null,
+                "tools": [
+                    "sys.find",
+                    "sys.read",
+                    "summary"
+                ],
+                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "id": "testdata/SamplesReadme/test.gpt:",
+                "toolMapping": {
+                    "summary": [
+                        {
+                            "reference": "summary",
+                            "toolID": "testdata/SamplesReadme/test.gpt:summary"
+                        }
+                    ],
+                    "sys.find": [
+                        {
+                            "reference": "sys.find",
+                            "toolID": "sys.find"
+                        }
+                    ],
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 1
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null
+        },
+        "type": "callFinish",
+        "usage": {},
+        "content": "Based on the summaries of the GPTScript files found in the testdata directory, I'll now generate a README that provides a consolidated summary of each sample *.gpt file, including links to the referenced files:\n\n# Sample GPTScript Files README\n\nThis README provides a summary of the sample GPTScript files found in the testdata directory. Each entry includes a brief description of the file's contents and the technique it demonstrates, along with a link to the file.\n\n## [testdata/Bob/test.gpt](testdata/Bob/test.gpt)\n\nThis GPTScript file demonstrates the creation and use of a custom AI tool named \"Bob\". \n\n**Key Features:**\n- Defines a custom tool called \"bob\" with a specific behavior\n- Shows how to create parameterized responses\n- Demonstrates scripted interactions with an AI tool\n- Illustrates the use of template-based replies\n\n**Technique Demonstrated:** The script showcases how to create a simple conversational AI agent within an automation framework, including defining specific behaviors and scripting basic interactions.\n\n## [testdata/BobAsShell/test.gpt](testdata/BobAsShell/test.gpt)\n\nThis GPTScript file demonstrates the integration of an external script (in this case, a Bash script) as a custom AI tool named \"Bob\".\n\n**Key Features:**\n- Declares and defines a custom tool \"bob\"\n- Implements the tool's functionality using Bash script\n- Shows how to interact with the custom tool within GPTScript\n\n**Technique Demonstrated:** This script illustrates how GPTScript can integrate external scripts or programs as AI tools, allowing for flexible and extensible AI automation workflows.\n\n## [testdata/SamplesReadme/test.gpt](testdata/SamplesReadme/test.gpt)\n\nThis GPTScript file is designed to generate a readme that summarizes other GPTScript files in a directory.\n\n**Key Features:**\n- Uses system tools (sys.find, sys.read) to locate and read GPTScript files\n- Defines a custom \"summary\" tool for file summarization\n- Demonstrates how to create documentation for a collection of scripts\n\n**Technique Demonstrated:** The script showcases the creation of a custom tool for automatic documentation generation, which can be useful for maintaining a library of GPTScript examples or creating user documentation.\n\nThis README provides an overview of the sample GPTScript files, demonstrating various techniques from simple AI interactions to more complex automation and documentation tasks. Each sample illustrates different aspects of working with GPTScript, offering valuable examples for users learning to create their own AI-powered automation scripts."
+    },
+    {
+        "time": "2024-08-06T12:06:33.603203-04:00",
+        "type": "runFinish",
+        "usage": {}
+    }
+]

--- a/pkg/tests/smoke/testdata/SamplesReadme/claude-3-5-sonnet-20240620-expected.json
+++ b/pkg/tests/smoke/testdata/SamplesReadme/claude-3-5-sonnet-20240620-expected.json
@@ -1,13 +1,13 @@
 [
     {
-        "time": "2024-08-06T12:05:32.225085-04:00",
+        "time": "2024-08-23T12:02:23.303172-04:00",
         "type": "runStart",
         "usage": {}
     },
     {
-        "time": "2024-08-06T12:05:32.226098-04:00",
+        "time": "2024-08-23T12:02:23.303434-04:00",
         "callContext": {
-            "id": "1722960333",
+            "id": "1724428944",
             "tool": {
                 "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "internalPrompt": null,
@@ -16,7 +16,7 @@
                     "sys.read",
                     "summary"
                 ],
-                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "instructions": "Generate a readme that gives a consolidated summary of each *.gpt file in the testdata directory.\nEach entry should be a include a link to the referenced file.",
                 "id": "testdata/SamplesReadme/test.gpt:",
                 "toolMapping": {
                     "summary": [
@@ -55,14 +55,14 @@
         "usage": {}
     },
     {
-        "time": "2024-08-06T12:05:32.894044-04:00",
+        "time": "2024-08-23T12:02:23.952218-04:00",
         "type": "runStart",
         "usage": {}
     },
     {
-        "time": "2024-08-06T12:05:32.894378-04:00",
+        "time": "2024-08-23T12:02:23.952555-04:00",
         "callContext": {
-            "id": "1722960334",
+            "id": "1724428945",
             "tool": {
                 "name": "Anthropic Claude3 Model Provider",
                 "description": "Model provider for Anthropic hosted Claude3 models",
@@ -107,9 +107,9 @@
         "usage": {}
     },
     {
-        "time": "2024-08-06T12:05:33.911076-04:00",
+        "time": "2024-08-23T12:02:24.965699-04:00",
         "callContext": {
-            "id": "1722960334",
+            "id": "1724428945",
             "tool": {
                 "name": "Anthropic Claude3 Model Provider",
                 "description": "Model provider for Anthropic hosted Claude3 models",
@@ -152,17 +152,17 @@
         },
         "type": "callFinish",
         "usage": {},
-        "content": "http://127.0.0.1:10598"
+        "content": "http://127.0.0.1:11236"
     },
     {
-        "time": "2024-08-06T12:05:33.911294-04:00",
+        "time": "2024-08-23T12:02:24.965909-04:00",
         "type": "runFinish",
         "usage": {}
     },
     {
-        "time": "2024-08-06T12:05:33.911369-04:00",
+        "time": "2024-08-23T12:02:24.966017-04:00",
         "callContext": {
-            "id": "1722960333",
+            "id": "1724428944",
             "tool": {
                 "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "internalPrompt": null,
@@ -171,7 +171,7 @@
                     "sys.read",
                     "summary"
                 ],
-                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "instructions": "Generate a readme that gives a consolidated summary of each *.gpt file in the testdata directory.\nEach entry should be a include a link to the referenced file.",
                 "id": "testdata/SamplesReadme/test.gpt:",
                 "toolMapping": {
                     "summary": [
@@ -207,14 +207,14 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1722960335",
+        "chatCompletionId": "1724428946",
         "usage": {},
         "chatRequest": {
             "model": "claude-3-5-sonnet-20240620",
             "messages": [
                 {
                     "role": "system",
-                    "content": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file."
+                    "content": "Generate a readme that gives a consolidated summary of each *.gpt file in the testdata directory.\nEach entry should be a include a link to the referenced file."
                 }
             ],
             "temperature": 0,
@@ -275,9 +275,9 @@
         }
     },
     {
-        "time": "2024-08-06T12:05:37.827865-04:00",
+        "time": "2024-08-23T12:02:27.675387-04:00",
         "callContext": {
-            "id": "1722960333",
+            "id": "1724428944",
             "tool": {
                 "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "internalPrompt": null,
@@ -286,7 +286,7 @@
                     "sys.read",
                     "summary"
                 ],
-                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "instructions": "Generate a readme that gives a consolidated summary of each *.gpt file in the testdata directory.\nEach entry should be a include a link to the referenced file.",
                 "id": "testdata/SamplesReadme/test.gpt:",
                 "toolMapping": {
                     "summary": [
@@ -322,7 +322,7 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1722960335",
+        "chatCompletionId": "1724428946",
         "usage": {},
         "chatResponse": {
             "role": "assistant",
@@ -330,7 +330,7 @@
                 {
                     "toolCall": {
                         "index": 0,
-                        "id": "toolu_01LdSKcXyjdbBRxDeM1c9FC1",
+                        "id": "toolu_01YWQ7wLRQ7tv4dSUJ6drs6Z",
                         "function": {
                             "name": "find",
                             "arguments": "{\"directory\": \"testdata\", \"pattern\": \"*.gpt\"}"
@@ -342,9 +342,9 @@
         }
     },
     {
-        "time": "2024-08-06T12:05:37.82796-04:00",
+        "time": "2024-08-23T12:02:27.675761-04:00",
         "callContext": {
-            "id": "1722960333",
+            "id": "1724428944",
             "tool": {
                 "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "internalPrompt": null,
@@ -353,7 +353,7 @@
                     "sys.read",
                     "summary"
                 ],
-                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "instructions": "Generate a readme that gives a consolidated summary of each *.gpt file in the testdata directory.\nEach entry should be a include a link to the referenced file.",
                 "id": "testdata/SamplesReadme/test.gpt:",
                 "toolMapping": {
                     "summary": [
@@ -389,7 +389,7 @@
             "inputContext": null
         },
         "toolSubCalls": {
-            "toolu_01LdSKcXyjdbBRxDeM1c9FC1": {
+            "toolu_01YWQ7wLRQ7tv4dSUJ6drs6Z": {
                 "toolID": "sys.find",
                 "input": "{\"directory\": \"testdata\", \"pattern\": \"*.gpt\"}"
             }
@@ -398,9 +398,9 @@
         "usage": {}
     },
     {
-        "time": "2024-08-06T12:05:37.828009-04:00",
+        "time": "2024-08-23T12:02:27.6758-04:00",
         "callContext": {
-            "id": "toolu_01LdSKcXyjdbBRxDeM1c9FC1",
+            "id": "toolu_01YWQ7wLRQ7tv4dSUJ6drs6Z",
             "tool": {
                 "name": "sys.find",
                 "description": "Traverse a directory looking for files that match a pattern in the style of the unix find command",
@@ -426,7 +426,7 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "sys.find",
-            "parentID": "1722960333",
+            "parentID": "1724428944",
             "displayText": "Finding `*.gpt` in `testdata`"
         },
         "type": "callStart",
@@ -434,9 +434,9 @@
         "content": "{\"directory\": \"testdata\", \"pattern\": \"*.gpt\"}"
     },
     {
-        "time": "2024-08-06T12:05:37.828079-04:00",
+        "time": "2024-08-23T12:02:27.675881-04:00",
         "callContext": {
-            "id": "toolu_01LdSKcXyjdbBRxDeM1c9FC1",
+            "id": "toolu_01YWQ7wLRQ7tv4dSUJ6drs6Z",
             "tool": {
                 "name": "sys.find",
                 "description": "Traverse a directory looking for files that match a pattern in the style of the unix find command",
@@ -462,11 +462,11 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "sys.find",
-            "parentID": "1722960333",
+            "parentID": "1724428944",
             "displayText": "Finding `*.gpt` in `testdata`"
         },
         "type": "callChat",
-        "chatCompletionId": "1722960336",
+        "chatCompletionId": "1724428947",
         "usage": {},
         "chatRequest": {
             "model": "",
@@ -474,9 +474,9 @@
         }
     },
     {
-        "time": "2024-08-06T12:05:37.828287-04:00",
+        "time": "2024-08-23T12:02:27.676139-04:00",
         "callContext": {
-            "id": "toolu_01LdSKcXyjdbBRxDeM1c9FC1",
+            "id": "toolu_01YWQ7wLRQ7tv4dSUJ6drs6Z",
             "tool": {
                 "name": "sys.find",
                 "description": "Traverse a directory looking for files that match a pattern in the style of the unix find command",
@@ -502,20 +502,20 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "sys.find",
-            "parentID": "1722960333",
+            "parentID": "1724428944",
             "displayText": "Finding `*.gpt` in `testdata`"
         },
         "type": "callChat",
-        "chatCompletionId": "1722960336",
+        "chatCompletionId": "1724428947",
         "usage": {},
         "chatResponse": {
             "usage": {}
         }
     },
     {
-        "time": "2024-08-06T12:05:37.82832-04:00",
+        "time": "2024-08-23T12:02:27.676181-04:00",
         "callContext": {
-            "id": "toolu_01LdSKcXyjdbBRxDeM1c9FC1",
+            "id": "toolu_01YWQ7wLRQ7tv4dSUJ6drs6Z",
             "tool": {
                 "name": "sys.find",
                 "description": "Traverse a directory looking for files that match a pattern in the style of the unix find command",
@@ -541,7 +541,7 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "sys.find",
-            "parentID": "1722960333",
+            "parentID": "1724428944",
             "displayText": "Finding `*.gpt` in `testdata`"
         },
         "type": "callFinish",
@@ -549,9 +549,9 @@
         "content": "testdata/Bob/test.gpt\ntestdata/BobAsShell/test.gpt\ntestdata/SamplesReadme/test.gpt"
     },
     {
-        "time": "2024-08-06T12:05:37.828345-04:00",
+        "time": "2024-08-23T12:02:27.67621-04:00",
         "callContext": {
-            "id": "1722960333",
+            "id": "1724428944",
             "tool": {
                 "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "internalPrompt": null,
@@ -560,7 +560,7 @@
                     "sys.read",
                     "summary"
                 ],
-                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "instructions": "Generate a readme that gives a consolidated summary of each *.gpt file in the testdata directory.\nEach entry should be a include a link to the referenced file.",
                 "id": "testdata/SamplesReadme/test.gpt:",
                 "toolMapping": {
                     "summary": [
@@ -600,9 +600,9 @@
         "usage": {}
     },
     {
-        "time": "2024-08-06T12:05:38.016257-04:00",
+        "time": "2024-08-23T12:02:27.907536-04:00",
         "callContext": {
-            "id": "1722960333",
+            "id": "1724428944",
             "tool": {
                 "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "internalPrompt": null,
@@ -611,7 +611,7 @@
                     "sys.read",
                     "summary"
                 ],
-                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "instructions": "Generate a readme that gives a consolidated summary of each *.gpt file in the testdata directory.\nEach entry should be a include a link to the referenced file.",
                 "id": "testdata/SamplesReadme/test.gpt:",
                 "toolMapping": {
                     "summary": [
@@ -647,21 +647,21 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1722960337",
+        "chatCompletionId": "1724428948",
         "usage": {},
         "chatRequest": {
             "model": "claude-3-5-sonnet-20240620",
             "messages": [
                 {
                     "role": "system",
-                    "content": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file."
+                    "content": "Generate a readme that gives a consolidated summary of each *.gpt file in the testdata directory.\nEach entry should be a include a link to the referenced file."
                 },
                 {
                     "role": "assistant",
                     "content": "",
                     "tool_calls": [
                         {
-                            "id": "toolu_01LdSKcXyjdbBRxDeM1c9FC1",
+                            "id": "toolu_01YWQ7wLRQ7tv4dSUJ6drs6Z",
                             "type": "function",
                             "function": {
                                 "name": "find",
@@ -674,7 +674,7 @@
                     "role": "tool",
                     "content": "testdata/Bob/test.gpt\ntestdata/BobAsShell/test.gpt\ntestdata/SamplesReadme/test.gpt",
                     "name": "find",
-                    "tool_call_id": "toolu_01LdSKcXyjdbBRxDeM1c9FC1"
+                    "tool_call_id": "toolu_01YWQ7wLRQ7tv4dSUJ6drs6Z"
                 }
             ],
             "temperature": 0,
@@ -735,9 +735,9 @@
         }
     },
     {
-        "time": "2024-08-06T12:05:40.239488-04:00",
+        "time": "2024-08-23T12:02:29.596773-04:00",
         "callContext": {
-            "id": "1722960333",
+            "id": "1724428944",
             "tool": {
                 "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "internalPrompt": null,
@@ -746,63 +746,7 @@
                     "sys.read",
                     "summary"
                 ],
-                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
-                "id": "testdata/SamplesReadme/test.gpt:",
-                "toolMapping": {
-                    "summary": [
-                        {
-                            "reference": "summary",
-                            "toolID": "testdata/SamplesReadme/test.gpt:summary"
-                        }
-                    ],
-                    "sys.find": [
-                        {
-                            "reference": "sys.find",
-                            "toolID": "sys.find"
-                        }
-                    ],
-                    "sys.read": [
-                        {
-                            "reference": "sys.read",
-                            "toolID": "sys.read"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/SamplesReadme/test.gpt:",
-                    "summary": "testdata/SamplesReadme/test.gpt:summary"
-                },
-                "source": {
-                    "location": "testdata/SamplesReadme/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/SamplesReadme"
-            },
-            "currentAgent": {},
-            "inputContext": null
-        },
-        "toolSubCalls": {
-            "toolu_01GA1t6HhRTq4pzvRH6XNNkx": {
-                "toolID": "testdata/SamplesReadme/test.gpt:summary",
-                "input": "{\"file\": \"testdata/Bob/test.gpt\"}"
-            }
-        },
-        "type": "callSubCalls",
-        "usage": {}
-    },
-    {
-        "time": "2024-08-06T12:05:40.23949-04:00",
-        "callContext": {
-            "id": "1722960333",
-            "tool": {
-                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
-                "internalPrompt": null,
-                "tools": [
-                    "sys.find",
-                    "sys.read",
-                    "summary"
-                ],
-                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "instructions": "Generate a readme that gives a consolidated summary of each *.gpt file in the testdata directory.\nEach entry should be a include a link to the referenced file.",
                 "id": "testdata/SamplesReadme/test.gpt:",
                 "toolMapping": {
                     "summary": [
@@ -838,7 +782,7 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1722960337",
+        "chatCompletionId": "1724428948",
         "usage": {},
         "chatResponse": {
             "role": "assistant",
@@ -846,7 +790,7 @@
                 {
                     "toolCall": {
                         "index": 0,
-                        "id": "toolu_01GA1t6HhRTq4pzvRH6XNNkx",
+                        "id": "toolu_01W6GYNz1MwRBgehjZQQCWz3",
                         "function": {
                             "name": "summary",
                             "arguments": "{\"file\": \"testdata/Bob/test.gpt\"}"
@@ -858,14 +802,69 @@
         }
     },
     {
-        "time": "2024-08-06T12:05:40.239549-04:00",
+        "time": "2024-08-23T12:02:29.59679-04:00",
         "callContext": {
-            "id": "toolu_01GA1t6HhRTq4pzvRH6XNNkx",
+            "id": "1724428944",
+            "tool": {
+                "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
+                "internalPrompt": null,
+                "tools": [
+                    "sys.find",
+                    "sys.read",
+                    "summary"
+                ],
+                "instructions": "Generate a readme that gives a consolidated summary of each *.gpt file in the testdata directory.\nEach entry should be a include a link to the referenced file.",
+                "id": "testdata/SamplesReadme/test.gpt:",
+                "toolMapping": {
+                    "summary": [
+                        {
+                            "reference": "summary",
+                            "toolID": "testdata/SamplesReadme/test.gpt:summary"
+                        }
+                    ],
+                    "sys.find": [
+                        {
+                            "reference": "sys.find",
+                            "toolID": "sys.find"
+                        }
+                    ],
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 1
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null
+        },
+        "toolSubCalls": {
+            "toolu_01W6GYNz1MwRBgehjZQQCWz3": {
+                "toolID": "testdata/SamplesReadme/test.gpt:summary",
+                "input": "{\"file\": \"testdata/Bob/test.gpt\"}"
+            }
+        },
+        "type": "callSubCalls",
+        "usage": {}
+    },
+    {
+        "time": "2024-08-23T12:02:29.596885-04:00",
+        "callContext": {
+            "id": "toolu_01W6GYNz1MwRBgehjZQQCWz3",
             "tool": {
                 "name": "summary",
                 "description": "Summarize a gpt file",
                 "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
-                "temperature": 0.7,
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -902,21 +901,20 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "summary",
-            "parentID": "1722960333"
+            "parentID": "1724428944"
         },
         "type": "callStart",
         "usage": {},
         "content": "{\"file\": \"testdata/Bob/test.gpt\"}"
     },
     {
-        "time": "2024-08-06T12:05:40.486174-04:00",
+        "time": "2024-08-23T12:02:29.834449-04:00",
         "callContext": {
-            "id": "toolu_01GA1t6HhRTq4pzvRH6XNNkx",
+            "id": "toolu_01W6GYNz1MwRBgehjZQQCWz3",
             "tool": {
                 "name": "summary",
                 "description": "Summarize a gpt file",
                 "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
-                "temperature": 0.7,
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -953,10 +951,10 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "summary",
-            "parentID": "1722960333"
+            "parentID": "1724428944"
         },
         "type": "callChat",
-        "chatCompletionId": "1722960338",
+        "chatCompletionId": "1724428949",
         "usage": {},
         "chatRequest": {
             "model": "claude-3-5-sonnet-20240620",
@@ -970,7 +968,7 @@
                     "content": "{\"file\": \"testdata/Bob/test.gpt\"}"
                 }
             ],
-            "temperature": 0.7,
+            "temperature": 0,
             "tools": [
                 {
                     "type": "function",
@@ -992,14 +990,13 @@
         }
     },
     {
-        "time": "2024-08-06T12:05:43.852168-04:00",
+        "time": "2024-08-23T12:02:31.80403-04:00",
         "callContext": {
-            "id": "toolu_01GA1t6HhRTq4pzvRH6XNNkx",
+            "id": "toolu_01W6GYNz1MwRBgehjZQQCWz3",
             "tool": {
                 "name": "summary",
                 "description": "Summarize a gpt file",
                 "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
-                "temperature": 0.7,
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -1036,10 +1033,10 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "summary",
-            "parentID": "1722960333"
+            "parentID": "1724428944"
         },
         "type": "callChat",
-        "chatCompletionId": "1722960338",
+        "chatCompletionId": "1724428949",
         "usage": {},
         "chatResponse": {
             "role": "assistant",
@@ -1047,7 +1044,7 @@
                 {
                     "toolCall": {
                         "index": 0,
-                        "id": "toolu_01KhwrAvNEskbWRCFZBrn5co",
+                        "id": "toolu_01Qx7nHyrAr7SeGvNNM7sYVh",
                         "function": {
                             "name": "read",
                             "arguments": "{\"filename\": \"testdata/Bob/test.gpt\"}"
@@ -1059,14 +1056,13 @@
         }
     },
     {
-        "time": "2024-08-06T12:05:43.852236-04:00",
+        "time": "2024-08-23T12:02:31.804102-04:00",
         "callContext": {
-            "id": "toolu_01GA1t6HhRTq4pzvRH6XNNkx",
+            "id": "toolu_01W6GYNz1MwRBgehjZQQCWz3",
             "tool": {
                 "name": "summary",
                 "description": "Summarize a gpt file",
                 "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
-                "temperature": 0.7,
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -1103,10 +1099,10 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "summary",
-            "parentID": "1722960333"
+            "parentID": "1724428944"
         },
         "toolSubCalls": {
-            "toolu_01KhwrAvNEskbWRCFZBrn5co": {
+            "toolu_01Qx7nHyrAr7SeGvNNM7sYVh": {
                 "toolID": "sys.read",
                 "input": "{\"filename\": \"testdata/Bob/test.gpt\"}"
             }
@@ -1115,9 +1111,9 @@
         "usage": {}
     },
     {
-        "time": "2024-08-06T12:05:43.852279-04:00",
+        "time": "2024-08-23T12:02:31.804143-04:00",
         "callContext": {
-            "id": "toolu_01KhwrAvNEskbWRCFZBrn5co",
+            "id": "toolu_01Qx7nHyrAr7SeGvNNM7sYVh",
             "tool": {
                 "name": "sys.read",
                 "description": "Reads the contents of a file",
@@ -1139,7 +1135,7 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "sys.read",
-            "parentID": "toolu_01GA1t6HhRTq4pzvRH6XNNkx",
+            "parentID": "toolu_01W6GYNz1MwRBgehjZQQCWz3",
             "displayText": "Reading `testdata/Bob/test.gpt`"
         },
         "type": "callStart",
@@ -1147,9 +1143,9 @@
         "content": "{\"filename\": \"testdata/Bob/test.gpt\"}"
     },
     {
-        "time": "2024-08-06T12:05:43.852343-04:00",
+        "time": "2024-08-23T12:02:31.804204-04:00",
         "callContext": {
-            "id": "toolu_01KhwrAvNEskbWRCFZBrn5co",
+            "id": "toolu_01Qx7nHyrAr7SeGvNNM7sYVh",
             "tool": {
                 "name": "sys.read",
                 "description": "Reads the contents of a file",
@@ -1171,11 +1167,11 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "sys.read",
-            "parentID": "toolu_01GA1t6HhRTq4pzvRH6XNNkx",
+            "parentID": "toolu_01W6GYNz1MwRBgehjZQQCWz3",
             "displayText": "Reading `testdata/Bob/test.gpt`"
         },
         "type": "callChat",
-        "chatCompletionId": "1722960339",
+        "chatCompletionId": "1724428950",
         "usage": {},
         "chatRequest": {
             "model": "",
@@ -1183,9 +1179,9 @@
         }
     },
     {
-        "time": "2024-08-06T12:05:43.852425-04:00",
+        "time": "2024-08-23T12:02:31.804268-04:00",
         "callContext": {
-            "id": "toolu_01KhwrAvNEskbWRCFZBrn5co",
+            "id": "toolu_01Qx7nHyrAr7SeGvNNM7sYVh",
             "tool": {
                 "name": "sys.read",
                 "description": "Reads the contents of a file",
@@ -1207,20 +1203,20 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "sys.read",
-            "parentID": "toolu_01GA1t6HhRTq4pzvRH6XNNkx",
+            "parentID": "toolu_01W6GYNz1MwRBgehjZQQCWz3",
             "displayText": "Reading `testdata/Bob/test.gpt`"
         },
         "type": "callChat",
-        "chatCompletionId": "1722960339",
+        "chatCompletionId": "1724428950",
         "usage": {},
         "chatResponse": {
             "usage": {}
         }
     },
     {
-        "time": "2024-08-06T12:05:43.852462-04:00",
+        "time": "2024-08-23T12:02:31.804291-04:00",
         "callContext": {
-            "id": "toolu_01KhwrAvNEskbWRCFZBrn5co",
+            "id": "toolu_01Qx7nHyrAr7SeGvNNM7sYVh",
             "tool": {
                 "name": "sys.read",
                 "description": "Reads the contents of a file",
@@ -1242,22 +1238,21 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "sys.read",
-            "parentID": "toolu_01GA1t6HhRTq4pzvRH6XNNkx",
+            "parentID": "toolu_01W6GYNz1MwRBgehjZQQCWz3",
             "displayText": "Reading `testdata/Bob/test.gpt`"
         },
         "type": "callFinish",
         "usage": {},
-        "content": "tools: bob\n\nAsk Bob \"how are you doing\" and repeat his reply exactly.\n\n---\nname: bob\ndescription: I'm Bob, a friendly guy.\nargs: question: The question to ask Bob.\n\nWhen asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"\n"
+        "content": "tools: bob\n\nAsk Bob \"how are you doing\" and repeat his reply exactly.\n\n---\nname: bob\ndescription: I'm Bob, a friendly guy.\nargs: question: The question to ask Bob.\n\nWhen asked how I am doing, respond with exactly \"Thanks for asking \"${QUESTION}\", I'm doing great fellow friendly AI tool!\"\n"
     },
     {
-        "time": "2024-08-06T12:05:43.852484-04:00",
+        "time": "2024-08-23T12:02:31.804313-04:00",
         "callContext": {
-            "id": "toolu_01GA1t6HhRTq4pzvRH6XNNkx",
+            "id": "toolu_01W6GYNz1MwRBgehjZQQCWz3",
             "tool": {
                 "name": "summary",
                 "description": "Summarize a gpt file",
                 "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
-                "temperature": 0.7,
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -1294,21 +1289,20 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "summary",
-            "parentID": "1722960333"
+            "parentID": "1724428944"
         },
         "toolResults": 1,
         "type": "callContinue",
         "usage": {}
     },
     {
-        "time": "2024-08-06T12:05:44.274147-04:00",
+        "time": "2024-08-23T12:02:32.040688-04:00",
         "callContext": {
-            "id": "toolu_01GA1t6HhRTq4pzvRH6XNNkx",
+            "id": "toolu_01W6GYNz1MwRBgehjZQQCWz3",
             "tool": {
                 "name": "summary",
                 "description": "Summarize a gpt file",
                 "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
-                "temperature": 0.7,
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -1345,10 +1339,10 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "summary",
-            "parentID": "1722960333"
+            "parentID": "1724428944"
         },
         "type": "callChat",
-        "chatCompletionId": "1722960340",
+        "chatCompletionId": "1724428951",
         "usage": {},
         "chatRequest": {
             "model": "claude-3-5-sonnet-20240620",
@@ -1366,7 +1360,7 @@
                     "content": "",
                     "tool_calls": [
                         {
-                            "id": "toolu_01KhwrAvNEskbWRCFZBrn5co",
+                            "id": "toolu_01Qx7nHyrAr7SeGvNNM7sYVh",
                             "type": "function",
                             "function": {
                                 "name": "read",
@@ -1377,12 +1371,12 @@
                 },
                 {
                     "role": "tool",
-                    "content": "tools: bob\n\nAsk Bob \"how are you doing\" and repeat his reply exactly.\n\n---\nname: bob\ndescription: I'm Bob, a friendly guy.\nargs: question: The question to ask Bob.\n\nWhen asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"\n",
+                    "content": "tools: bob\n\nAsk Bob \"how are you doing\" and repeat his reply exactly.\n\n---\nname: bob\ndescription: I'm Bob, a friendly guy.\nargs: question: The question to ask Bob.\n\nWhen asked how I am doing, respond with exactly \"Thanks for asking \"${QUESTION}\", I'm doing great fellow friendly AI tool!\"\n",
                     "name": "read",
-                    "tool_call_id": "toolu_01KhwrAvNEskbWRCFZBrn5co"
+                    "tool_call_id": "toolu_01Qx7nHyrAr7SeGvNNM7sYVh"
                 }
             ],
-            "temperature": 0.7,
+            "temperature": 0,
             "tools": [
                 {
                     "type": "function",
@@ -1404,14 +1398,13 @@
         }
     },
     {
-        "time": "2024-08-06T12:05:53.297643-04:00",
+        "time": "2024-08-23T12:02:38.871357-04:00",
         "callContext": {
-            "id": "toolu_01GA1t6HhRTq4pzvRH6XNNkx",
+            "id": "toolu_01W6GYNz1MwRBgehjZQQCWz3",
             "tool": {
                 "name": "summary",
                 "description": "Summarize a gpt file",
                 "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
-                "temperature": 0.7,
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -1448,30 +1441,29 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "summary",
-            "parentID": "1722960333"
+            "parentID": "1724428944"
         },
         "type": "callChat",
-        "chatCompletionId": "1722960340",
+        "chatCompletionId": "1724428951",
         "usage": {},
         "chatResponse": {
             "role": "assistant",
             "content": [
                 {
-                    "text": "Thank you for providing the GPTScript file. I've read its contents, and I'll briefly describe what it contains and the technique it's demonstrating.\n\nThe GPTScript file contains a simple script that demonstrates the use of a custom AI tool or agent named \"Bob\". Here's a breakdown of the file's contents and the technique it's showcasing:\n\n1. Content Description:\n   - The script defines a tool called \"bob\" in the tools section.\n   - It includes a main instruction to ask Bob \"how are you doing\" and repeat his reply exactly.\n   - The \"bob\" tool is defined with a name, description, and an argument called \"question\".\n   - Bob is programmed to respond in a specific way when asked how he's doing.\n\n2. Technique Demonstration:\n   The script is demonstrating a few key concepts in AI automation and scripting:\n\n   a) Custom Tool Creation: It shows how to define a custom AI tool or agent (in this case, \"Bob\") with specific behaviors and responses.\n   \n   b) Parameterized Responses: The script showcases how to create a tool that can take an input (the \"question\" argument) and incorporate it into a predefined response template.\n   \n   c) Scripted Interactions: It demonstrates how to script a simple interaction with an AI tool, including asking a specific question and handling the response.\n   \n   d) Template-based Replies: Bob's response is templated, showing how to create consistent yet personalized responses by inserting a variable (${question}) into a fixed string.\n\nIn essence, this GPTScript file is a simple example of creating and interacting with a custom AI agent within an automation framework. It shows how one might script basic conversational interactions and define specific behaviors for AI tools or personas in a larger automation system."
+                    "text": "Thank you for providing the GPTScript file. I've read its contents, and I'll briefly describe what it contains and the technique it's trying to demonstrate.\n\nThe GPTScript file \"test.gpt\" is demonstrating a simple AI automation script that involves interaction with a simulated AI tool or agent named \"Bob\". Here's a breakdown of its contents and the technique it's showcasing:\n\n1. Content Description:\n   - The script defines a tool called \"bob\".\n   - It instructs to ask Bob a specific question: \"how are you doing\".\n   - It then directs to repeat Bob's reply exactly.\n   - The script includes a definition for the \"bob\" tool, describing it as a friendly character.\n   - It specifies an argument \"question\" for interacting with Bob.\n   - Finally, it provides a specific response format for when Bob is asked how he's doing.\n\n2. Technique Demonstration:\n   The script is demonstrating several key concepts in AI automation scripting:\n\n   a) Tool Definition: It shows how to define a custom AI tool or agent (in this case, \"bob\") within a script.\n   \n   b) Parameterized Interactions: The script demonstrates how to set up parameterized interactions with an AI tool, using the \"question\" argument.\n   \n   c) Scripted Responses: It showcases how to create scripted or predefined responses for specific inputs. In this case, when asked \"how are you doing\", Bob has a specific, templated response.\n   \n   d) String Interpolation: The response uses string interpolation (${QUESTION}) to incorporate the input question into the output, demonstrating dynamic response generation.\n   \n   e) Exact Output Control: The script emphasizes exact repetition of responses, showing how GPTScript can be used to control AI outputs precisely.\n\nIn summary, this GPTScript file is a simple yet effective demonstration of creating a basic interactive AI tool with predefined behaviors and responses. It showcases the potential of GPTScript for crafting specific AI interactions and responses in an automation context."
                 }
             ],
             "usage": {}
         }
     },
     {
-        "time": "2024-08-06T12:05:53.297743-04:00",
+        "time": "2024-08-23T12:02:38.871416-04:00",
         "callContext": {
-            "id": "toolu_01GA1t6HhRTq4pzvRH6XNNkx",
+            "id": "toolu_01W6GYNz1MwRBgehjZQQCWz3",
             "tool": {
                 "name": "summary",
                 "description": "Summarize a gpt file",
                 "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
-                "temperature": 0.7,
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -1508,16 +1500,16 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "summary",
-            "parentID": "1722960333"
+            "parentID": "1724428944"
         },
         "type": "callFinish",
         "usage": {},
-        "content": "Thank you for providing the GPTScript file. I've read its contents, and I'll briefly describe what it contains and the technique it's demonstrating.\n\nThe GPTScript file contains a simple script that demonstrates the use of a custom AI tool or agent named \"Bob\". Here's a breakdown of the file's contents and the technique it's showcasing:\n\n1. Content Description:\n   - The script defines a tool called \"bob\" in the tools section.\n   - It includes a main instruction to ask Bob \"how are you doing\" and repeat his reply exactly.\n   - The \"bob\" tool is defined with a name, description, and an argument called \"question\".\n   - Bob is programmed to respond in a specific way when asked how he's doing.\n\n2. Technique Demonstration:\n   The script is demonstrating a few key concepts in AI automation and scripting:\n\n   a) Custom Tool Creation: It shows how to define a custom AI tool or agent (in this case, \"Bob\") with specific behaviors and responses.\n   \n   b) Parameterized Responses: The script showcases how to create a tool that can take an input (the \"question\" argument) and incorporate it into a predefined response template.\n   \n   c) Scripted Interactions: It demonstrates how to script a simple interaction with an AI tool, including asking a specific question and handling the response.\n   \n   d) Template-based Replies: Bob's response is templated, showing how to create consistent yet personalized responses by inserting a variable (${question}) into a fixed string.\n\nIn essence, this GPTScript file is a simple example of creating and interacting with a custom AI agent within an automation framework. It shows how one might script basic conversational interactions and define specific behaviors for AI tools or personas in a larger automation system."
+        "content": "Thank you for providing the GPTScript file. I've read its contents, and I'll briefly describe what it contains and the technique it's trying to demonstrate.\n\nThe GPTScript file \"test.gpt\" is demonstrating a simple AI automation script that involves interaction with a simulated AI tool or agent named \"Bob\". Here's a breakdown of its contents and the technique it's showcasing:\n\n1. Content Description:\n   - The script defines a tool called \"bob\".\n   - It instructs to ask Bob a specific question: \"how are you doing\".\n   - It then directs to repeat Bob's reply exactly.\n   - The script includes a definition for the \"bob\" tool, describing it as a friendly character.\n   - It specifies an argument \"question\" for interacting with Bob.\n   - Finally, it provides a specific response format for when Bob is asked how he's doing.\n\n2. Technique Demonstration:\n   The script is demonstrating several key concepts in AI automation scripting:\n\n   a) Tool Definition: It shows how to define a custom AI tool or agent (in this case, \"bob\") within a script.\n   \n   b) Parameterized Interactions: The script demonstrates how to set up parameterized interactions with an AI tool, using the \"question\" argument.\n   \n   c) Scripted Responses: It showcases how to create scripted or predefined responses for specific inputs. In this case, when asked \"how are you doing\", Bob has a specific, templated response.\n   \n   d) String Interpolation: The response uses string interpolation (${QUESTION}) to incorporate the input question into the output, demonstrating dynamic response generation.\n   \n   e) Exact Output Control: The script emphasizes exact repetition of responses, showing how GPTScript can be used to control AI outputs precisely.\n\nIn summary, this GPTScript file is a simple yet effective demonstration of creating a basic interactive AI tool with predefined behaviors and responses. It showcases the potential of GPTScript for crafting specific AI interactions and responses in an automation context."
     },
     {
-        "time": "2024-08-06T12:05:53.298113-04:00",
+        "time": "2024-08-23T12:02:38.871459-04:00",
         "callContext": {
-            "id": "1722960333",
+            "id": "1724428944",
             "tool": {
                 "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "internalPrompt": null,
@@ -1526,7 +1518,7 @@
                     "sys.read",
                     "summary"
                 ],
-                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "instructions": "Generate a readme that gives a consolidated summary of each *.gpt file in the testdata directory.\nEach entry should be a include a link to the referenced file.",
                 "id": "testdata/SamplesReadme/test.gpt:",
                 "toolMapping": {
                     "summary": [
@@ -1566,9 +1558,9 @@
         "usage": {}
     },
     {
-        "time": "2024-08-06T12:05:53.49392-04:00",
+        "time": "2024-08-23T12:02:39.125653-04:00",
         "callContext": {
-            "id": "1722960333",
+            "id": "1724428944",
             "tool": {
                 "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "internalPrompt": null,
@@ -1577,7 +1569,7 @@
                     "sys.read",
                     "summary"
                 ],
-                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "instructions": "Generate a readme that gives a consolidated summary of each *.gpt file in the testdata directory.\nEach entry should be a include a link to the referenced file.",
                 "id": "testdata/SamplesReadme/test.gpt:",
                 "toolMapping": {
                     "summary": [
@@ -1613,21 +1605,21 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1722960341",
+        "chatCompletionId": "1724428952",
         "usage": {},
         "chatRequest": {
             "model": "claude-3-5-sonnet-20240620",
             "messages": [
                 {
                     "role": "system",
-                    "content": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file."
+                    "content": "Generate a readme that gives a consolidated summary of each *.gpt file in the testdata directory.\nEach entry should be a include a link to the referenced file."
                 },
                 {
                     "role": "assistant",
                     "content": "",
                     "tool_calls": [
                         {
-                            "id": "toolu_01LdSKcXyjdbBRxDeM1c9FC1",
+                            "id": "toolu_01YWQ7wLRQ7tv4dSUJ6drs6Z",
                             "type": "function",
                             "function": {
                                 "name": "find",
@@ -1640,14 +1632,14 @@
                     "role": "tool",
                     "content": "testdata/Bob/test.gpt\ntestdata/BobAsShell/test.gpt\ntestdata/SamplesReadme/test.gpt",
                     "name": "find",
-                    "tool_call_id": "toolu_01LdSKcXyjdbBRxDeM1c9FC1"
+                    "tool_call_id": "toolu_01YWQ7wLRQ7tv4dSUJ6drs6Z"
                 },
                 {
                     "role": "assistant",
                     "content": "",
                     "tool_calls": [
                         {
-                            "id": "toolu_01GA1t6HhRTq4pzvRH6XNNkx",
+                            "id": "toolu_01W6GYNz1MwRBgehjZQQCWz3",
                             "type": "function",
                             "function": {
                                 "name": "summary",
@@ -1658,9 +1650,9 @@
                 },
                 {
                     "role": "tool",
-                    "content": "Thank you for providing the GPTScript file. I've read its contents, and I'll briefly describe what it contains and the technique it's demonstrating.\n\nThe GPTScript file contains a simple script that demonstrates the use of a custom AI tool or agent named \"Bob\". Here's a breakdown of the file's contents and the technique it's showcasing:\n\n1. Content Description:\n   - The script defines a tool called \"bob\" in the tools section.\n   - It includes a main instruction to ask Bob \"how are you doing\" and repeat his reply exactly.\n   - The \"bob\" tool is defined with a name, description, and an argument called \"question\".\n   - Bob is programmed to respond in a specific way when asked how he's doing.\n\n2. Technique Demonstration:\n   The script is demonstrating a few key concepts in AI automation and scripting:\n\n   a) Custom Tool Creation: It shows how to define a custom AI tool or agent (in this case, \"Bob\") with specific behaviors and responses.\n   \n   b) Parameterized Responses: The script showcases how to create a tool that can take an input (the \"question\" argument) and incorporate it into a predefined response template.\n   \n   c) Scripted Interactions: It demonstrates how to script a simple interaction with an AI tool, including asking a specific question and handling the response.\n   \n   d) Template-based Replies: Bob's response is templated, showing how to create consistent yet personalized responses by inserting a variable (${question}) into a fixed string.\n\nIn essence, this GPTScript file is a simple example of creating and interacting with a custom AI agent within an automation framework. It shows how one might script basic conversational interactions and define specific behaviors for AI tools or personas in a larger automation system.",
+                    "content": "Thank you for providing the GPTScript file. I've read its contents, and I'll briefly describe what it contains and the technique it's trying to demonstrate.\n\nThe GPTScript file \"test.gpt\" is demonstrating a simple AI automation script that involves interaction with a simulated AI tool or agent named \"Bob\". Here's a breakdown of its contents and the technique it's showcasing:\n\n1. Content Description:\n   - The script defines a tool called \"bob\".\n   - It instructs to ask Bob a specific question: \"how are you doing\".\n   - It then directs to repeat Bob's reply exactly.\n   - The script includes a definition for the \"bob\" tool, describing it as a friendly character.\n   - It specifies an argument \"question\" for interacting with Bob.\n   - Finally, it provides a specific response format for when Bob is asked how he's doing.\n\n2. Technique Demonstration:\n   The script is demonstrating several key concepts in AI automation scripting:\n\n   a) Tool Definition: It shows how to define a custom AI tool or agent (in this case, \"bob\") within a script.\n   \n   b) Parameterized Interactions: The script demonstrates how to set up parameterized interactions with an AI tool, using the \"question\" argument.\n   \n   c) Scripted Responses: It showcases how to create scripted or predefined responses for specific inputs. In this case, when asked \"how are you doing\", Bob has a specific, templated response.\n   \n   d) String Interpolation: The response uses string interpolation (${QUESTION}) to incorporate the input question into the output, demonstrating dynamic response generation.\n   \n   e) Exact Output Control: The script emphasizes exact repetition of responses, showing how GPTScript can be used to control AI outputs precisely.\n\nIn summary, this GPTScript file is a simple yet effective demonstration of creating a basic interactive AI tool with predefined behaviors and responses. It showcases the potential of GPTScript for crafting specific AI interactions and responses in an automation context.",
                     "name": "summary",
-                    "tool_call_id": "toolu_01GA1t6HhRTq4pzvRH6XNNkx"
+                    "tool_call_id": "toolu_01W6GYNz1MwRBgehjZQQCWz3"
                 }
             ],
             "temperature": 0,
@@ -1721,9 +1713,9 @@
         }
     },
     {
-        "time": "2024-08-06T12:05:55.636946-04:00",
+        "time": "2024-08-23T12:02:41.73696-04:00",
         "callContext": {
-            "id": "1722960333",
+            "id": "1724428944",
             "tool": {
                 "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "internalPrompt": null,
@@ -1732,7 +1724,7 @@
                     "sys.read",
                     "summary"
                 ],
-                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "instructions": "Generate a readme that gives a consolidated summary of each *.gpt file in the testdata directory.\nEach entry should be a include a link to the referenced file.",
                 "id": "testdata/SamplesReadme/test.gpt:",
                 "toolMapping": {
                     "summary": [
@@ -1768,7 +1760,7 @@
             "inputContext": null
         },
         "toolSubCalls": {
-            "toolu_01VTsZPAxCf1sJusFUoqHtgR": {
+            "toolu_01VosVGbzD4M8g6jw5ZQUgQy": {
                 "toolID": "testdata/SamplesReadme/test.gpt:summary",
                 "input": "{\"file\": \"testdata/BobAsShell/test.gpt\"}"
             }
@@ -1777,9 +1769,9 @@
         "usage": {}
     },
     {
-        "time": "2024-08-06T12:05:55.636958-04:00",
+        "time": "2024-08-23T12:02:41.736966-04:00",
         "callContext": {
-            "id": "1722960333",
+            "id": "1724428944",
             "tool": {
                 "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "internalPrompt": null,
@@ -1788,7 +1780,7 @@
                     "sys.read",
                     "summary"
                 ],
-                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "instructions": "Generate a readme that gives a consolidated summary of each *.gpt file in the testdata directory.\nEach entry should be a include a link to the referenced file.",
                 "id": "testdata/SamplesReadme/test.gpt:",
                 "toolMapping": {
                     "summary": [
@@ -1824,7 +1816,7 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1722960341",
+        "chatCompletionId": "1724428952",
         "usage": {},
         "chatResponse": {
             "role": "assistant",
@@ -1832,7 +1824,7 @@
                 {
                     "toolCall": {
                         "index": 0,
-                        "id": "toolu_01VTsZPAxCf1sJusFUoqHtgR",
+                        "id": "toolu_01VosVGbzD4M8g6jw5ZQUgQy",
                         "function": {
                             "name": "summary",
                             "arguments": "{\"file\": \"testdata/BobAsShell/test.gpt\"}"
@@ -1844,14 +1836,13 @@
         }
     },
     {
-        "time": "2024-08-06T12:05:55.637002-04:00",
+        "time": "2024-08-23T12:02:41.737024-04:00",
         "callContext": {
-            "id": "toolu_01VTsZPAxCf1sJusFUoqHtgR",
+            "id": "toolu_01VosVGbzD4M8g6jw5ZQUgQy",
             "tool": {
                 "name": "summary",
                 "description": "Summarize a gpt file",
                 "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
-                "temperature": 0.7,
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -1888,21 +1879,20 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "summary",
-            "parentID": "1722960333"
+            "parentID": "1724428944"
         },
         "type": "callStart",
         "usage": {},
         "content": "{\"file\": \"testdata/BobAsShell/test.gpt\"}"
     },
     {
-        "time": "2024-08-06T12:05:55.806829-04:00",
+        "time": "2024-08-23T12:02:42.081991-04:00",
         "callContext": {
-            "id": "toolu_01VTsZPAxCf1sJusFUoqHtgR",
+            "id": "toolu_01VosVGbzD4M8g6jw5ZQUgQy",
             "tool": {
                 "name": "summary",
                 "description": "Summarize a gpt file",
                 "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
-                "temperature": 0.7,
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -1939,10 +1929,10 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "summary",
-            "parentID": "1722960333"
+            "parentID": "1724428944"
         },
         "type": "callChat",
-        "chatCompletionId": "1722960342",
+        "chatCompletionId": "1724428953",
         "usage": {},
         "chatRequest": {
             "model": "claude-3-5-sonnet-20240620",
@@ -1956,7 +1946,7 @@
                     "content": "{\"file\": \"testdata/BobAsShell/test.gpt\"}"
                 }
             ],
-            "temperature": 0.7,
+            "temperature": 0,
             "tools": [
                 {
                     "type": "function",
@@ -1978,14 +1968,13 @@
         }
     },
     {
-        "time": "2024-08-06T12:05:58.795512-04:00",
+        "time": "2024-08-23T12:02:44.971294-04:00",
         "callContext": {
-            "id": "toolu_01VTsZPAxCf1sJusFUoqHtgR",
+            "id": "toolu_01VosVGbzD4M8g6jw5ZQUgQy",
             "tool": {
                 "name": "summary",
                 "description": "Summarize a gpt file",
                 "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
-                "temperature": 0.7,
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -2022,10 +2011,10 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "summary",
-            "parentID": "1722960333"
+            "parentID": "1724428944"
         },
         "type": "callChat",
-        "chatCompletionId": "1722960342",
+        "chatCompletionId": "1724428953",
         "usage": {},
         "chatResponse": {
             "role": "assistant",
@@ -2033,7 +2022,7 @@
                 {
                     "toolCall": {
                         "index": 0,
-                        "id": "toolu_01Ph36AMoyPFtJyoSSh3fkPX",
+                        "id": "toolu_01Wk8G3ag7MXGTKSwDhPdbnT",
                         "function": {
                             "name": "read",
                             "arguments": "{\"filename\": \"testdata/BobAsShell/test.gpt\"}"
@@ -2045,14 +2034,13 @@
         }
     },
     {
-        "time": "2024-08-06T12:05:58.795554-04:00",
+        "time": "2024-08-23T12:02:44.971336-04:00",
         "callContext": {
-            "id": "toolu_01VTsZPAxCf1sJusFUoqHtgR",
+            "id": "toolu_01VosVGbzD4M8g6jw5ZQUgQy",
             "tool": {
                 "name": "summary",
                 "description": "Summarize a gpt file",
                 "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
-                "temperature": 0.7,
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -2089,10 +2077,10 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "summary",
-            "parentID": "1722960333"
+            "parentID": "1724428944"
         },
         "toolSubCalls": {
-            "toolu_01Ph36AMoyPFtJyoSSh3fkPX": {
+            "toolu_01Wk8G3ag7MXGTKSwDhPdbnT": {
                 "toolID": "sys.read",
                 "input": "{\"filename\": \"testdata/BobAsShell/test.gpt\"}"
             }
@@ -2101,9 +2089,9 @@
         "usage": {}
     },
     {
-        "time": "2024-08-06T12:05:58.795591-04:00",
+        "time": "2024-08-23T12:02:44.971405-04:00",
         "callContext": {
-            "id": "toolu_01Ph36AMoyPFtJyoSSh3fkPX",
+            "id": "toolu_01Wk8G3ag7MXGTKSwDhPdbnT",
             "tool": {
                 "name": "sys.read",
                 "description": "Reads the contents of a file",
@@ -2125,7 +2113,7 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "sys.read",
-            "parentID": "toolu_01VTsZPAxCf1sJusFUoqHtgR",
+            "parentID": "toolu_01VosVGbzD4M8g6jw5ZQUgQy",
             "displayText": "Reading `testdata/BobAsShell/test.gpt`"
         },
         "type": "callStart",
@@ -2133,9 +2121,9 @@
         "content": "{\"filename\": \"testdata/BobAsShell/test.gpt\"}"
     },
     {
-        "time": "2024-08-06T12:05:58.795642-04:00",
+        "time": "2024-08-23T12:02:44.971462-04:00",
         "callContext": {
-            "id": "toolu_01Ph36AMoyPFtJyoSSh3fkPX",
+            "id": "toolu_01Wk8G3ag7MXGTKSwDhPdbnT",
             "tool": {
                 "name": "sys.read",
                 "description": "Reads the contents of a file",
@@ -2157,11 +2145,11 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "sys.read",
-            "parentID": "toolu_01VTsZPAxCf1sJusFUoqHtgR",
+            "parentID": "toolu_01VosVGbzD4M8g6jw5ZQUgQy",
             "displayText": "Reading `testdata/BobAsShell/test.gpt`"
         },
         "type": "callChat",
-        "chatCompletionId": "1722960343",
+        "chatCompletionId": "1724428954",
         "usage": {},
         "chatRequest": {
             "model": "",
@@ -2169,9 +2157,9 @@
         }
     },
     {
-        "time": "2024-08-06T12:05:58.795709-04:00",
+        "time": "2024-08-23T12:02:44.971526-04:00",
         "callContext": {
-            "id": "toolu_01Ph36AMoyPFtJyoSSh3fkPX",
+            "id": "toolu_01Wk8G3ag7MXGTKSwDhPdbnT",
             "tool": {
                 "name": "sys.read",
                 "description": "Reads the contents of a file",
@@ -2193,20 +2181,20 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "sys.read",
-            "parentID": "toolu_01VTsZPAxCf1sJusFUoqHtgR",
+            "parentID": "toolu_01VosVGbzD4M8g6jw5ZQUgQy",
             "displayText": "Reading `testdata/BobAsShell/test.gpt`"
         },
         "type": "callChat",
-        "chatCompletionId": "1722960343",
+        "chatCompletionId": "1724428954",
         "usage": {},
         "chatResponse": {
             "usage": {}
         }
     },
     {
-        "time": "2024-08-06T12:05:58.795729-04:00",
+        "time": "2024-08-23T12:02:44.971548-04:00",
         "callContext": {
-            "id": "toolu_01Ph36AMoyPFtJyoSSh3fkPX",
+            "id": "toolu_01Wk8G3ag7MXGTKSwDhPdbnT",
             "tool": {
                 "name": "sys.read",
                 "description": "Reads the contents of a file",
@@ -2228,22 +2216,21 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "sys.read",
-            "parentID": "toolu_01VTsZPAxCf1sJusFUoqHtgR",
+            "parentID": "toolu_01VosVGbzD4M8g6jw5ZQUgQy",
             "displayText": "Reading `testdata/BobAsShell/test.gpt`"
         },
         "type": "callFinish",
         "usage": {},
-        "content": "\ntools: bob\n\nAsk Bob \"how are you doing\" and repeat his reply exactly.\n\n---\nname: bob\ndescription: I'm Bob, a friendly guy.\nargs: question: The question to ask Bob.\n\n#!/bin/bash\n\necho \"Thanks for asking ${question}, I'm doing great fellow friendly AI tool!\"\n"
+        "content": "\ntools: bob\n\nAsk Bob \"how are you doing\" and repeat his reply exactly.\n\n---\nname: bob\ndescription: I'm Bob, a friendly guy.\nargs: question: The question to ask Bob.\n\n#!/bin/bash\n\necho \"Thanks for asking ${QUESTION}, I'm doing great fellow friendly AI tool!\"\n"
     },
     {
-        "time": "2024-08-06T12:05:58.795747-04:00",
+        "time": "2024-08-23T12:02:44.971575-04:00",
         "callContext": {
-            "id": "toolu_01VTsZPAxCf1sJusFUoqHtgR",
+            "id": "toolu_01VosVGbzD4M8g6jw5ZQUgQy",
             "tool": {
                 "name": "summary",
                 "description": "Summarize a gpt file",
                 "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
-                "temperature": 0.7,
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -2280,21 +2267,20 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "summary",
-            "parentID": "1722960333"
+            "parentID": "1724428944"
         },
         "toolResults": 1,
         "type": "callContinue",
         "usage": {}
     },
     {
-        "time": "2024-08-06T12:05:59.059914-04:00",
+        "time": "2024-08-23T12:02:45.19226-04:00",
         "callContext": {
-            "id": "toolu_01VTsZPAxCf1sJusFUoqHtgR",
+            "id": "toolu_01VosVGbzD4M8g6jw5ZQUgQy",
             "tool": {
                 "name": "summary",
                 "description": "Summarize a gpt file",
                 "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
-                "temperature": 0.7,
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -2331,10 +2317,10 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "summary",
-            "parentID": "1722960333"
+            "parentID": "1724428944"
         },
         "type": "callChat",
-        "chatCompletionId": "1722960344",
+        "chatCompletionId": "1724428955",
         "usage": {},
         "chatRequest": {
             "model": "claude-3-5-sonnet-20240620",
@@ -2352,7 +2338,7 @@
                     "content": "",
                     "tool_calls": [
                         {
-                            "id": "toolu_01Ph36AMoyPFtJyoSSh3fkPX",
+                            "id": "toolu_01Wk8G3ag7MXGTKSwDhPdbnT",
                             "type": "function",
                             "function": {
                                 "name": "read",
@@ -2363,12 +2349,12 @@
                 },
                 {
                     "role": "tool",
-                    "content": "\ntools: bob\n\nAsk Bob \"how are you doing\" and repeat his reply exactly.\n\n---\nname: bob\ndescription: I'm Bob, a friendly guy.\nargs: question: The question to ask Bob.\n\n#!/bin/bash\n\necho \"Thanks for asking ${question}, I'm doing great fellow friendly AI tool!\"\n",
+                    "content": "\ntools: bob\n\nAsk Bob \"how are you doing\" and repeat his reply exactly.\n\n---\nname: bob\ndescription: I'm Bob, a friendly guy.\nargs: question: The question to ask Bob.\n\n#!/bin/bash\n\necho \"Thanks for asking ${QUESTION}, I'm doing great fellow friendly AI tool!\"\n",
                     "name": "read",
-                    "tool_call_id": "toolu_01Ph36AMoyPFtJyoSSh3fkPX"
+                    "tool_call_id": "toolu_01Wk8G3ag7MXGTKSwDhPdbnT"
                 }
             ],
-            "temperature": 0.7,
+            "temperature": 0,
             "tools": [
                 {
                     "type": "function",
@@ -2390,14 +2376,13 @@
         }
     },
     {
-        "time": "2024-08-06T12:06:07.091565-04:00",
+        "time": "2024-08-23T12:02:52.544775-04:00",
         "callContext": {
-            "id": "toolu_01VTsZPAxCf1sJusFUoqHtgR",
+            "id": "toolu_01VosVGbzD4M8g6jw5ZQUgQy",
             "tool": {
                 "name": "summary",
                 "description": "Summarize a gpt file",
                 "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
-                "temperature": 0.7,
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -2434,30 +2419,29 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "summary",
-            "parentID": "1722960333"
+            "parentID": "1724428944"
         },
         "type": "callChat",
-        "chatCompletionId": "1722960344",
+        "chatCompletionId": "1724428955",
         "usage": {},
         "chatResponse": {
             "role": "assistant",
             "content": [
                 {
-                    "text": "I have read the contents of the file \"testdata/BobAsShell/test.gpt\". This is a sample GPTScript file that demonstrates a simple interaction with a custom AI tool named \"Bob\". Let me briefly describe the contents and the technique it's trying to demonstrate:\n\n1. Contents of the GPTScript file:\n   - The file starts by declaring the tool it will use: \"bob\"\n   - It then provides an instruction to ask Bob \"how are you doing\" and repeat his reply exactly.\n   - After that, there's a section that defines the \"bob\" tool:\n     - It gives Bob a name and a brief description\n     - It specifies that Bob takes one argument: \"question\"\n     - The implementation of Bob is written in Bash script\n\n2. Technique being demonstrated:\n   This GPTScript file is demonstrating the technique of creating and using a custom AI tool within the GPTScript environment. Specifically, it shows:\n\n   a. Tool Declaration: How to declare a tool that will be used in the script.\n   b. Tool Definition: How to define a custom tool, including its name, description, and parameters.\n   c. Tool Implementation: How to implement the functionality of a tool using a different programming language (in this case, Bash).\n   d. Tool Usage: How to use the defined tool within the GPTScript by providing instructions to interact with it.\n\nThe script creates a simple conversational AI named Bob, implemented as a Bash script, which responds to questions in a friendly manner. This demonstrates how GPTScript can integrate external scripts or programs as AI tools, allowing for flexible and extensible AI automation workflows."
+                    "text": "I've read the contents of the file \"testdata/BobAsShell/test.gpt\". This is a sample GPTScript file that demonstrates a simple interaction with a custom AI tool named \"Bob\". Let me briefly describe the contents and the technique it's trying to demonstrate:\n\n1. Contents of the GPTScript file:\n   - The file starts by declaring the tool it will use: \"bob\"\n   - It then provides an instruction to ask Bob \"how are you doing\" and repeat his reply exactly.\n   - After that, there's a section that defines the \"bob\" tool:\n     - It gives Bob a name and a description: \"I'm Bob, a friendly guy.\"\n     - It specifies that Bob takes one argument: \"question\"\n     - The implementation of Bob is written in Bash script, which echoes a friendly response incorporating the question asked.\n\n2. Technique demonstrated:\n   This GPTScript file is demonstrating the creation and use of a custom AI tool within the GPTScript environment. Specifically, it shows:\n\n   a. Tool Declaration: How to declare a tool that will be used in the script.\n   b. Tool Definition: How to define a custom tool, including its name, description, and parameters.\n   c. Tool Implementation: How to implement the tool's functionality (in this case, using a Bash script).\n   d. Tool Usage: How to use the defined tool within the script by asking it a question.\n\nThe technique showcases the flexibility of GPTScript in integrating custom tools that can be implemented in various ways (like Bash scripts) and then used seamlessly within the AI conversation flow. This allows for extending the capabilities of the AI system with custom, potentially external functionalities.\n\nIn this specific example, \"Bob\" is a simple tool that responds to questions in a friendly manner, demonstrating how personality or specific response patterns can be incorporated into custom tools in GPTScript."
                 }
             ],
             "usage": {}
         }
     },
     {
-        "time": "2024-08-06T12:06:07.091589-04:00",
+        "time": "2024-08-23T12:02:52.544808-04:00",
         "callContext": {
-            "id": "toolu_01VTsZPAxCf1sJusFUoqHtgR",
+            "id": "toolu_01VosVGbzD4M8g6jw5ZQUgQy",
             "tool": {
                 "name": "summary",
                 "description": "Summarize a gpt file",
                 "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
-                "temperature": 0.7,
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -2494,16 +2478,16 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "summary",
-            "parentID": "1722960333"
+            "parentID": "1724428944"
         },
         "type": "callFinish",
         "usage": {},
-        "content": "I have read the contents of the file \"testdata/BobAsShell/test.gpt\". This is a sample GPTScript file that demonstrates a simple interaction with a custom AI tool named \"Bob\". Let me briefly describe the contents and the technique it's trying to demonstrate:\n\n1. Contents of the GPTScript file:\n   - The file starts by declaring the tool it will use: \"bob\"\n   - It then provides an instruction to ask Bob \"how are you doing\" and repeat his reply exactly.\n   - After that, there's a section that defines the \"bob\" tool:\n     - It gives Bob a name and a brief description\n     - It specifies that Bob takes one argument: \"question\"\n     - The implementation of Bob is written in Bash script\n\n2. Technique being demonstrated:\n   This GPTScript file is demonstrating the technique of creating and using a custom AI tool within the GPTScript environment. Specifically, it shows:\n\n   a. Tool Declaration: How to declare a tool that will be used in the script.\n   b. Tool Definition: How to define a custom tool, including its name, description, and parameters.\n   c. Tool Implementation: How to implement the functionality of a tool using a different programming language (in this case, Bash).\n   d. Tool Usage: How to use the defined tool within the GPTScript by providing instructions to interact with it.\n\nThe script creates a simple conversational AI named Bob, implemented as a Bash script, which responds to questions in a friendly manner. This demonstrates how GPTScript can integrate external scripts or programs as AI tools, allowing for flexible and extensible AI automation workflows."
+        "content": "I've read the contents of the file \"testdata/BobAsShell/test.gpt\". This is a sample GPTScript file that demonstrates a simple interaction with a custom AI tool named \"Bob\". Let me briefly describe the contents and the technique it's trying to demonstrate:\n\n1. Contents of the GPTScript file:\n   - The file starts by declaring the tool it will use: \"bob\"\n   - It then provides an instruction to ask Bob \"how are you doing\" and repeat his reply exactly.\n   - After that, there's a section that defines the \"bob\" tool:\n     - It gives Bob a name and a description: \"I'm Bob, a friendly guy.\"\n     - It specifies that Bob takes one argument: \"question\"\n     - The implementation of Bob is written in Bash script, which echoes a friendly response incorporating the question asked.\n\n2. Technique demonstrated:\n   This GPTScript file is demonstrating the creation and use of a custom AI tool within the GPTScript environment. Specifically, it shows:\n\n   a. Tool Declaration: How to declare a tool that will be used in the script.\n   b. Tool Definition: How to define a custom tool, including its name, description, and parameters.\n   c. Tool Implementation: How to implement the tool's functionality (in this case, using a Bash script).\n   d. Tool Usage: How to use the defined tool within the script by asking it a question.\n\nThe technique showcases the flexibility of GPTScript in integrating custom tools that can be implemented in various ways (like Bash scripts) and then used seamlessly within the AI conversation flow. This allows for extending the capabilities of the AI system with custom, potentially external functionalities.\n\nIn this specific example, \"Bob\" is a simple tool that responds to questions in a friendly manner, demonstrating how personality or specific response patterns can be incorporated into custom tools in GPTScript."
     },
     {
-        "time": "2024-08-06T12:06:07.09162-04:00",
+        "time": "2024-08-23T12:02:52.544835-04:00",
         "callContext": {
-            "id": "1722960333",
+            "id": "1724428944",
             "tool": {
                 "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "internalPrompt": null,
@@ -2512,7 +2496,7 @@
                     "sys.read",
                     "summary"
                 ],
-                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "instructions": "Generate a readme that gives a consolidated summary of each *.gpt file in the testdata directory.\nEach entry should be a include a link to the referenced file.",
                 "id": "testdata/SamplesReadme/test.gpt:",
                 "toolMapping": {
                     "summary": [
@@ -2552,9 +2536,9 @@
         "usage": {}
     },
     {
-        "time": "2024-08-06T12:06:07.414741-04:00",
+        "time": "2024-08-23T12:02:52.808549-04:00",
         "callContext": {
-            "id": "1722960333",
+            "id": "1724428944",
             "tool": {
                 "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "internalPrompt": null,
@@ -2563,7 +2547,7 @@
                     "sys.read",
                     "summary"
                 ],
-                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "instructions": "Generate a readme that gives a consolidated summary of each *.gpt file in the testdata directory.\nEach entry should be a include a link to the referenced file.",
                 "id": "testdata/SamplesReadme/test.gpt:",
                 "toolMapping": {
                     "summary": [
@@ -2599,21 +2583,21 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1722960345",
+        "chatCompletionId": "1724428956",
         "usage": {},
         "chatRequest": {
             "model": "claude-3-5-sonnet-20240620",
             "messages": [
                 {
                     "role": "system",
-                    "content": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file."
+                    "content": "Generate a readme that gives a consolidated summary of each *.gpt file in the testdata directory.\nEach entry should be a include a link to the referenced file."
                 },
                 {
                     "role": "assistant",
                     "content": "",
                     "tool_calls": [
                         {
-                            "id": "toolu_01LdSKcXyjdbBRxDeM1c9FC1",
+                            "id": "toolu_01YWQ7wLRQ7tv4dSUJ6drs6Z",
                             "type": "function",
                             "function": {
                                 "name": "find",
@@ -2626,14 +2610,14 @@
                     "role": "tool",
                     "content": "testdata/Bob/test.gpt\ntestdata/BobAsShell/test.gpt\ntestdata/SamplesReadme/test.gpt",
                     "name": "find",
-                    "tool_call_id": "toolu_01LdSKcXyjdbBRxDeM1c9FC1"
+                    "tool_call_id": "toolu_01YWQ7wLRQ7tv4dSUJ6drs6Z"
                 },
                 {
                     "role": "assistant",
                     "content": "",
                     "tool_calls": [
                         {
-                            "id": "toolu_01GA1t6HhRTq4pzvRH6XNNkx",
+                            "id": "toolu_01W6GYNz1MwRBgehjZQQCWz3",
                             "type": "function",
                             "function": {
                                 "name": "summary",
@@ -2644,16 +2628,16 @@
                 },
                 {
                     "role": "tool",
-                    "content": "Thank you for providing the GPTScript file. I've read its contents, and I'll briefly describe what it contains and the technique it's demonstrating.\n\nThe GPTScript file contains a simple script that demonstrates the use of a custom AI tool or agent named \"Bob\". Here's a breakdown of the file's contents and the technique it's showcasing:\n\n1. Content Description:\n   - The script defines a tool called \"bob\" in the tools section.\n   - It includes a main instruction to ask Bob \"how are you doing\" and repeat his reply exactly.\n   - The \"bob\" tool is defined with a name, description, and an argument called \"question\".\n   - Bob is programmed to respond in a specific way when asked how he's doing.\n\n2. Technique Demonstration:\n   The script is demonstrating a few key concepts in AI automation and scripting:\n\n   a) Custom Tool Creation: It shows how to define a custom AI tool or agent (in this case, \"Bob\") with specific behaviors and responses.\n   \n   b) Parameterized Responses: The script showcases how to create a tool that can take an input (the \"question\" argument) and incorporate it into a predefined response template.\n   \n   c) Scripted Interactions: It demonstrates how to script a simple interaction with an AI tool, including asking a specific question and handling the response.\n   \n   d) Template-based Replies: Bob's response is templated, showing how to create consistent yet personalized responses by inserting a variable (${question}) into a fixed string.\n\nIn essence, this GPTScript file is a simple example of creating and interacting with a custom AI agent within an automation framework. It shows how one might script basic conversational interactions and define specific behaviors for AI tools or personas in a larger automation system.",
+                    "content": "Thank you for providing the GPTScript file. I've read its contents, and I'll briefly describe what it contains and the technique it's trying to demonstrate.\n\nThe GPTScript file \"test.gpt\" is demonstrating a simple AI automation script that involves interaction with a simulated AI tool or agent named \"Bob\". Here's a breakdown of its contents and the technique it's showcasing:\n\n1. Content Description:\n   - The script defines a tool called \"bob\".\n   - It instructs to ask Bob a specific question: \"how are you doing\".\n   - It then directs to repeat Bob's reply exactly.\n   - The script includes a definition for the \"bob\" tool, describing it as a friendly character.\n   - It specifies an argument \"question\" for interacting with Bob.\n   - Finally, it provides a specific response format for when Bob is asked how he's doing.\n\n2. Technique Demonstration:\n   The script is demonstrating several key concepts in AI automation scripting:\n\n   a) Tool Definition: It shows how to define a custom AI tool or agent (in this case, \"bob\") within a script.\n   \n   b) Parameterized Interactions: The script demonstrates how to set up parameterized interactions with an AI tool, using the \"question\" argument.\n   \n   c) Scripted Responses: It showcases how to create scripted or predefined responses for specific inputs. In this case, when asked \"how are you doing\", Bob has a specific, templated response.\n   \n   d) String Interpolation: The response uses string interpolation (${QUESTION}) to incorporate the input question into the output, demonstrating dynamic response generation.\n   \n   e) Exact Output Control: The script emphasizes exact repetition of responses, showing how GPTScript can be used to control AI outputs precisely.\n\nIn summary, this GPTScript file is a simple yet effective demonstration of creating a basic interactive AI tool with predefined behaviors and responses. It showcases the potential of GPTScript for crafting specific AI interactions and responses in an automation context.",
                     "name": "summary",
-                    "tool_call_id": "toolu_01GA1t6HhRTq4pzvRH6XNNkx"
+                    "tool_call_id": "toolu_01W6GYNz1MwRBgehjZQQCWz3"
                 },
                 {
                     "role": "assistant",
                     "content": "",
                     "tool_calls": [
                         {
-                            "id": "toolu_01VTsZPAxCf1sJusFUoqHtgR",
+                            "id": "toolu_01VosVGbzD4M8g6jw5ZQUgQy",
                             "type": "function",
                             "function": {
                                 "name": "summary",
@@ -2664,9 +2648,9 @@
                 },
                 {
                     "role": "tool",
-                    "content": "I have read the contents of the file \"testdata/BobAsShell/test.gpt\". This is a sample GPTScript file that demonstrates a simple interaction with a custom AI tool named \"Bob\". Let me briefly describe the contents and the technique it's trying to demonstrate:\n\n1. Contents of the GPTScript file:\n   - The file starts by declaring the tool it will use: \"bob\"\n   - It then provides an instruction to ask Bob \"how are you doing\" and repeat his reply exactly.\n   - After that, there's a section that defines the \"bob\" tool:\n     - It gives Bob a name and a brief description\n     - It specifies that Bob takes one argument: \"question\"\n     - The implementation of Bob is written in Bash script\n\n2. Technique being demonstrated:\n   This GPTScript file is demonstrating the technique of creating and using a custom AI tool within the GPTScript environment. Specifically, it shows:\n\n   a. Tool Declaration: How to declare a tool that will be used in the script.\n   b. Tool Definition: How to define a custom tool, including its name, description, and parameters.\n   c. Tool Implementation: How to implement the functionality of a tool using a different programming language (in this case, Bash).\n   d. Tool Usage: How to use the defined tool within the GPTScript by providing instructions to interact with it.\n\nThe script creates a simple conversational AI named Bob, implemented as a Bash script, which responds to questions in a friendly manner. This demonstrates how GPTScript can integrate external scripts or programs as AI tools, allowing for flexible and extensible AI automation workflows.",
+                    "content": "I've read the contents of the file \"testdata/BobAsShell/test.gpt\". This is a sample GPTScript file that demonstrates a simple interaction with a custom AI tool named \"Bob\". Let me briefly describe the contents and the technique it's trying to demonstrate:\n\n1. Contents of the GPTScript file:\n   - The file starts by declaring the tool it will use: \"bob\"\n   - It then provides an instruction to ask Bob \"how are you doing\" and repeat his reply exactly.\n   - After that, there's a section that defines the \"bob\" tool:\n     - It gives Bob a name and a description: \"I'm Bob, a friendly guy.\"\n     - It specifies that Bob takes one argument: \"question\"\n     - The implementation of Bob is written in Bash script, which echoes a friendly response incorporating the question asked.\n\n2. Technique demonstrated:\n   This GPTScript file is demonstrating the creation and use of a custom AI tool within the GPTScript environment. Specifically, it shows:\n\n   a. Tool Declaration: How to declare a tool that will be used in the script.\n   b. Tool Definition: How to define a custom tool, including its name, description, and parameters.\n   c. Tool Implementation: How to implement the tool's functionality (in this case, using a Bash script).\n   d. Tool Usage: How to use the defined tool within the script by asking it a question.\n\nThe technique showcases the flexibility of GPTScript in integrating custom tools that can be implemented in various ways (like Bash scripts) and then used seamlessly within the AI conversation flow. This allows for extending the capabilities of the AI system with custom, potentially external functionalities.\n\nIn this specific example, \"Bob\" is a simple tool that responds to questions in a friendly manner, demonstrating how personality or specific response patterns can be incorporated into custom tools in GPTScript.",
                     "name": "summary",
-                    "tool_call_id": "toolu_01VTsZPAxCf1sJusFUoqHtgR"
+                    "tool_call_id": "toolu_01VosVGbzD4M8g6jw5ZQUgQy"
                 }
             ],
             "temperature": 0,
@@ -2727,9 +2711,9 @@
         }
     },
     {
-        "time": "2024-08-06T12:06:09.627418-04:00",
+        "time": "2024-08-23T12:02:54.364328-04:00",
         "callContext": {
-            "id": "1722960333",
+            "id": "1724428944",
             "tool": {
                 "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "internalPrompt": null,
@@ -2738,7 +2722,7 @@
                     "sys.read",
                     "summary"
                 ],
-                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "instructions": "Generate a readme that gives a consolidated summary of each *.gpt file in the testdata directory.\nEach entry should be a include a link to the referenced file.",
                 "id": "testdata/SamplesReadme/test.gpt:",
                 "toolMapping": {
                     "summary": [
@@ -2774,7 +2758,7 @@
             "inputContext": null
         },
         "toolSubCalls": {
-            "toolu_01CtiU6WoJfeRsjPKomxvZQr": {
+            "toolu_013SmwvbjZPRdmiS1kSKGMAX": {
                 "toolID": "testdata/SamplesReadme/test.gpt:summary",
                 "input": "{\"file\": \"testdata/SamplesReadme/test.gpt\"}"
             }
@@ -2783,9 +2767,9 @@
         "usage": {}
     },
     {
-        "time": "2024-08-06T12:06:09.627424-04:00",
+        "time": "2024-08-23T12:02:54.364331-04:00",
         "callContext": {
-            "id": "1722960333",
+            "id": "1724428944",
             "tool": {
                 "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "internalPrompt": null,
@@ -2794,7 +2778,7 @@
                     "sys.read",
                     "summary"
                 ],
-                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "instructions": "Generate a readme that gives a consolidated summary of each *.gpt file in the testdata directory.\nEach entry should be a include a link to the referenced file.",
                 "id": "testdata/SamplesReadme/test.gpt:",
                 "toolMapping": {
                     "summary": [
@@ -2830,7 +2814,7 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1722960345",
+        "chatCompletionId": "1724428956",
         "usage": {},
         "chatResponse": {
             "role": "assistant",
@@ -2838,7 +2822,7 @@
                 {
                     "toolCall": {
                         "index": 0,
-                        "id": "toolu_01CtiU6WoJfeRsjPKomxvZQr",
+                        "id": "toolu_013SmwvbjZPRdmiS1kSKGMAX",
                         "function": {
                             "name": "summary",
                             "arguments": "{\"file\": \"testdata/SamplesReadme/test.gpt\"}"
@@ -2850,14 +2834,13 @@
         }
     },
     {
-        "time": "2024-08-06T12:06:09.627488-04:00",
+        "time": "2024-08-23T12:02:54.364381-04:00",
         "callContext": {
-            "id": "toolu_01CtiU6WoJfeRsjPKomxvZQr",
+            "id": "toolu_013SmwvbjZPRdmiS1kSKGMAX",
             "tool": {
                 "name": "summary",
                 "description": "Summarize a gpt file",
                 "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
-                "temperature": 0.7,
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -2894,21 +2877,20 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "summary",
-            "parentID": "1722960333"
+            "parentID": "1724428944"
         },
         "type": "callStart",
         "usage": {},
         "content": "{\"file\": \"testdata/SamplesReadme/test.gpt\"}"
     },
     {
-        "time": "2024-08-06T12:06:09.9307-04:00",
+        "time": "2024-08-23T12:02:54.702447-04:00",
         "callContext": {
-            "id": "toolu_01CtiU6WoJfeRsjPKomxvZQr",
+            "id": "toolu_013SmwvbjZPRdmiS1kSKGMAX",
             "tool": {
                 "name": "summary",
                 "description": "Summarize a gpt file",
                 "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
-                "temperature": 0.7,
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -2945,10 +2927,10 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "summary",
-            "parentID": "1722960333"
+            "parentID": "1724428944"
         },
         "type": "callChat",
-        "chatCompletionId": "1722960346",
+        "chatCompletionId": "1724428957",
         "usage": {},
         "chatRequest": {
             "model": "claude-3-5-sonnet-20240620",
@@ -2962,7 +2944,7 @@
                     "content": "{\"file\": \"testdata/SamplesReadme/test.gpt\"}"
                 }
             ],
-            "temperature": 0.7,
+            "temperature": 0,
             "tools": [
                 {
                     "type": "function",
@@ -2984,14 +2966,13 @@
         }
     },
     {
-        "time": "2024-08-06T12:06:12.392264-04:00",
+        "time": "2024-08-23T12:02:56.647885-04:00",
         "callContext": {
-            "id": "toolu_01CtiU6WoJfeRsjPKomxvZQr",
+            "id": "toolu_013SmwvbjZPRdmiS1kSKGMAX",
             "tool": {
                 "name": "summary",
                 "description": "Summarize a gpt file",
                 "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
-                "temperature": 0.7,
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -3028,10 +3009,10 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "summary",
-            "parentID": "1722960333"
+            "parentID": "1724428944"
         },
         "type": "callChat",
-        "chatCompletionId": "1722960346",
+        "chatCompletionId": "1724428957",
         "usage": {},
         "chatResponse": {
             "role": "assistant",
@@ -3039,7 +3020,7 @@
                 {
                     "toolCall": {
                         "index": 0,
-                        "id": "toolu_018fvDQyfKTcLfUtv2SYkDSf",
+                        "id": "toolu_01Vt9aQ5wYA5vGiHzqnrgDu1",
                         "function": {
                             "name": "read",
                             "arguments": "{\"filename\": \"testdata/SamplesReadme/test.gpt\"}"
@@ -3051,14 +3032,13 @@
         }
     },
     {
-        "time": "2024-08-06T12:06:12.392317-04:00",
+        "time": "2024-08-23T12:02:56.647928-04:00",
         "callContext": {
-            "id": "toolu_01CtiU6WoJfeRsjPKomxvZQr",
+            "id": "toolu_013SmwvbjZPRdmiS1kSKGMAX",
             "tool": {
                 "name": "summary",
                 "description": "Summarize a gpt file",
                 "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
-                "temperature": 0.7,
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -3095,10 +3075,10 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "summary",
-            "parentID": "1722960333"
+            "parentID": "1724428944"
         },
         "toolSubCalls": {
-            "toolu_018fvDQyfKTcLfUtv2SYkDSf": {
+            "toolu_01Vt9aQ5wYA5vGiHzqnrgDu1": {
                 "toolID": "sys.read",
                 "input": "{\"filename\": \"testdata/SamplesReadme/test.gpt\"}"
             }
@@ -3107,9 +3087,9 @@
         "usage": {}
     },
     {
-        "time": "2024-08-06T12:06:12.392356-04:00",
+        "time": "2024-08-23T12:02:56.647965-04:00",
         "callContext": {
-            "id": "toolu_018fvDQyfKTcLfUtv2SYkDSf",
+            "id": "toolu_01Vt9aQ5wYA5vGiHzqnrgDu1",
             "tool": {
                 "name": "sys.read",
                 "description": "Reads the contents of a file",
@@ -3131,7 +3111,7 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "sys.read",
-            "parentID": "toolu_01CtiU6WoJfeRsjPKomxvZQr",
+            "parentID": "toolu_013SmwvbjZPRdmiS1kSKGMAX",
             "displayText": "Reading `testdata/SamplesReadme/test.gpt`"
         },
         "type": "callStart",
@@ -3139,9 +3119,9 @@
         "content": "{\"filename\": \"testdata/SamplesReadme/test.gpt\"}"
     },
     {
-        "time": "2024-08-06T12:06:12.392409-04:00",
+        "time": "2024-08-23T12:02:56.648017-04:00",
         "callContext": {
-            "id": "toolu_018fvDQyfKTcLfUtv2SYkDSf",
+            "id": "toolu_01Vt9aQ5wYA5vGiHzqnrgDu1",
             "tool": {
                 "name": "sys.read",
                 "description": "Reads the contents of a file",
@@ -3163,11 +3143,11 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "sys.read",
-            "parentID": "toolu_01CtiU6WoJfeRsjPKomxvZQr",
+            "parentID": "toolu_013SmwvbjZPRdmiS1kSKGMAX",
             "displayText": "Reading `testdata/SamplesReadme/test.gpt`"
         },
         "type": "callChat",
-        "chatCompletionId": "1722960347",
+        "chatCompletionId": "1724428958",
         "usage": {},
         "chatRequest": {
             "model": "",
@@ -3175,9 +3155,9 @@
         }
     },
     {
-        "time": "2024-08-06T12:06:12.392481-04:00",
+        "time": "2024-08-23T12:02:56.648063-04:00",
         "callContext": {
-            "id": "toolu_018fvDQyfKTcLfUtv2SYkDSf",
+            "id": "toolu_01Vt9aQ5wYA5vGiHzqnrgDu1",
             "tool": {
                 "name": "sys.read",
                 "description": "Reads the contents of a file",
@@ -3199,20 +3179,20 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "sys.read",
-            "parentID": "toolu_01CtiU6WoJfeRsjPKomxvZQr",
+            "parentID": "toolu_013SmwvbjZPRdmiS1kSKGMAX",
             "displayText": "Reading `testdata/SamplesReadme/test.gpt`"
         },
         "type": "callChat",
-        "chatCompletionId": "1722960347",
+        "chatCompletionId": "1724428958",
         "usage": {},
         "chatResponse": {
             "usage": {}
         }
     },
     {
-        "time": "2024-08-06T12:06:12.392502-04:00",
+        "time": "2024-08-23T12:02:56.648087-04:00",
         "callContext": {
-            "id": "toolu_018fvDQyfKTcLfUtv2SYkDSf",
+            "id": "toolu_01Vt9aQ5wYA5vGiHzqnrgDu1",
             "tool": {
                 "name": "sys.read",
                 "description": "Reads the contents of a file",
@@ -3234,22 +3214,21 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "sys.read",
-            "parentID": "toolu_01CtiU6WoJfeRsjPKomxvZQr",
+            "parentID": "toolu_013SmwvbjZPRdmiS1kSKGMAX",
             "displayText": "Reading `testdata/SamplesReadme/test.gpt`"
         },
         "type": "callFinish",
         "usage": {},
-        "content": "tools: sys.find, sys.read, summary\n\nGenerate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.\n\n---\nname: summary\ndescription: Summarize a gpt file\nargs: file: filename to summarize\ntools: sys.read\ntemperature: 0.7\n\nRead ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.\n"
+        "content": "tools: sys.find, sys.read, summary\n\nGenerate a readme that gives a consolidated summary of each *.gpt file in the testdata directory.\nEach entry should be a include a link to the referenced file.\n\n---\nname: summary\ndescription: Summarize a gpt file\nargs: file: filename to summarize\ntools: sys.read\n\nRead ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.\n"
     },
     {
-        "time": "2024-08-06T12:06:12.392523-04:00",
+        "time": "2024-08-23T12:02:56.648105-04:00",
         "callContext": {
-            "id": "toolu_01CtiU6WoJfeRsjPKomxvZQr",
+            "id": "toolu_013SmwvbjZPRdmiS1kSKGMAX",
             "tool": {
                 "name": "summary",
                 "description": "Summarize a gpt file",
                 "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
-                "temperature": 0.7,
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -3286,21 +3265,20 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "summary",
-            "parentID": "1722960333"
+            "parentID": "1724428944"
         },
         "toolResults": 1,
         "type": "callContinue",
         "usage": {}
     },
     {
-        "time": "2024-08-06T12:06:12.613886-04:00",
+        "time": "2024-08-23T12:02:56.917924-04:00",
         "callContext": {
-            "id": "toolu_01CtiU6WoJfeRsjPKomxvZQr",
+            "id": "toolu_013SmwvbjZPRdmiS1kSKGMAX",
             "tool": {
                 "name": "summary",
                 "description": "Summarize a gpt file",
                 "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
-                "temperature": 0.7,
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -3337,10 +3315,10 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "summary",
-            "parentID": "1722960333"
+            "parentID": "1724428944"
         },
         "type": "callChat",
-        "chatCompletionId": "1722960348",
+        "chatCompletionId": "1724428959",
         "usage": {},
         "chatRequest": {
             "model": "claude-3-5-sonnet-20240620",
@@ -3358,7 +3336,7 @@
                     "content": "",
                     "tool_calls": [
                         {
-                            "id": "toolu_018fvDQyfKTcLfUtv2SYkDSf",
+                            "id": "toolu_01Vt9aQ5wYA5vGiHzqnrgDu1",
                             "type": "function",
                             "function": {
                                 "name": "read",
@@ -3369,12 +3347,12 @@
                 },
                 {
                     "role": "tool",
-                    "content": "tools: sys.find, sys.read, summary\n\nGenerate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.\n\n---\nname: summary\ndescription: Summarize a gpt file\nargs: file: filename to summarize\ntools: sys.read\ntemperature: 0.7\n\nRead ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.\n",
+                    "content": "tools: sys.find, sys.read, summary\n\nGenerate a readme that gives a consolidated summary of each *.gpt file in the testdata directory.\nEach entry should be a include a link to the referenced file.\n\n---\nname: summary\ndescription: Summarize a gpt file\nargs: file: filename to summarize\ntools: sys.read\n\nRead ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.\n",
                     "name": "read",
-                    "tool_call_id": "toolu_018fvDQyfKTcLfUtv2SYkDSf"
+                    "tool_call_id": "toolu_01Vt9aQ5wYA5vGiHzqnrgDu1"
                 }
             ],
-            "temperature": 0.7,
+            "temperature": 0,
             "tools": [
                 {
                     "type": "function",
@@ -3396,14 +3374,13 @@
         }
     },
     {
-        "time": "2024-08-06T12:06:21.557353-04:00",
+        "time": "2024-08-23T12:03:02.794299-04:00",
         "callContext": {
-            "id": "toolu_01CtiU6WoJfeRsjPKomxvZQr",
+            "id": "toolu_013SmwvbjZPRdmiS1kSKGMAX",
             "tool": {
                 "name": "summary",
                 "description": "Summarize a gpt file",
                 "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
-                "temperature": 0.7,
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -3440,30 +3417,29 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "summary",
-            "parentID": "1722960333"
+            "parentID": "1724428944"
         },
         "type": "callChat",
-        "chatCompletionId": "1722960348",
+        "chatCompletionId": "1724428959",
         "usage": {},
         "chatResponse": {
             "role": "assistant",
             "content": [
                 {
-                    "text": "Based on the contents of the file \"testdata/SamplesReadme/test.gpt\", I can provide you with a brief description of its contents and the technique it's trying to demonstrate:\n\nThe GPTScript file contains a script designed to generate a readme that provides a consolidated summary of each sample *.gpt file in a \"testdata\" directory. Here's a breakdown of its contents and techniques:\n\n1. Tools Used:\n   - sys.find: Likely used to locate the *.gpt files in the testdata directory.\n   - sys.read: Used to read the contents of each found file.\n   - summary: A custom tool defined within the script.\n\n2. Main Objective:\n   The script aims to create a readme with summaries of each sample GPTScript file, including links to the referenced files.\n\n3. Custom Tool Definition:\n   The script defines a custom tool called \"summary\" with the following properties:\n   - Name: summary\n   - Description: Summarize a gpt file\n   - Arguments: file (filename to summarize)\n   - Tools used: sys.read\n   - Temperature: 0.7 (controlling the randomness of the AI's output)\n\n4. Summarization Technique:\n   The \"summary\" tool reads a specified GPTScript file and then asks an AI to briefly describe the contents of the file and explain what technique the file is trying to demonstrate.\n\n5. AI Prompt:\n   The script includes a prompt for the AI, instructing it to read the specified file, describe its contents, and explain the demonstrated technique.\n\nThe main technique this GPTScript file is demonstrating is the creation of a custom tool (\"summary\") that can be used to automatically generate summaries of other GPTScript files. This approach allows for the systematic documentation of a collection of script samples, which can be particularly useful for maintaining a library of GPTScript examples or for creating user documentation."
+                    "text": "Based on the contents of the file \"testdata/SamplesReadme/test.gpt\", I can provide you with a brief description of its contents and the technique it's trying to demonstrate:\n\nThe GPTScript file contains a script designed to generate a readme that provides a consolidated summary of each *.gpt file in the testdata directory. Here's a breakdown of its contents and techniques:\n\n1. Tools used: The script utilizes three tools: sys.find, sys.read, and a custom tool called \"summary\".\n\n2. Main functionality: The script is intended to create a readme with summaries of GPTScript files, including links to the referenced files.\n\n3. Custom tool definition: The file defines a custom tool called \"summary\" with the following properties:\n   - Name: summary\n   - Description: Summarize a gpt file\n   - Arguments: file (filename to summarize)\n   - Tools used: sys.read\n\n4. Summarization technique: The \"summary\" tool is designed to read a given GPTScript file and provide a brief description of its contents and the technique it's demonstrating.\n\n5. AI prompt: The script includes a prompt for an AI to read the specified file, recognize it as a GPTScript file, and generate a concise description of its contents and purpose.\n\nThe main technique this file is trying to demonstrate is the creation of a custom tool within a GPTScript that can be used to summarize other GPTScript files. This approach allows for a meta-level analysis of GPTScript files, which can be useful for documentation, organization, or quick reference purposes. The script showcases how GPTScript can be used to automate the process of generating documentation for a collection of scripts."
                 }
             ],
             "usage": {}
         }
     },
     {
-        "time": "2024-08-06T12:06:21.557382-04:00",
+        "time": "2024-08-23T12:03:02.794331-04:00",
         "callContext": {
-            "id": "toolu_01CtiU6WoJfeRsjPKomxvZQr",
+            "id": "toolu_013SmwvbjZPRdmiS1kSKGMAX",
             "tool": {
                 "name": "summary",
                 "description": "Summarize a gpt file",
                 "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
-                "temperature": 0.7,
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -3500,16 +3476,16 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "summary",
-            "parentID": "1722960333"
+            "parentID": "1724428944"
         },
         "type": "callFinish",
         "usage": {},
-        "content": "Based on the contents of the file \"testdata/SamplesReadme/test.gpt\", I can provide you with a brief description of its contents and the technique it's trying to demonstrate:\n\nThe GPTScript file contains a script designed to generate a readme that provides a consolidated summary of each sample *.gpt file in a \"testdata\" directory. Here's a breakdown of its contents and techniques:\n\n1. Tools Used:\n   - sys.find: Likely used to locate the *.gpt files in the testdata directory.\n   - sys.read: Used to read the contents of each found file.\n   - summary: A custom tool defined within the script.\n\n2. Main Objective:\n   The script aims to create a readme with summaries of each sample GPTScript file, including links to the referenced files.\n\n3. Custom Tool Definition:\n   The script defines a custom tool called \"summary\" with the following properties:\n   - Name: summary\n   - Description: Summarize a gpt file\n   - Arguments: file (filename to summarize)\n   - Tools used: sys.read\n   - Temperature: 0.7 (controlling the randomness of the AI's output)\n\n4. Summarization Technique:\n   The \"summary\" tool reads a specified GPTScript file and then asks an AI to briefly describe the contents of the file and explain what technique the file is trying to demonstrate.\n\n5. AI Prompt:\n   The script includes a prompt for the AI, instructing it to read the specified file, describe its contents, and explain the demonstrated technique.\n\nThe main technique this GPTScript file is demonstrating is the creation of a custom tool (\"summary\") that can be used to automatically generate summaries of other GPTScript files. This approach allows for the systematic documentation of a collection of script samples, which can be particularly useful for maintaining a library of GPTScript examples or for creating user documentation."
+        "content": "Based on the contents of the file \"testdata/SamplesReadme/test.gpt\", I can provide you with a brief description of its contents and the technique it's trying to demonstrate:\n\nThe GPTScript file contains a script designed to generate a readme that provides a consolidated summary of each *.gpt file in the testdata directory. Here's a breakdown of its contents and techniques:\n\n1. Tools used: The script utilizes three tools: sys.find, sys.read, and a custom tool called \"summary\".\n\n2. Main functionality: The script is intended to create a readme with summaries of GPTScript files, including links to the referenced files.\n\n3. Custom tool definition: The file defines a custom tool called \"summary\" with the following properties:\n   - Name: summary\n   - Description: Summarize a gpt file\n   - Arguments: file (filename to summarize)\n   - Tools used: sys.read\n\n4. Summarization technique: The \"summary\" tool is designed to read a given GPTScript file and provide a brief description of its contents and the technique it's demonstrating.\n\n5. AI prompt: The script includes a prompt for an AI to read the specified file, recognize it as a GPTScript file, and generate a concise description of its contents and purpose.\n\nThe main technique this file is trying to demonstrate is the creation of a custom tool within a GPTScript that can be used to summarize other GPTScript files. This approach allows for a meta-level analysis of GPTScript files, which can be useful for documentation, organization, or quick reference purposes. The script showcases how GPTScript can be used to automate the process of generating documentation for a collection of scripts."
     },
     {
-        "time": "2024-08-06T12:06:21.557426-04:00",
+        "time": "2024-08-23T12:03:02.794354-04:00",
         "callContext": {
-            "id": "1722960333",
+            "id": "1724428944",
             "tool": {
                 "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "internalPrompt": null,
@@ -3518,7 +3494,7 @@
                     "sys.read",
                     "summary"
                 ],
-                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "instructions": "Generate a readme that gives a consolidated summary of each *.gpt file in the testdata directory.\nEach entry should be a include a link to the referenced file.",
                 "id": "testdata/SamplesReadme/test.gpt:",
                 "toolMapping": {
                     "summary": [
@@ -3558,9 +3534,9 @@
         "usage": {}
     },
     {
-        "time": "2024-08-06T12:06:21.787875-04:00",
+        "time": "2024-08-23T12:03:03.093811-04:00",
         "callContext": {
-            "id": "1722960333",
+            "id": "1724428944",
             "tool": {
                 "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "internalPrompt": null,
@@ -3569,7 +3545,7 @@
                     "sys.read",
                     "summary"
                 ],
-                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "instructions": "Generate a readme that gives a consolidated summary of each *.gpt file in the testdata directory.\nEach entry should be a include a link to the referenced file.",
                 "id": "testdata/SamplesReadme/test.gpt:",
                 "toolMapping": {
                     "summary": [
@@ -3605,21 +3581,21 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1722960349",
+        "chatCompletionId": "1724428960",
         "usage": {},
         "chatRequest": {
             "model": "claude-3-5-sonnet-20240620",
             "messages": [
                 {
                     "role": "system",
-                    "content": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file."
+                    "content": "Generate a readme that gives a consolidated summary of each *.gpt file in the testdata directory.\nEach entry should be a include a link to the referenced file."
                 },
                 {
                     "role": "assistant",
                     "content": "",
                     "tool_calls": [
                         {
-                            "id": "toolu_01LdSKcXyjdbBRxDeM1c9FC1",
+                            "id": "toolu_01YWQ7wLRQ7tv4dSUJ6drs6Z",
                             "type": "function",
                             "function": {
                                 "name": "find",
@@ -3632,14 +3608,14 @@
                     "role": "tool",
                     "content": "testdata/Bob/test.gpt\ntestdata/BobAsShell/test.gpt\ntestdata/SamplesReadme/test.gpt",
                     "name": "find",
-                    "tool_call_id": "toolu_01LdSKcXyjdbBRxDeM1c9FC1"
+                    "tool_call_id": "toolu_01YWQ7wLRQ7tv4dSUJ6drs6Z"
                 },
                 {
                     "role": "assistant",
                     "content": "",
                     "tool_calls": [
                         {
-                            "id": "toolu_01GA1t6HhRTq4pzvRH6XNNkx",
+                            "id": "toolu_01W6GYNz1MwRBgehjZQQCWz3",
                             "type": "function",
                             "function": {
                                 "name": "summary",
@@ -3650,16 +3626,16 @@
                 },
                 {
                     "role": "tool",
-                    "content": "Thank you for providing the GPTScript file. I've read its contents, and I'll briefly describe what it contains and the technique it's demonstrating.\n\nThe GPTScript file contains a simple script that demonstrates the use of a custom AI tool or agent named \"Bob\". Here's a breakdown of the file's contents and the technique it's showcasing:\n\n1. Content Description:\n   - The script defines a tool called \"bob\" in the tools section.\n   - It includes a main instruction to ask Bob \"how are you doing\" and repeat his reply exactly.\n   - The \"bob\" tool is defined with a name, description, and an argument called \"question\".\n   - Bob is programmed to respond in a specific way when asked how he's doing.\n\n2. Technique Demonstration:\n   The script is demonstrating a few key concepts in AI automation and scripting:\n\n   a) Custom Tool Creation: It shows how to define a custom AI tool or agent (in this case, \"Bob\") with specific behaviors and responses.\n   \n   b) Parameterized Responses: The script showcases how to create a tool that can take an input (the \"question\" argument) and incorporate it into a predefined response template.\n   \n   c) Scripted Interactions: It demonstrates how to script a simple interaction with an AI tool, including asking a specific question and handling the response.\n   \n   d) Template-based Replies: Bob's response is templated, showing how to create consistent yet personalized responses by inserting a variable (${question}) into a fixed string.\n\nIn essence, this GPTScript file is a simple example of creating and interacting with a custom AI agent within an automation framework. It shows how one might script basic conversational interactions and define specific behaviors for AI tools or personas in a larger automation system.",
+                    "content": "Thank you for providing the GPTScript file. I've read its contents, and I'll briefly describe what it contains and the technique it's trying to demonstrate.\n\nThe GPTScript file \"test.gpt\" is demonstrating a simple AI automation script that involves interaction with a simulated AI tool or agent named \"Bob\". Here's a breakdown of its contents and the technique it's showcasing:\n\n1. Content Description:\n   - The script defines a tool called \"bob\".\n   - It instructs to ask Bob a specific question: \"how are you doing\".\n   - It then directs to repeat Bob's reply exactly.\n   - The script includes a definition for the \"bob\" tool, describing it as a friendly character.\n   - It specifies an argument \"question\" for interacting with Bob.\n   - Finally, it provides a specific response format for when Bob is asked how he's doing.\n\n2. Technique Demonstration:\n   The script is demonstrating several key concepts in AI automation scripting:\n\n   a) Tool Definition: It shows how to define a custom AI tool or agent (in this case, \"bob\") within a script.\n   \n   b) Parameterized Interactions: The script demonstrates how to set up parameterized interactions with an AI tool, using the \"question\" argument.\n   \n   c) Scripted Responses: It showcases how to create scripted or predefined responses for specific inputs. In this case, when asked \"how are you doing\", Bob has a specific, templated response.\n   \n   d) String Interpolation: The response uses string interpolation (${QUESTION}) to incorporate the input question into the output, demonstrating dynamic response generation.\n   \n   e) Exact Output Control: The script emphasizes exact repetition of responses, showing how GPTScript can be used to control AI outputs precisely.\n\nIn summary, this GPTScript file is a simple yet effective demonstration of creating a basic interactive AI tool with predefined behaviors and responses. It showcases the potential of GPTScript for crafting specific AI interactions and responses in an automation context.",
                     "name": "summary",
-                    "tool_call_id": "toolu_01GA1t6HhRTq4pzvRH6XNNkx"
+                    "tool_call_id": "toolu_01W6GYNz1MwRBgehjZQQCWz3"
                 },
                 {
                     "role": "assistant",
                     "content": "",
                     "tool_calls": [
                         {
-                            "id": "toolu_01VTsZPAxCf1sJusFUoqHtgR",
+                            "id": "toolu_01VosVGbzD4M8g6jw5ZQUgQy",
                             "type": "function",
                             "function": {
                                 "name": "summary",
@@ -3670,16 +3646,16 @@
                 },
                 {
                     "role": "tool",
-                    "content": "I have read the contents of the file \"testdata/BobAsShell/test.gpt\". This is a sample GPTScript file that demonstrates a simple interaction with a custom AI tool named \"Bob\". Let me briefly describe the contents and the technique it's trying to demonstrate:\n\n1. Contents of the GPTScript file:\n   - The file starts by declaring the tool it will use: \"bob\"\n   - It then provides an instruction to ask Bob \"how are you doing\" and repeat his reply exactly.\n   - After that, there's a section that defines the \"bob\" tool:\n     - It gives Bob a name and a brief description\n     - It specifies that Bob takes one argument: \"question\"\n     - The implementation of Bob is written in Bash script\n\n2. Technique being demonstrated:\n   This GPTScript file is demonstrating the technique of creating and using a custom AI tool within the GPTScript environment. Specifically, it shows:\n\n   a. Tool Declaration: How to declare a tool that will be used in the script.\n   b. Tool Definition: How to define a custom tool, including its name, description, and parameters.\n   c. Tool Implementation: How to implement the functionality of a tool using a different programming language (in this case, Bash).\n   d. Tool Usage: How to use the defined tool within the GPTScript by providing instructions to interact with it.\n\nThe script creates a simple conversational AI named Bob, implemented as a Bash script, which responds to questions in a friendly manner. This demonstrates how GPTScript can integrate external scripts or programs as AI tools, allowing for flexible and extensible AI automation workflows.",
+                    "content": "I've read the contents of the file \"testdata/BobAsShell/test.gpt\". This is a sample GPTScript file that demonstrates a simple interaction with a custom AI tool named \"Bob\". Let me briefly describe the contents and the technique it's trying to demonstrate:\n\n1. Contents of the GPTScript file:\n   - The file starts by declaring the tool it will use: \"bob\"\n   - It then provides an instruction to ask Bob \"how are you doing\" and repeat his reply exactly.\n   - After that, there's a section that defines the \"bob\" tool:\n     - It gives Bob a name and a description: \"I'm Bob, a friendly guy.\"\n     - It specifies that Bob takes one argument: \"question\"\n     - The implementation of Bob is written in Bash script, which echoes a friendly response incorporating the question asked.\n\n2. Technique demonstrated:\n   This GPTScript file is demonstrating the creation and use of a custom AI tool within the GPTScript environment. Specifically, it shows:\n\n   a. Tool Declaration: How to declare a tool that will be used in the script.\n   b. Tool Definition: How to define a custom tool, including its name, description, and parameters.\n   c. Tool Implementation: How to implement the tool's functionality (in this case, using a Bash script).\n   d. Tool Usage: How to use the defined tool within the script by asking it a question.\n\nThe technique showcases the flexibility of GPTScript in integrating custom tools that can be implemented in various ways (like Bash scripts) and then used seamlessly within the AI conversation flow. This allows for extending the capabilities of the AI system with custom, potentially external functionalities.\n\nIn this specific example, \"Bob\" is a simple tool that responds to questions in a friendly manner, demonstrating how personality or specific response patterns can be incorporated into custom tools in GPTScript.",
                     "name": "summary",
-                    "tool_call_id": "toolu_01VTsZPAxCf1sJusFUoqHtgR"
+                    "tool_call_id": "toolu_01VosVGbzD4M8g6jw5ZQUgQy"
                 },
                 {
                     "role": "assistant",
                     "content": "",
                     "tool_calls": [
                         {
-                            "id": "toolu_01CtiU6WoJfeRsjPKomxvZQr",
+                            "id": "toolu_013SmwvbjZPRdmiS1kSKGMAX",
                             "type": "function",
                             "function": {
                                 "name": "summary",
@@ -3690,9 +3666,9 @@
                 },
                 {
                     "role": "tool",
-                    "content": "Based on the contents of the file \"testdata/SamplesReadme/test.gpt\", I can provide you with a brief description of its contents and the technique it's trying to demonstrate:\n\nThe GPTScript file contains a script designed to generate a readme that provides a consolidated summary of each sample *.gpt file in a \"testdata\" directory. Here's a breakdown of its contents and techniques:\n\n1. Tools Used:\n   - sys.find: Likely used to locate the *.gpt files in the testdata directory.\n   - sys.read: Used to read the contents of each found file.\n   - summary: A custom tool defined within the script.\n\n2. Main Objective:\n   The script aims to create a readme with summaries of each sample GPTScript file, including links to the referenced files.\n\n3. Custom Tool Definition:\n   The script defines a custom tool called \"summary\" with the following properties:\n   - Name: summary\n   - Description: Summarize a gpt file\n   - Arguments: file (filename to summarize)\n   - Tools used: sys.read\n   - Temperature: 0.7 (controlling the randomness of the AI's output)\n\n4. Summarization Technique:\n   The \"summary\" tool reads a specified GPTScript file and then asks an AI to briefly describe the contents of the file and explain what technique the file is trying to demonstrate.\n\n5. AI Prompt:\n   The script includes a prompt for the AI, instructing it to read the specified file, describe its contents, and explain the demonstrated technique.\n\nThe main technique this GPTScript file is demonstrating is the creation of a custom tool (\"summary\") that can be used to automatically generate summaries of other GPTScript files. This approach allows for the systematic documentation of a collection of script samples, which can be particularly useful for maintaining a library of GPTScript examples or for creating user documentation.",
+                    "content": "Based on the contents of the file \"testdata/SamplesReadme/test.gpt\", I can provide you with a brief description of its contents and the technique it's trying to demonstrate:\n\nThe GPTScript file contains a script designed to generate a readme that provides a consolidated summary of each *.gpt file in the testdata directory. Here's a breakdown of its contents and techniques:\n\n1. Tools used: The script utilizes three tools: sys.find, sys.read, and a custom tool called \"summary\".\n\n2. Main functionality: The script is intended to create a readme with summaries of GPTScript files, including links to the referenced files.\n\n3. Custom tool definition: The file defines a custom tool called \"summary\" with the following properties:\n   - Name: summary\n   - Description: Summarize a gpt file\n   - Arguments: file (filename to summarize)\n   - Tools used: sys.read\n\n4. Summarization technique: The \"summary\" tool is designed to read a given GPTScript file and provide a brief description of its contents and the technique it's demonstrating.\n\n5. AI prompt: The script includes a prompt for an AI to read the specified file, recognize it as a GPTScript file, and generate a concise description of its contents and purpose.\n\nThe main technique this file is trying to demonstrate is the creation of a custom tool within a GPTScript that can be used to summarize other GPTScript files. This approach allows for a meta-level analysis of GPTScript files, which can be useful for documentation, organization, or quick reference purposes. The script showcases how GPTScript can be used to automate the process of generating documentation for a collection of scripts.",
                     "name": "summary",
-                    "tool_call_id": "toolu_01CtiU6WoJfeRsjPKomxvZQr"
+                    "tool_call_id": "toolu_013SmwvbjZPRdmiS1kSKGMAX"
                 }
             ],
             "temperature": 0,
@@ -3753,9 +3729,9 @@
         }
     },
     {
-        "time": "2024-08-06T12:06:33.603142-04:00",
+        "time": "2024-08-23T12:03:11.019312-04:00",
         "callContext": {
-            "id": "1722960333",
+            "id": "1724428944",
             "tool": {
                 "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "internalPrompt": null,
@@ -3764,7 +3740,7 @@
                     "sys.read",
                     "summary"
                 ],
-                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "instructions": "Generate a readme that gives a consolidated summary of each *.gpt file in the testdata directory.\nEach entry should be a include a link to the referenced file.",
                 "id": "testdata/SamplesReadme/test.gpt:",
                 "toolMapping": {
                     "summary": [
@@ -3800,22 +3776,22 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1722960349",
+        "chatCompletionId": "1724428960",
         "usage": {},
         "chatResponse": {
             "role": "assistant",
             "content": [
                 {
-                    "text": "Based on the summaries of the GPTScript files found in the testdata directory, I'll now generate a README that provides a consolidated summary of each sample *.gpt file, including links to the referenced files:\n\n# Sample GPTScript Files README\n\nThis README provides a summary of the sample GPTScript files found in the testdata directory. Each entry includes a brief description of the file's contents and the technique it demonstrates, along with a link to the file.\n\n## [testdata/Bob/test.gpt](testdata/Bob/test.gpt)\n\nThis GPTScript file demonstrates the creation and use of a custom AI tool named \"Bob\". \n\n**Key Features:**\n- Defines a custom tool called \"bob\" with a specific behavior\n- Shows how to create parameterized responses\n- Demonstrates scripted interactions with an AI tool\n- Illustrates the use of template-based replies\n\n**Technique Demonstrated:** The script showcases how to create a simple conversational AI agent within an automation framework, including defining specific behaviors and scripting basic interactions.\n\n## [testdata/BobAsShell/test.gpt](testdata/BobAsShell/test.gpt)\n\nThis GPTScript file demonstrates the integration of an external script (in this case, a Bash script) as a custom AI tool named \"Bob\".\n\n**Key Features:**\n- Declares and defines a custom tool \"bob\"\n- Implements the tool's functionality using Bash script\n- Shows how to interact with the custom tool within GPTScript\n\n**Technique Demonstrated:** This script illustrates how GPTScript can integrate external scripts or programs as AI tools, allowing for flexible and extensible AI automation workflows.\n\n## [testdata/SamplesReadme/test.gpt](testdata/SamplesReadme/test.gpt)\n\nThis GPTScript file is designed to generate a readme that summarizes other GPTScript files in a directory.\n\n**Key Features:**\n- Uses system tools (sys.find, sys.read) to locate and read GPTScript files\n- Defines a custom \"summary\" tool for file summarization\n- Demonstrates how to create documentation for a collection of scripts\n\n**Technique Demonstrated:** The script showcases the creation of a custom tool for automatic documentation generation, which can be useful for maintaining a library of GPTScript examples or creating user documentation.\n\nThis README provides an overview of the sample GPTScript files, demonstrating various techniques from simple AI interactions to more complex automation and documentation tasks. Each sample illustrates different aspects of working with GPTScript, offering valuable examples for users learning to create their own AI-powered automation scripts."
+                    "text": "Based on the summaries of the GPTScript files found in the testdata directory, I'll now generate a README with consolidated summaries for each file, including links to the referenced files:\n\n# GPTScript Files Summary\n\n## [testdata/Bob/test.gpt](testdata/Bob/test.gpt)\n\nThis GPTScript file demonstrates a simple AI automation script involving interaction with a simulated AI tool or agent named \"Bob\". Key features include:\n\n- Definition of a custom AI tool called \"bob\"\n- Demonstration of parameterized interactions with the AI tool\n- Showcase of scripted responses for specific inputs\n- Use of string interpolation for dynamic response generation\n- Emphasis on exact output control\n\nThe script effectively demonstrates the creation of a basic interactive AI tool with predefined behaviors and responses, highlighting the potential of GPTScript for crafting specific AI interactions in an automation context.\n\n## [testdata/BobAsShell/test.gpt](testdata/BobAsShell/test.gpt)\n\nThis GPTScript file showcases the creation and use of a custom AI tool named \"Bob\" within the GPTScript environment. Notable aspects include:\n\n- Declaration and definition of a custom tool\n- Implementation of the tool's functionality using a Bash script\n- Demonstration of tool usage within the script\n- Integration of personality into the custom tool's responses\n\nThe script illustrates the flexibility of GPTScript in integrating custom tools that can be implemented in various ways (like Bash scripts) and then used seamlessly within the AI conversation flow. This allows for extending the capabilities of the AI system with custom, potentially external functionalities.\n\n## [testdata/SamplesReadme/test.gpt](testdata/SamplesReadme/test.gpt)\n\nThis GPTScript file contains a script designed to generate a readme that provides a consolidated summary of each *.gpt file in the testdata directory. Key features include:\n\n- Utilization of multiple tools: sys.find, sys.read, and a custom \"summary\" tool\n- Definition of a custom \"summary\" tool for summarizing GPTScript files\n- Implementation of a meta-level analysis of GPTScript files\n- Automation of documentation generation for a collection of scripts\n\nThe script demonstrates how GPTScript can be used to create custom tools for analyzing and documenting other GPTScript files, showcasing its potential for automating meta-level tasks and generating documentation.\n\nThis README provides an overview of the GPTScript files found in the testdata directory, highlighting their key features and demonstrating various techniques for working with GPTScript."
                 }
             ],
             "usage": {}
         }
     },
     {
-        "time": "2024-08-06T12:06:33.603177-04:00",
+        "time": "2024-08-23T12:03:11.019337-04:00",
         "callContext": {
-            "id": "1722960333",
+            "id": "1724428944",
             "tool": {
                 "modelName": "claude-3-5-sonnet-20240620 from github.com/gptscript-ai/claude3-anthropic-provider",
                 "internalPrompt": null,
@@ -3824,7 +3800,7 @@
                     "sys.read",
                     "summary"
                 ],
-                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "instructions": "Generate a readme that gives a consolidated summary of each *.gpt file in the testdata directory.\nEach entry should be a include a link to the referenced file.",
                 "id": "testdata/SamplesReadme/test.gpt:",
                 "toolMapping": {
                     "summary": [
@@ -3861,10 +3837,10 @@
         },
         "type": "callFinish",
         "usage": {},
-        "content": "Based on the summaries of the GPTScript files found in the testdata directory, I'll now generate a README that provides a consolidated summary of each sample *.gpt file, including links to the referenced files:\n\n# Sample GPTScript Files README\n\nThis README provides a summary of the sample GPTScript files found in the testdata directory. Each entry includes a brief description of the file's contents and the technique it demonstrates, along with a link to the file.\n\n## [testdata/Bob/test.gpt](testdata/Bob/test.gpt)\n\nThis GPTScript file demonstrates the creation and use of a custom AI tool named \"Bob\". \n\n**Key Features:**\n- Defines a custom tool called \"bob\" with a specific behavior\n- Shows how to create parameterized responses\n- Demonstrates scripted interactions with an AI tool\n- Illustrates the use of template-based replies\n\n**Technique Demonstrated:** The script showcases how to create a simple conversational AI agent within an automation framework, including defining specific behaviors and scripting basic interactions.\n\n## [testdata/BobAsShell/test.gpt](testdata/BobAsShell/test.gpt)\n\nThis GPTScript file demonstrates the integration of an external script (in this case, a Bash script) as a custom AI tool named \"Bob\".\n\n**Key Features:**\n- Declares and defines a custom tool \"bob\"\n- Implements the tool's functionality using Bash script\n- Shows how to interact with the custom tool within GPTScript\n\n**Technique Demonstrated:** This script illustrates how GPTScript can integrate external scripts or programs as AI tools, allowing for flexible and extensible AI automation workflows.\n\n## [testdata/SamplesReadme/test.gpt](testdata/SamplesReadme/test.gpt)\n\nThis GPTScript file is designed to generate a readme that summarizes other GPTScript files in a directory.\n\n**Key Features:**\n- Uses system tools (sys.find, sys.read) to locate and read GPTScript files\n- Defines a custom \"summary\" tool for file summarization\n- Demonstrates how to create documentation for a collection of scripts\n\n**Technique Demonstrated:** The script showcases the creation of a custom tool for automatic documentation generation, which can be useful for maintaining a library of GPTScript examples or creating user documentation.\n\nThis README provides an overview of the sample GPTScript files, demonstrating various techniques from simple AI interactions to more complex automation and documentation tasks. Each sample illustrates different aspects of working with GPTScript, offering valuable examples for users learning to create their own AI-powered automation scripts."
+        "content": "Based on the summaries of the GPTScript files found in the testdata directory, I'll now generate a README with consolidated summaries for each file, including links to the referenced files:\n\n# GPTScript Files Summary\n\n## [testdata/Bob/test.gpt](testdata/Bob/test.gpt)\n\nThis GPTScript file demonstrates a simple AI automation script involving interaction with a simulated AI tool or agent named \"Bob\". Key features include:\n\n- Definition of a custom AI tool called \"bob\"\n- Demonstration of parameterized interactions with the AI tool\n- Showcase of scripted responses for specific inputs\n- Use of string interpolation for dynamic response generation\n- Emphasis on exact output control\n\nThe script effectively demonstrates the creation of a basic interactive AI tool with predefined behaviors and responses, highlighting the potential of GPTScript for crafting specific AI interactions in an automation context.\n\n## [testdata/BobAsShell/test.gpt](testdata/BobAsShell/test.gpt)\n\nThis GPTScript file showcases the creation and use of a custom AI tool named \"Bob\" within the GPTScript environment. Notable aspects include:\n\n- Declaration and definition of a custom tool\n- Implementation of the tool's functionality using a Bash script\n- Demonstration of tool usage within the script\n- Integration of personality into the custom tool's responses\n\nThe script illustrates the flexibility of GPTScript in integrating custom tools that can be implemented in various ways (like Bash scripts) and then used seamlessly within the AI conversation flow. This allows for extending the capabilities of the AI system with custom, potentially external functionalities.\n\n## [testdata/SamplesReadme/test.gpt](testdata/SamplesReadme/test.gpt)\n\nThis GPTScript file contains a script designed to generate a readme that provides a consolidated summary of each *.gpt file in the testdata directory. Key features include:\n\n- Utilization of multiple tools: sys.find, sys.read, and a custom \"summary\" tool\n- Definition of a custom \"summary\" tool for summarizing GPTScript files\n- Implementation of a meta-level analysis of GPTScript files\n- Automation of documentation generation for a collection of scripts\n\nThe script demonstrates how GPTScript can be used to create custom tools for analyzing and documenting other GPTScript files, showcasing its potential for automating meta-level tasks and generating documentation.\n\nThis README provides an overview of the GPTScript files found in the testdata directory, highlighting their key features and demonstrating various techniques for working with GPTScript."
     },
     {
-        "time": "2024-08-06T12:06:33.603203-04:00",
+        "time": "2024-08-23T12:03:11.019355-04:00",
         "type": "runFinish",
         "usage": {}
     }

--- a/pkg/tests/smoke/testdata/SamplesReadme/gpt-4-turbo-2024-04-09-expected.json
+++ b/pkg/tests/smoke/testdata/SamplesReadme/gpt-4-turbo-2024-04-09-expected.json
@@ -1,0 +1,3176 @@
+[
+    {
+        "time": "2024-08-06T12:11:40.783111-04:00",
+        "type": "runStart",
+        "usage": {}
+    },
+    {
+        "time": "2024-08-06T12:11:40.7838-04:00",
+        "callContext": {
+            "id": "1722960701",
+            "tool": {
+                "modelName": "gpt-4-turbo-2024-04-09",
+                "internalPrompt": null,
+                "tools": [
+                    "sys.find",
+                    "sys.read",
+                    "summary"
+                ],
+                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "id": "testdata/SamplesReadme/test.gpt:",
+                "toolMapping": {
+                    "summary": [
+                        {
+                            "reference": "summary",
+                            "toolID": "testdata/SamplesReadme/test.gpt:summary"
+                        }
+                    ],
+                    "sys.find": [
+                        {
+                            "reference": "sys.find",
+                            "toolID": "sys.find"
+                        }
+                    ],
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 1
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null
+        },
+        "type": "callStart",
+        "usage": {}
+    },
+    {
+        "time": "2024-08-06T12:11:40.784104-04:00",
+        "callContext": {
+            "id": "1722960701",
+            "tool": {
+                "modelName": "gpt-4-turbo-2024-04-09",
+                "internalPrompt": null,
+                "tools": [
+                    "sys.find",
+                    "sys.read",
+                    "summary"
+                ],
+                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "id": "testdata/SamplesReadme/test.gpt:",
+                "toolMapping": {
+                    "summary": [
+                        {
+                            "reference": "summary",
+                            "toolID": "testdata/SamplesReadme/test.gpt:summary"
+                        }
+                    ],
+                    "sys.find": [
+                        {
+                            "reference": "sys.find",
+                            "toolID": "sys.find"
+                        }
+                    ],
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 1
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722960702",
+        "usage": {},
+        "chatRequest": {
+            "model": "gpt-4-turbo-2024-04-09",
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "\nYou are task oriented system.\nYou receive input from a user, process the input from the given instructions, and then output the result.\nYour objective is to provide consistent and correct results.\nYou do not need to explain the steps taken, only provide the result to the given instructions.\nYou are referred to as a tool.\nYou don't move to the next step until you have a result.\n\nGenerate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file."
+                }
+            ],
+            "temperature": 0,
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "find",
+                        "description": "Traverse a directory looking for files that match a pattern in the style of the unix find command",
+                        "parameters": {
+                            "properties": {
+                                "directory": {
+                                    "description": "The directory to search in. The current directory \".\" will be used as the default if no argument is passed",
+                                    "type": "string"
+                                },
+                                "pattern": {
+                                    "description": "The file pattern to look for. The pattern is a traditional unix glob format with * matching any character and ? matching a single character",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                },
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "read",
+                        "description": "Reads the contents of a file",
+                        "parameters": {
+                            "properties": {
+                                "filename": {
+                                    "description": "The name of the file to read",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                },
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "summary",
+                        "description": "Summarize a gpt file",
+                        "parameters": {
+                            "properties": {
+                                "file": {
+                                    "description": "filename to summarize",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    {
+        "time": "2024-08-06T12:11:41.755591-04:00",
+        "callContext": {
+            "id": "1722960701",
+            "tool": {
+                "modelName": "gpt-4-turbo-2024-04-09",
+                "internalPrompt": null,
+                "tools": [
+                    "sys.find",
+                    "sys.read",
+                    "summary"
+                ],
+                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "id": "testdata/SamplesReadme/test.gpt:",
+                "toolMapping": {
+                    "summary": [
+                        {
+                            "reference": "summary",
+                            "toolID": "testdata/SamplesReadme/test.gpt:summary"
+                        }
+                    ],
+                    "sys.find": [
+                        {
+                            "reference": "sys.find",
+                            "toolID": "sys.find"
+                        }
+                    ],
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 1
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722960702",
+        "usage": {
+            "promptTokens": 278,
+            "completionTokens": 15,
+            "totalTokens": 293
+        },
+        "chatResponse": {
+            "role": "assistant",
+            "content": [
+                {
+                    "toolCall": {
+                        "index": 0,
+                        "id": "call_yDNxq1wjVLJ5RRj1njcLMVzJ",
+                        "function": {
+                            "name": "find",
+                            "arguments": "{\"pattern\":\"*.gpt\"}"
+                        }
+                    }
+                }
+            ],
+            "usage": {
+                "promptTokens": 278,
+                "completionTokens": 15,
+                "totalTokens": 293
+            }
+        }
+    },
+    {
+        "time": "2024-08-06T12:11:41.755834-04:00",
+        "callContext": {
+            "id": "1722960701",
+            "tool": {
+                "modelName": "gpt-4-turbo-2024-04-09",
+                "internalPrompt": null,
+                "tools": [
+                    "sys.find",
+                    "sys.read",
+                    "summary"
+                ],
+                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "id": "testdata/SamplesReadme/test.gpt:",
+                "toolMapping": {
+                    "summary": [
+                        {
+                            "reference": "summary",
+                            "toolID": "testdata/SamplesReadme/test.gpt:summary"
+                        }
+                    ],
+                    "sys.find": [
+                        {
+                            "reference": "sys.find",
+                            "toolID": "sys.find"
+                        }
+                    ],
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 1
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null
+        },
+        "toolSubCalls": {
+            "call_yDNxq1wjVLJ5RRj1njcLMVzJ": {
+                "toolID": "sys.find",
+                "input": "{\"pattern\":\"*.gpt\"}"
+            }
+        },
+        "type": "callSubCalls",
+        "usage": {}
+    },
+    {
+        "time": "2024-08-06T12:11:41.755929-04:00",
+        "callContext": {
+            "id": "call_yDNxq1wjVLJ5RRj1njcLMVzJ",
+            "tool": {
+                "name": "sys.find",
+                "description": "Traverse a directory looking for files that match a pattern in the style of the unix find command",
+                "modelName": "gpt-4-turbo-2024-04-09",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "directory": {
+                            "description": "The directory to search in. The current directory \".\" will be used as the default if no argument is passed",
+                            "type": "string"
+                        },
+                        "pattern": {
+                            "description": "The file pattern to look for. The pattern is a traditional unix glob format with * matching any character and ? matching a single character",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "instructions": "#!sys.find",
+                "id": "sys.find",
+                "source": {}
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "sys.find",
+            "parentID": "1722960701",
+            "displayText": "Finding `*.gpt` in `.`"
+        },
+        "type": "callStart",
+        "usage": {},
+        "content": "{\"pattern\":\"*.gpt\"}"
+    },
+    {
+        "time": "2024-08-06T12:11:41.756063-04:00",
+        "callContext": {
+            "id": "call_yDNxq1wjVLJ5RRj1njcLMVzJ",
+            "tool": {
+                "name": "sys.find",
+                "description": "Traverse a directory looking for files that match a pattern in the style of the unix find command",
+                "modelName": "gpt-4-turbo-2024-04-09",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "directory": {
+                            "description": "The directory to search in. The current directory \".\" will be used as the default if no argument is passed",
+                            "type": "string"
+                        },
+                        "pattern": {
+                            "description": "The file pattern to look for. The pattern is a traditional unix glob format with * matching any character and ? matching a single character",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "instructions": "#!sys.find",
+                "id": "sys.find",
+                "source": {}
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "sys.find",
+            "parentID": "1722960701",
+            "displayText": "Finding `*.gpt` in `.`"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722960703",
+        "usage": {},
+        "chatRequest": {
+            "model": "",
+            "messages": null
+        }
+    },
+    {
+        "time": "2024-08-06T12:11:41.75687-04:00",
+        "callContext": {
+            "id": "call_yDNxq1wjVLJ5RRj1njcLMVzJ",
+            "tool": {
+                "name": "sys.find",
+                "description": "Traverse a directory looking for files that match a pattern in the style of the unix find command",
+                "modelName": "gpt-4-turbo-2024-04-09",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "directory": {
+                            "description": "The directory to search in. The current directory \".\" will be used as the default if no argument is passed",
+                            "type": "string"
+                        },
+                        "pattern": {
+                            "description": "The file pattern to look for. The pattern is a traditional unix glob format with * matching any character and ? matching a single character",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "instructions": "#!sys.find",
+                "id": "sys.find",
+                "source": {}
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "sys.find",
+            "parentID": "1722960701",
+            "displayText": "Finding `*.gpt` in `.`"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722960703",
+        "usage": {},
+        "chatResponse": {
+            "usage": {}
+        }
+    },
+    {
+        "time": "2024-08-06T12:11:41.756952-04:00",
+        "callContext": {
+            "id": "call_yDNxq1wjVLJ5RRj1njcLMVzJ",
+            "tool": {
+                "name": "sys.find",
+                "description": "Traverse a directory looking for files that match a pattern in the style of the unix find command",
+                "modelName": "gpt-4-turbo-2024-04-09",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "directory": {
+                            "description": "The directory to search in. The current directory \".\" will be used as the default if no argument is passed",
+                            "type": "string"
+                        },
+                        "pattern": {
+                            "description": "The file pattern to look for. The pattern is a traditional unix glob format with * matching any character and ? matching a single character",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "instructions": "#!sys.find",
+                "id": "sys.find",
+                "source": {}
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "sys.find",
+            "parentID": "1722960701",
+            "displayText": "Finding `*.gpt` in `.`"
+        },
+        "type": "callFinish",
+        "usage": {},
+        "content": "testdata/Bob/test.gpt\ntestdata/BobAsShell/test.gpt\ntestdata/SamplesReadme/test.gpt"
+    },
+    {
+        "time": "2024-08-06T12:11:41.757004-04:00",
+        "callContext": {
+            "id": "1722960701",
+            "tool": {
+                "modelName": "gpt-4-turbo-2024-04-09",
+                "internalPrompt": null,
+                "tools": [
+                    "sys.find",
+                    "sys.read",
+                    "summary"
+                ],
+                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "id": "testdata/SamplesReadme/test.gpt:",
+                "toolMapping": {
+                    "summary": [
+                        {
+                            "reference": "summary",
+                            "toolID": "testdata/SamplesReadme/test.gpt:summary"
+                        }
+                    ],
+                    "sys.find": [
+                        {
+                            "reference": "sys.find",
+                            "toolID": "sys.find"
+                        }
+                    ],
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 1
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null
+        },
+        "toolResults": 1,
+        "type": "callContinue",
+        "usage": {}
+    },
+    {
+        "time": "2024-08-06T12:11:41.757102-04:00",
+        "callContext": {
+            "id": "1722960701",
+            "tool": {
+                "modelName": "gpt-4-turbo-2024-04-09",
+                "internalPrompt": null,
+                "tools": [
+                    "sys.find",
+                    "sys.read",
+                    "summary"
+                ],
+                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "id": "testdata/SamplesReadme/test.gpt:",
+                "toolMapping": {
+                    "summary": [
+                        {
+                            "reference": "summary",
+                            "toolID": "testdata/SamplesReadme/test.gpt:summary"
+                        }
+                    ],
+                    "sys.find": [
+                        {
+                            "reference": "sys.find",
+                            "toolID": "sys.find"
+                        }
+                    ],
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 1
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722960704",
+        "usage": {},
+        "chatRequest": {
+            "model": "gpt-4-turbo-2024-04-09",
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "\nYou are task oriented system.\nYou receive input from a user, process the input from the given instructions, and then output the result.\nYour objective is to provide consistent and correct results.\nYou do not need to explain the steps taken, only provide the result to the given instructions.\nYou are referred to as a tool.\nYou don't move to the next step until you have a result.\n\nGenerate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file."
+                },
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "call_yDNxq1wjVLJ5RRj1njcLMVzJ",
+                            "type": "function",
+                            "function": {
+                                "name": "find",
+                                "arguments": "{\"pattern\":\"*.gpt\"}"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "role": "tool",
+                    "content": "testdata/Bob/test.gpt\ntestdata/BobAsShell/test.gpt\ntestdata/SamplesReadme/test.gpt",
+                    "name": "find",
+                    "tool_call_id": "call_yDNxq1wjVLJ5RRj1njcLMVzJ"
+                }
+            ],
+            "temperature": 0,
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "find",
+                        "description": "Traverse a directory looking for files that match a pattern in the style of the unix find command",
+                        "parameters": {
+                            "properties": {
+                                "directory": {
+                                    "description": "The directory to search in. The current directory \".\" will be used as the default if no argument is passed",
+                                    "type": "string"
+                                },
+                                "pattern": {
+                                    "description": "The file pattern to look for. The pattern is a traditional unix glob format with * matching any character and ? matching a single character",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                },
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "read",
+                        "description": "Reads the contents of a file",
+                        "parameters": {
+                            "properties": {
+                                "filename": {
+                                    "description": "The name of the file to read",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                },
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "summary",
+                        "description": "Summarize a gpt file",
+                        "parameters": {
+                            "properties": {
+                                "file": {
+                                    "description": "filename to summarize",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    {
+        "time": "2024-08-06T12:11:45.759078-04:00",
+        "callContext": {
+            "id": "1722960701",
+            "tool": {
+                "modelName": "gpt-4-turbo-2024-04-09",
+                "internalPrompt": null,
+                "tools": [
+                    "sys.find",
+                    "sys.read",
+                    "summary"
+                ],
+                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "id": "testdata/SamplesReadme/test.gpt:",
+                "toolMapping": {
+                    "summary": [
+                        {
+                            "reference": "summary",
+                            "toolID": "testdata/SamplesReadme/test.gpt:summary"
+                        }
+                    ],
+                    "sys.find": [
+                        {
+                            "reference": "sys.find",
+                            "toolID": "sys.find"
+                        }
+                    ],
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 1
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722960704",
+        "usage": {
+            "promptTokens": 324,
+            "completionTokens": 73,
+            "totalTokens": 397
+        },
+        "chatResponse": {
+            "role": "assistant",
+            "content": [
+                {
+                    "toolCall": {
+                        "index": 0,
+                        "id": "call_YN3tzEVmoC9vTQaecwpVTKUH",
+                        "function": {
+                            "name": "summary",
+                            "arguments": "{\"file\": \"testdata/Bob/test.gpt\"}"
+                        }
+                    }
+                },
+                {
+                    "toolCall": {
+                        "index": 1,
+                        "id": "call_D8bRgymmLNpau89owZ2GBhz2",
+                        "function": {
+                            "name": "summary",
+                            "arguments": "{\"file\": \"testdata/BobAsShell/test.gpt\"}"
+                        }
+                    }
+                },
+                {
+                    "toolCall": {
+                        "index": 2,
+                        "id": "call_yaaUSsKuLBRUcQ1XdYiVVq79",
+                        "function": {
+                            "name": "summary",
+                            "arguments": "{\"file\": \"testdata/SamplesReadme/test.gpt\"}"
+                        }
+                    }
+                }
+            ],
+            "usage": {
+                "promptTokens": 324,
+                "completionTokens": 73,
+                "totalTokens": 397
+            }
+        }
+    },
+    {
+        "time": "2024-08-06T12:11:45.759089-04:00",
+        "callContext": {
+            "id": "1722960701",
+            "tool": {
+                "modelName": "gpt-4-turbo-2024-04-09",
+                "internalPrompt": null,
+                "tools": [
+                    "sys.find",
+                    "sys.read",
+                    "summary"
+                ],
+                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "id": "testdata/SamplesReadme/test.gpt:",
+                "toolMapping": {
+                    "summary": [
+                        {
+                            "reference": "summary",
+                            "toolID": "testdata/SamplesReadme/test.gpt:summary"
+                        }
+                    ],
+                    "sys.find": [
+                        {
+                            "reference": "sys.find",
+                            "toolID": "sys.find"
+                        }
+                    ],
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 1
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null
+        },
+        "toolSubCalls": {
+            "call_D8bRgymmLNpau89owZ2GBhz2": {
+                "toolID": "testdata/SamplesReadme/test.gpt:summary",
+                "input": "{\"file\": \"testdata/BobAsShell/test.gpt\"}"
+            },
+            "call_YN3tzEVmoC9vTQaecwpVTKUH": {
+                "toolID": "testdata/SamplesReadme/test.gpt:summary",
+                "input": "{\"file\": \"testdata/Bob/test.gpt\"}"
+            },
+            "call_yaaUSsKuLBRUcQ1XdYiVVq79": {
+                "toolID": "testdata/SamplesReadme/test.gpt:summary",
+                "input": "{\"file\": \"testdata/SamplesReadme/test.gpt\"}"
+            }
+        },
+        "type": "callSubCalls",
+        "usage": {}
+    },
+    {
+        "time": "2024-08-06T12:11:45.759272-04:00",
+        "callContext": {
+            "id": "call_yaaUSsKuLBRUcQ1XdYiVVq79",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "gpt-4-turbo-2024-04-09",
+                "temperature": 0.7,
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722960701"
+        },
+        "type": "callStart",
+        "usage": {},
+        "content": "{\"file\": \"testdata/SamplesReadme/test.gpt\"}"
+    },
+    {
+        "time": "2024-08-06T12:11:45.759305-04:00",
+        "callContext": {
+            "id": "call_D8bRgymmLNpau89owZ2GBhz2",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "gpt-4-turbo-2024-04-09",
+                "temperature": 0.7,
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722960701"
+        },
+        "type": "callStart",
+        "usage": {},
+        "content": "{\"file\": \"testdata/BobAsShell/test.gpt\"}"
+    },
+    {
+        "time": "2024-08-06T12:11:45.759551-04:00",
+        "callContext": {
+            "id": "call_yaaUSsKuLBRUcQ1XdYiVVq79",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "gpt-4-turbo-2024-04-09",
+                "temperature": 0.7,
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722960701"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722960705",
+        "usage": {},
+        "chatRequest": {
+            "model": "gpt-4-turbo-2024-04-09",
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "\nYou are task oriented system.\nYou receive input from a user, process the input from the given instructions, and then output the result.\nYour objective is to provide consistent and correct results.\nYou do not need to explain the steps taken, only provide the result to the given instructions.\nYou are referred to as a tool.\nYou don't move to the next step until you have a result.\n\nRead ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate."
+                },
+                {
+                    "role": "user",
+                    "content": "{\"file\": \"testdata/SamplesReadme/test.gpt\"}"
+                }
+            ],
+            "temperature": 0.7,
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "read",
+                        "description": "Reads the contents of a file",
+                        "parameters": {
+                            "properties": {
+                                "filename": {
+                                    "description": "The name of the file to read",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    {
+        "time": "2024-08-06T12:11:45.759583-04:00",
+        "callContext": {
+            "id": "call_D8bRgymmLNpau89owZ2GBhz2",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "gpt-4-turbo-2024-04-09",
+                "temperature": 0.7,
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722960701"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722960706",
+        "usage": {},
+        "chatRequest": {
+            "model": "gpt-4-turbo-2024-04-09",
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "\nYou are task oriented system.\nYou receive input from a user, process the input from the given instructions, and then output the result.\nYour objective is to provide consistent and correct results.\nYou do not need to explain the steps taken, only provide the result to the given instructions.\nYou are referred to as a tool.\nYou don't move to the next step until you have a result.\n\nRead ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate."
+                },
+                {
+                    "role": "user",
+                    "content": "{\"file\": \"testdata/BobAsShell/test.gpt\"}"
+                }
+            ],
+            "temperature": 0.7,
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "read",
+                        "description": "Reads the contents of a file",
+                        "parameters": {
+                            "properties": {
+                                "filename": {
+                                    "description": "The name of the file to read",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    {
+        "time": "2024-08-06T12:11:45.75934-04:00",
+        "callContext": {
+            "id": "call_YN3tzEVmoC9vTQaecwpVTKUH",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "gpt-4-turbo-2024-04-09",
+                "temperature": 0.7,
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722960701"
+        },
+        "type": "callStart",
+        "usage": {},
+        "content": "{\"file\": \"testdata/Bob/test.gpt\"}"
+    },
+    {
+        "time": "2024-08-06T12:11:45.761438-04:00",
+        "callContext": {
+            "id": "call_YN3tzEVmoC9vTQaecwpVTKUH",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "gpt-4-turbo-2024-04-09",
+                "temperature": 0.7,
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722960701"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722960707",
+        "usage": {},
+        "chatRequest": {
+            "model": "gpt-4-turbo-2024-04-09",
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "\nYou are task oriented system.\nYou receive input from a user, process the input from the given instructions, and then output the result.\nYour objective is to provide consistent and correct results.\nYou do not need to explain the steps taken, only provide the result to the given instructions.\nYou are referred to as a tool.\nYou don't move to the next step until you have a result.\n\nRead ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate."
+                },
+                {
+                    "role": "user",
+                    "content": "{\"file\": \"testdata/Bob/test.gpt\"}"
+                }
+            ],
+            "temperature": 0.7,
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "read",
+                        "description": "Reads the contents of a file",
+                        "parameters": {
+                            "properties": {
+                                "filename": {
+                                    "description": "The name of the file to read",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    {
+        "time": "2024-08-06T12:11:47.549754-04:00",
+        "callContext": {
+            "id": "call_YN3tzEVmoC9vTQaecwpVTKUH",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "gpt-4-turbo-2024-04-09",
+                "temperature": 0.7,
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722960701"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722960707",
+        "usage": {
+            "promptTokens": 188,
+            "completionTokens": 33,
+            "totalTokens": 221
+        },
+        "chatResponse": {
+            "role": "assistant",
+            "content": [
+                {
+                    "toolCall": {
+                        "index": 0,
+                        "id": "call_daDLuxOEwdbORfj6tufRQaDS",
+                        "function": {
+                            "name": "read",
+                            "arguments": "{\"filename\": \"testdata/Bob/test.gpt\"}"
+                        }
+                    }
+                }
+            ],
+            "usage": {
+                "promptTokens": 188,
+                "completionTokens": 33,
+                "totalTokens": 221
+            }
+        }
+    },
+    {
+        "time": "2024-08-06T12:11:47.549909-04:00",
+        "callContext": {
+            "id": "call_YN3tzEVmoC9vTQaecwpVTKUH",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "gpt-4-turbo-2024-04-09",
+                "temperature": 0.7,
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722960701"
+        },
+        "toolSubCalls": {
+            "call_daDLuxOEwdbORfj6tufRQaDS": {
+                "toolID": "sys.read",
+                "input": "{\"filename\": \"testdata/Bob/test.gpt\"}"
+            }
+        },
+        "type": "callSubCalls",
+        "usage": {}
+    },
+    {
+        "time": "2024-08-06T12:11:47.55008-04:00",
+        "callContext": {
+            "id": "call_daDLuxOEwdbORfj6tufRQaDS",
+            "tool": {
+                "name": "sys.read",
+                "description": "Reads the contents of a file",
+                "modelName": "gpt-4-turbo-2024-04-09",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "filename": {
+                            "description": "The name of the file to read",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "instructions": "#!sys.read",
+                "id": "sys.read",
+                "source": {}
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "sys.read",
+            "parentID": "call_YN3tzEVmoC9vTQaecwpVTKUH",
+            "displayText": "Reading `testdata/Bob/test.gpt`"
+        },
+        "type": "callStart",
+        "usage": {},
+        "content": "{\"filename\": \"testdata/Bob/test.gpt\"}"
+    },
+    {
+        "time": "2024-08-06T12:11:47.550304-04:00",
+        "callContext": {
+            "id": "call_daDLuxOEwdbORfj6tufRQaDS",
+            "tool": {
+                "name": "sys.read",
+                "description": "Reads the contents of a file",
+                "modelName": "gpt-4-turbo-2024-04-09",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "filename": {
+                            "description": "The name of the file to read",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "instructions": "#!sys.read",
+                "id": "sys.read",
+                "source": {}
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "sys.read",
+            "parentID": "call_YN3tzEVmoC9vTQaecwpVTKUH",
+            "displayText": "Reading `testdata/Bob/test.gpt`"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722960708",
+        "usage": {},
+        "chatRequest": {
+            "model": "",
+            "messages": null
+        }
+    },
+    {
+        "time": "2024-08-06T12:11:47.550649-04:00",
+        "callContext": {
+            "id": "call_daDLuxOEwdbORfj6tufRQaDS",
+            "tool": {
+                "name": "sys.read",
+                "description": "Reads the contents of a file",
+                "modelName": "gpt-4-turbo-2024-04-09",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "filename": {
+                            "description": "The name of the file to read",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "instructions": "#!sys.read",
+                "id": "sys.read",
+                "source": {}
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "sys.read",
+            "parentID": "call_YN3tzEVmoC9vTQaecwpVTKUH",
+            "displayText": "Reading `testdata/Bob/test.gpt`"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722960708",
+        "usage": {},
+        "chatResponse": {
+            "usage": {}
+        }
+    },
+    {
+        "time": "2024-08-06T12:11:47.550705-04:00",
+        "callContext": {
+            "id": "call_daDLuxOEwdbORfj6tufRQaDS",
+            "tool": {
+                "name": "sys.read",
+                "description": "Reads the contents of a file",
+                "modelName": "gpt-4-turbo-2024-04-09",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "filename": {
+                            "description": "The name of the file to read",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "instructions": "#!sys.read",
+                "id": "sys.read",
+                "source": {}
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "sys.read",
+            "parentID": "call_YN3tzEVmoC9vTQaecwpVTKUH",
+            "displayText": "Reading `testdata/Bob/test.gpt`"
+        },
+        "type": "callFinish",
+        "usage": {},
+        "content": "tools: bob\n\nAsk Bob \"how are you doing\" and repeat his reply exactly.\n\n---\nname: bob\ndescription: I'm Bob, a friendly guy.\nargs: question: The question to ask Bob.\n\nWhen asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"\n"
+    },
+    {
+        "time": "2024-08-06T12:11:47.550765-04:00",
+        "callContext": {
+            "id": "call_YN3tzEVmoC9vTQaecwpVTKUH",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "gpt-4-turbo-2024-04-09",
+                "temperature": 0.7,
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722960701"
+        },
+        "toolResults": 1,
+        "type": "callContinue",
+        "usage": {}
+    },
+    {
+        "time": "2024-08-06T12:11:47.550845-04:00",
+        "callContext": {
+            "id": "call_YN3tzEVmoC9vTQaecwpVTKUH",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "gpt-4-turbo-2024-04-09",
+                "temperature": 0.7,
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722960701"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722960709",
+        "usage": {},
+        "chatRequest": {
+            "model": "gpt-4-turbo-2024-04-09",
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "\nYou are task oriented system.\nYou receive input from a user, process the input from the given instructions, and then output the result.\nYour objective is to provide consistent and correct results.\nYou do not need to explain the steps taken, only provide the result to the given instructions.\nYou are referred to as a tool.\nYou don't move to the next step until you have a result.\n\nRead ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate."
+                },
+                {
+                    "role": "user",
+                    "content": "{\"file\": \"testdata/Bob/test.gpt\"}"
+                },
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "call_daDLuxOEwdbORfj6tufRQaDS",
+                            "type": "function",
+                            "function": {
+                                "name": "read",
+                                "arguments": "{\"filename\": \"testdata/Bob/test.gpt\"}"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "role": "tool",
+                    "content": "tools: bob\n\nAsk Bob \"how are you doing\" and repeat his reply exactly.\n\n---\nname: bob\ndescription: I'm Bob, a friendly guy.\nargs: question: The question to ask Bob.\n\nWhen asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"\n",
+                    "name": "read",
+                    "tool_call_id": "call_daDLuxOEwdbORfj6tufRQaDS"
+                }
+            ],
+            "temperature": 0.7,
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "read",
+                        "description": "Reads the contents of a file",
+                        "parameters": {
+                            "properties": {
+                                "filename": {
+                                    "description": "The name of the file to read",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    {
+        "time": "2024-08-06T12:11:47.797784-04:00",
+        "callContext": {
+            "id": "call_yaaUSsKuLBRUcQ1XdYiVVq79",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "gpt-4-turbo-2024-04-09",
+                "temperature": 0.7,
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722960701"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722960705",
+        "usage": {
+            "promptTokens": 190,
+            "completionTokens": 35,
+            "totalTokens": 225
+        },
+        "chatResponse": {
+            "role": "assistant",
+            "content": [
+                {
+                    "toolCall": {
+                        "index": 0,
+                        "id": "call_SLrLfDdqnwVwsihxy8VwlxhP",
+                        "function": {
+                            "name": "read",
+                            "arguments": "{\"filename\": \"testdata/SamplesReadme/test.gpt\"}"
+                        }
+                    }
+                }
+            ],
+            "usage": {
+                "promptTokens": 190,
+                "completionTokens": 35,
+                "totalTokens": 225
+            }
+        }
+    },
+    {
+        "time": "2024-08-06T12:11:47.797879-04:00",
+        "callContext": {
+            "id": "call_yaaUSsKuLBRUcQ1XdYiVVq79",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "gpt-4-turbo-2024-04-09",
+                "temperature": 0.7,
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722960701"
+        },
+        "toolSubCalls": {
+            "call_SLrLfDdqnwVwsihxy8VwlxhP": {
+                "toolID": "sys.read",
+                "input": "{\"filename\": \"testdata/SamplesReadme/test.gpt\"}"
+            }
+        },
+        "type": "callSubCalls",
+        "usage": {}
+    },
+    {
+        "time": "2024-08-06T12:11:47.797973-04:00",
+        "callContext": {
+            "id": "call_SLrLfDdqnwVwsihxy8VwlxhP",
+            "tool": {
+                "name": "sys.read",
+                "description": "Reads the contents of a file",
+                "modelName": "gpt-4-turbo-2024-04-09",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "filename": {
+                            "description": "The name of the file to read",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "instructions": "#!sys.read",
+                "id": "sys.read",
+                "source": {}
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "sys.read",
+            "parentID": "call_yaaUSsKuLBRUcQ1XdYiVVq79",
+            "displayText": "Reading `testdata/SamplesReadme/test.gpt`"
+        },
+        "type": "callStart",
+        "usage": {},
+        "content": "{\"filename\": \"testdata/SamplesReadme/test.gpt\"}"
+    },
+    {
+        "time": "2024-08-06T12:11:47.798121-04:00",
+        "callContext": {
+            "id": "call_SLrLfDdqnwVwsihxy8VwlxhP",
+            "tool": {
+                "name": "sys.read",
+                "description": "Reads the contents of a file",
+                "modelName": "gpt-4-turbo-2024-04-09",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "filename": {
+                            "description": "The name of the file to read",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "instructions": "#!sys.read",
+                "id": "sys.read",
+                "source": {}
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "sys.read",
+            "parentID": "call_yaaUSsKuLBRUcQ1XdYiVVq79",
+            "displayText": "Reading `testdata/SamplesReadme/test.gpt`"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722960710",
+        "usage": {},
+        "chatRequest": {
+            "model": "",
+            "messages": null
+        }
+    },
+    {
+        "time": "2024-08-06T12:11:47.79829-04:00",
+        "callContext": {
+            "id": "call_SLrLfDdqnwVwsihxy8VwlxhP",
+            "tool": {
+                "name": "sys.read",
+                "description": "Reads the contents of a file",
+                "modelName": "gpt-4-turbo-2024-04-09",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "filename": {
+                            "description": "The name of the file to read",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "instructions": "#!sys.read",
+                "id": "sys.read",
+                "source": {}
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "sys.read",
+            "parentID": "call_yaaUSsKuLBRUcQ1XdYiVVq79",
+            "displayText": "Reading `testdata/SamplesReadme/test.gpt`"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722960710",
+        "usage": {},
+        "chatResponse": {
+            "usage": {}
+        }
+    },
+    {
+        "time": "2024-08-06T12:11:47.79834-04:00",
+        "callContext": {
+            "id": "call_SLrLfDdqnwVwsihxy8VwlxhP",
+            "tool": {
+                "name": "sys.read",
+                "description": "Reads the contents of a file",
+                "modelName": "gpt-4-turbo-2024-04-09",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "filename": {
+                            "description": "The name of the file to read",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "instructions": "#!sys.read",
+                "id": "sys.read",
+                "source": {}
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "sys.read",
+            "parentID": "call_yaaUSsKuLBRUcQ1XdYiVVq79",
+            "displayText": "Reading `testdata/SamplesReadme/test.gpt`"
+        },
+        "type": "callFinish",
+        "usage": {},
+        "content": "tools: sys.find, sys.read, summary\n\nGenerate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.\n\n---\nname: summary\ndescription: Summarize a gpt file\nargs: file: filename to summarize\ntools: sys.read\ntemperature: 0.7\n\nRead ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.\n"
+    },
+    {
+        "time": "2024-08-06T12:11:47.79839-04:00",
+        "callContext": {
+            "id": "call_yaaUSsKuLBRUcQ1XdYiVVq79",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "gpt-4-turbo-2024-04-09",
+                "temperature": 0.7,
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722960701"
+        },
+        "toolResults": 1,
+        "type": "callContinue",
+        "usage": {}
+    },
+    {
+        "time": "2024-08-06T12:11:47.798466-04:00",
+        "callContext": {
+            "id": "call_yaaUSsKuLBRUcQ1XdYiVVq79",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "gpt-4-turbo-2024-04-09",
+                "temperature": 0.7,
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722960701"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722960711",
+        "usage": {},
+        "chatRequest": {
+            "model": "gpt-4-turbo-2024-04-09",
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "\nYou are task oriented system.\nYou receive input from a user, process the input from the given instructions, and then output the result.\nYour objective is to provide consistent and correct results.\nYou do not need to explain the steps taken, only provide the result to the given instructions.\nYou are referred to as a tool.\nYou don't move to the next step until you have a result.\n\nRead ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate."
+                },
+                {
+                    "role": "user",
+                    "content": "{\"file\": \"testdata/SamplesReadme/test.gpt\"}"
+                },
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "call_SLrLfDdqnwVwsihxy8VwlxhP",
+                            "type": "function",
+                            "function": {
+                                "name": "read",
+                                "arguments": "{\"filename\": \"testdata/SamplesReadme/test.gpt\"}"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "role": "tool",
+                    "content": "tools: sys.find, sys.read, summary\n\nGenerate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.\n\n---\nname: summary\ndescription: Summarize a gpt file\nargs: file: filename to summarize\ntools: sys.read\ntemperature: 0.7\n\nRead ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.\n",
+                    "name": "read",
+                    "tool_call_id": "call_SLrLfDdqnwVwsihxy8VwlxhP"
+                }
+            ],
+            "temperature": 0.7,
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "read",
+                        "description": "Reads the contents of a file",
+                        "parameters": {
+                            "properties": {
+                                "filename": {
+                                    "description": "The name of the file to read",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    {
+        "time": "2024-08-06T12:11:47.855252-04:00",
+        "callContext": {
+            "id": "call_D8bRgymmLNpau89owZ2GBhz2",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "gpt-4-turbo-2024-04-09",
+                "temperature": 0.7,
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722960701"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722960706",
+        "usage": {
+            "promptTokens": 190,
+            "completionTokens": 35,
+            "totalTokens": 225
+        },
+        "chatResponse": {
+            "role": "assistant",
+            "content": [
+                {
+                    "toolCall": {
+                        "index": 0,
+                        "id": "call_3Icyq5ArgTYHBUFeepITupM0",
+                        "function": {
+                            "name": "read",
+                            "arguments": "{\"filename\": \"testdata/BobAsShell/test.gpt\"}"
+                        }
+                    }
+                }
+            ],
+            "usage": {
+                "promptTokens": 190,
+                "completionTokens": 35,
+                "totalTokens": 225
+            }
+        }
+    },
+    {
+        "time": "2024-08-06T12:11:47.855315-04:00",
+        "callContext": {
+            "id": "call_D8bRgymmLNpau89owZ2GBhz2",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "gpt-4-turbo-2024-04-09",
+                "temperature": 0.7,
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722960701"
+        },
+        "toolSubCalls": {
+            "call_3Icyq5ArgTYHBUFeepITupM0": {
+                "toolID": "sys.read",
+                "input": "{\"filename\": \"testdata/BobAsShell/test.gpt\"}"
+            }
+        },
+        "type": "callSubCalls",
+        "usage": {}
+    },
+    {
+        "time": "2024-08-06T12:11:47.8554-04:00",
+        "callContext": {
+            "id": "call_3Icyq5ArgTYHBUFeepITupM0",
+            "tool": {
+                "name": "sys.read",
+                "description": "Reads the contents of a file",
+                "modelName": "gpt-4-turbo-2024-04-09",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "filename": {
+                            "description": "The name of the file to read",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "instructions": "#!sys.read",
+                "id": "sys.read",
+                "source": {}
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "sys.read",
+            "parentID": "call_D8bRgymmLNpau89owZ2GBhz2",
+            "displayText": "Reading `testdata/BobAsShell/test.gpt`"
+        },
+        "type": "callStart",
+        "usage": {},
+        "content": "{\"filename\": \"testdata/BobAsShell/test.gpt\"}"
+    },
+    {
+        "time": "2024-08-06T12:11:47.855542-04:00",
+        "callContext": {
+            "id": "call_3Icyq5ArgTYHBUFeepITupM0",
+            "tool": {
+                "name": "sys.read",
+                "description": "Reads the contents of a file",
+                "modelName": "gpt-4-turbo-2024-04-09",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "filename": {
+                            "description": "The name of the file to read",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "instructions": "#!sys.read",
+                "id": "sys.read",
+                "source": {}
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "sys.read",
+            "parentID": "call_D8bRgymmLNpau89owZ2GBhz2",
+            "displayText": "Reading `testdata/BobAsShell/test.gpt`"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722960712",
+        "usage": {},
+        "chatRequest": {
+            "model": "",
+            "messages": null
+        }
+    },
+    {
+        "time": "2024-08-06T12:11:47.855818-04:00",
+        "callContext": {
+            "id": "call_3Icyq5ArgTYHBUFeepITupM0",
+            "tool": {
+                "name": "sys.read",
+                "description": "Reads the contents of a file",
+                "modelName": "gpt-4-turbo-2024-04-09",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "filename": {
+                            "description": "The name of the file to read",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "instructions": "#!sys.read",
+                "id": "sys.read",
+                "source": {}
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "sys.read",
+            "parentID": "call_D8bRgymmLNpau89owZ2GBhz2",
+            "displayText": "Reading `testdata/BobAsShell/test.gpt`"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722960712",
+        "usage": {},
+        "chatResponse": {
+            "usage": {}
+        }
+    },
+    {
+        "time": "2024-08-06T12:11:47.855877-04:00",
+        "callContext": {
+            "id": "call_3Icyq5ArgTYHBUFeepITupM0",
+            "tool": {
+                "name": "sys.read",
+                "description": "Reads the contents of a file",
+                "modelName": "gpt-4-turbo-2024-04-09",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "filename": {
+                            "description": "The name of the file to read",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "instructions": "#!sys.read",
+                "id": "sys.read",
+                "source": {}
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "sys.read",
+            "parentID": "call_D8bRgymmLNpau89owZ2GBhz2",
+            "displayText": "Reading `testdata/BobAsShell/test.gpt`"
+        },
+        "type": "callFinish",
+        "usage": {},
+        "content": "\ntools: bob\n\nAsk Bob \"how are you doing\" and repeat his reply exactly.\n\n---\nname: bob\ndescription: I'm Bob, a friendly guy.\nargs: question: The question to ask Bob.\n\n#!/bin/bash\n\necho \"Thanks for asking ${question}, I'm doing great fellow friendly AI tool!\"\n"
+    },
+    {
+        "time": "2024-08-06T12:11:47.855946-04:00",
+        "callContext": {
+            "id": "call_D8bRgymmLNpau89owZ2GBhz2",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "gpt-4-turbo-2024-04-09",
+                "temperature": 0.7,
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722960701"
+        },
+        "toolResults": 1,
+        "type": "callContinue",
+        "usage": {}
+    },
+    {
+        "time": "2024-08-06T12:11:47.856021-04:00",
+        "callContext": {
+            "id": "call_D8bRgymmLNpau89owZ2GBhz2",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "gpt-4-turbo-2024-04-09",
+                "temperature": 0.7,
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722960701"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722960713",
+        "usage": {},
+        "chatRequest": {
+            "model": "gpt-4-turbo-2024-04-09",
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "\nYou are task oriented system.\nYou receive input from a user, process the input from the given instructions, and then output the result.\nYour objective is to provide consistent and correct results.\nYou do not need to explain the steps taken, only provide the result to the given instructions.\nYou are referred to as a tool.\nYou don't move to the next step until you have a result.\n\nRead ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate."
+                },
+                {
+                    "role": "user",
+                    "content": "{\"file\": \"testdata/BobAsShell/test.gpt\"}"
+                },
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "call_3Icyq5ArgTYHBUFeepITupM0",
+                            "type": "function",
+                            "function": {
+                                "name": "read",
+                                "arguments": "{\"filename\": \"testdata/BobAsShell/test.gpt\"}"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "role": "tool",
+                    "content": "\ntools: bob\n\nAsk Bob \"how are you doing\" and repeat his reply exactly.\n\n---\nname: bob\ndescription: I'm Bob, a friendly guy.\nargs: question: The question to ask Bob.\n\n#!/bin/bash\n\necho \"Thanks for asking ${question}, I'm doing great fellow friendly AI tool!\"\n",
+                    "name": "read",
+                    "tool_call_id": "call_3Icyq5ArgTYHBUFeepITupM0"
+                }
+            ],
+            "temperature": 0.7,
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "read",
+                        "description": "Reads the contents of a file",
+                        "parameters": {
+                            "properties": {
+                                "filename": {
+                                    "description": "The name of the file to read",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    {
+        "time": "2024-08-06T12:11:50.795072-04:00",
+        "callContext": {
+            "id": "call_D8bRgymmLNpau89owZ2GBhz2",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "gpt-4-turbo-2024-04-09",
+                "temperature": 0.7,
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722960701"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722960713",
+        "usage": {
+            "promptTokens": 282,
+            "completionTokens": 44,
+            "totalTokens": 326
+        },
+        "chatResponse": {
+            "role": "assistant",
+            "content": [
+                {
+                    "text": "The GPTScript file contains a script that demonstrates how to interact with a fictional character named Bob, by asking a specific question and echoing his response. The technique demonstrated is simple interaction and response handling within a script."
+                }
+            ],
+            "usage": {
+                "promptTokens": 282,
+                "completionTokens": 44,
+                "totalTokens": 326
+            }
+        }
+    },
+    {
+        "time": "2024-08-06T12:11:50.795138-04:00",
+        "callContext": {
+            "id": "call_D8bRgymmLNpau89owZ2GBhz2",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "gpt-4-turbo-2024-04-09",
+                "temperature": 0.7,
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722960701"
+        },
+        "type": "callFinish",
+        "usage": {},
+        "content": "The GPTScript file contains a script that demonstrates how to interact with a fictional character named Bob, by asking a specific question and echoing his response. The technique demonstrated is simple interaction and response handling within a script."
+    },
+    {
+        "time": "2024-08-06T12:11:52.578437-04:00",
+        "callContext": {
+            "id": "call_yaaUSsKuLBRUcQ1XdYiVVq79",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "gpt-4-turbo-2024-04-09",
+                "temperature": 0.7,
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722960701"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722960711",
+        "usage": {
+            "promptTokens": 338,
+            "completionTokens": 88,
+            "totalTokens": 426
+        },
+        "chatResponse": {
+            "role": "assistant",
+            "content": [
+                {
+                    "text": "The GPTScript file contains scripts for generating a readme that summarizes the contents of each sample *.gpt file located in a specified directory, including a link to each file. It uses the tools `sys.find`, `sys.read`, and a custom `summary` tool. The `summary` tool is specifically designed to summarize GPT files, indicating a focus on extracting and compiling key information from multiple script files into a single document."
+                }
+            ],
+            "usage": {
+                "promptTokens": 338,
+                "completionTokens": 88,
+                "totalTokens": 426
+            }
+        }
+    },
+    {
+        "time": "2024-08-06T12:11:52.578543-04:00",
+        "callContext": {
+            "id": "call_yaaUSsKuLBRUcQ1XdYiVVq79",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "gpt-4-turbo-2024-04-09",
+                "temperature": 0.7,
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722960701"
+        },
+        "type": "callFinish",
+        "usage": {},
+        "content": "The GPTScript file contains scripts for generating a readme that summarizes the contents of each sample *.gpt file located in a specified directory, including a link to each file. It uses the tools `sys.find`, `sys.read`, and a custom `summary` tool. The `summary` tool is specifically designed to summarize GPT files, indicating a focus on extracting and compiling key information from multiple script files into a single document."
+    },
+    {
+        "time": "2024-08-06T12:11:53.318165-04:00",
+        "callContext": {
+            "id": "call_YN3tzEVmoC9vTQaecwpVTKUH",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "gpt-4-turbo-2024-04-09",
+                "temperature": 0.7,
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722960701"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722960709",
+        "usage": {
+            "promptTokens": 282,
+            "completionTokens": 104,
+            "totalTokens": 386
+        },
+        "chatResponse": {
+            "role": "assistant",
+            "content": [
+                {
+                    "text": "The GPTScript file contains a script that interacts with an AI tool named Bob. The script instructs the AI to ask Bob \"how are you doing\" and then to repeat his reply exactly as he responds. The file also includes a description of Bob, describing him as a friendly guy, and specifies how Bob should respond to the question about how he is doing. The technique demonstrated in the file is straightforward AI interaction and response handling, specifically designed to showcase how to query an AI tool and handle its output."
+                }
+            ],
+            "usage": {
+                "promptTokens": 282,
+                "completionTokens": 104,
+                "totalTokens": 386
+            }
+        }
+    },
+    {
+        "time": "2024-08-06T12:11:53.318276-04:00",
+        "callContext": {
+            "id": "call_YN3tzEVmoC9vTQaecwpVTKUH",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "gpt-4-turbo-2024-04-09",
+                "temperature": 0.7,
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722960701"
+        },
+        "type": "callFinish",
+        "usage": {},
+        "content": "The GPTScript file contains a script that interacts with an AI tool named Bob. The script instructs the AI to ask Bob \"how are you doing\" and then to repeat his reply exactly as he responds. The file also includes a description of Bob, describing him as a friendly guy, and specifies how Bob should respond to the question about how he is doing. The technique demonstrated in the file is straightforward AI interaction and response handling, specifically designed to showcase how to query an AI tool and handle its output."
+    },
+    {
+        "time": "2024-08-06T12:11:53.318399-04:00",
+        "callContext": {
+            "id": "1722960701",
+            "tool": {
+                "modelName": "gpt-4-turbo-2024-04-09",
+                "internalPrompt": null,
+                "tools": [
+                    "sys.find",
+                    "sys.read",
+                    "summary"
+                ],
+                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "id": "testdata/SamplesReadme/test.gpt:",
+                "toolMapping": {
+                    "summary": [
+                        {
+                            "reference": "summary",
+                            "toolID": "testdata/SamplesReadme/test.gpt:summary"
+                        }
+                    ],
+                    "sys.find": [
+                        {
+                            "reference": "sys.find",
+                            "toolID": "sys.find"
+                        }
+                    ],
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 1
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null
+        },
+        "toolResults": 3,
+        "type": "callContinue",
+        "usage": {}
+    },
+    {
+        "time": "2024-08-06T12:11:53.318604-04:00",
+        "callContext": {
+            "id": "1722960701",
+            "tool": {
+                "modelName": "gpt-4-turbo-2024-04-09",
+                "internalPrompt": null,
+                "tools": [
+                    "sys.find",
+                    "sys.read",
+                    "summary"
+                ],
+                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "id": "testdata/SamplesReadme/test.gpt:",
+                "toolMapping": {
+                    "summary": [
+                        {
+                            "reference": "summary",
+                            "toolID": "testdata/SamplesReadme/test.gpt:summary"
+                        }
+                    ],
+                    "sys.find": [
+                        {
+                            "reference": "sys.find",
+                            "toolID": "sys.find"
+                        }
+                    ],
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 1
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722960714",
+        "usage": {},
+        "chatRequest": {
+            "model": "gpt-4-turbo-2024-04-09",
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "\nYou are task oriented system.\nYou receive input from a user, process the input from the given instructions, and then output the result.\nYour objective is to provide consistent and correct results.\nYou do not need to explain the steps taken, only provide the result to the given instructions.\nYou are referred to as a tool.\nYou don't move to the next step until you have a result.\n\nGenerate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file."
+                },
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "call_yDNxq1wjVLJ5RRj1njcLMVzJ",
+                            "type": "function",
+                            "function": {
+                                "name": "find",
+                                "arguments": "{\"pattern\":\"*.gpt\"}"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "role": "tool",
+                    "content": "testdata/Bob/test.gpt\ntestdata/BobAsShell/test.gpt\ntestdata/SamplesReadme/test.gpt",
+                    "name": "find",
+                    "tool_call_id": "call_yDNxq1wjVLJ5RRj1njcLMVzJ"
+                },
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "call_YN3tzEVmoC9vTQaecwpVTKUH",
+                            "type": "function",
+                            "function": {
+                                "name": "summary",
+                                "arguments": "{\"file\": \"testdata/Bob/test.gpt\"}"
+                            }
+                        },
+                        {
+                            "id": "call_D8bRgymmLNpau89owZ2GBhz2",
+                            "type": "function",
+                            "function": {
+                                "name": "summary",
+                                "arguments": "{\"file\": \"testdata/BobAsShell/test.gpt\"}"
+                            }
+                        },
+                        {
+                            "id": "call_yaaUSsKuLBRUcQ1XdYiVVq79",
+                            "type": "function",
+                            "function": {
+                                "name": "summary",
+                                "arguments": "{\"file\": \"testdata/SamplesReadme/test.gpt\"}"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "role": "tool",
+                    "content": "The GPTScript file contains a script that interacts with an AI tool named Bob. The script instructs the AI to ask Bob \"how are you doing\" and then to repeat his reply exactly as he responds. The file also includes a description of Bob, describing him as a friendly guy, and specifies how Bob should respond to the question about how he is doing. The technique demonstrated in the file is straightforward AI interaction and response handling, specifically designed to showcase how to query an AI tool and handle its output.",
+                    "name": "summary",
+                    "tool_call_id": "call_YN3tzEVmoC9vTQaecwpVTKUH"
+                },
+                {
+                    "role": "tool",
+                    "content": "The GPTScript file contains a script that demonstrates how to interact with a fictional character named Bob, by asking a specific question and echoing his response. The technique demonstrated is simple interaction and response handling within a script.",
+                    "name": "summary",
+                    "tool_call_id": "call_D8bRgymmLNpau89owZ2GBhz2"
+                },
+                {
+                    "role": "tool",
+                    "content": "The GPTScript file contains scripts for generating a readme that summarizes the contents of each sample *.gpt file located in a specified directory, including a link to each file. It uses the tools `sys.find`, `sys.read`, and a custom `summary` tool. The `summary` tool is specifically designed to summarize GPT files, indicating a focus on extracting and compiling key information from multiple script files into a single document.",
+                    "name": "summary",
+                    "tool_call_id": "call_yaaUSsKuLBRUcQ1XdYiVVq79"
+                }
+            ],
+            "temperature": 0,
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "find",
+                        "description": "Traverse a directory looking for files that match a pattern in the style of the unix find command",
+                        "parameters": {
+                            "properties": {
+                                "directory": {
+                                    "description": "The directory to search in. The current directory \".\" will be used as the default if no argument is passed",
+                                    "type": "string"
+                                },
+                                "pattern": {
+                                    "description": "The file pattern to look for. The pattern is a traditional unix glob format with * matching any character and ? matching a single character",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                },
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "read",
+                        "description": "Reads the contents of a file",
+                        "parameters": {
+                            "properties": {
+                                "filename": {
+                                    "description": "The name of the file to read",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                },
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "summary",
+                        "description": "Summarize a gpt file",
+                        "parameters": {
+                            "properties": {
+                                "file": {
+                                    "description": "filename to summarize",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    {
+        "time": "2024-08-06T12:12:07.857266-04:00",
+        "callContext": {
+            "id": "1722960701",
+            "tool": {
+                "modelName": "gpt-4-turbo-2024-04-09",
+                "internalPrompt": null,
+                "tools": [
+                    "sys.find",
+                    "sys.read",
+                    "summary"
+                ],
+                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "id": "testdata/SamplesReadme/test.gpt:",
+                "toolMapping": {
+                    "summary": [
+                        {
+                            "reference": "summary",
+                            "toolID": "testdata/SamplesReadme/test.gpt:summary"
+                        }
+                    ],
+                    "sys.find": [
+                        {
+                            "reference": "sys.find",
+                            "toolID": "sys.find"
+                        }
+                    ],
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 1
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722960714",
+        "usage": {
+            "promptTokens": 643,
+            "completionTokens": 307,
+            "totalTokens": 950
+        },
+        "chatResponse": {
+            "role": "assistant",
+            "content": [
+                {
+                    "text": "### Consolidated Summary of Sample *.gpt Files\n\n1. **[Bob/test.gpt](testdata/Bob/test.gpt)**  \n   The GPTScript file contains a script that interacts with an AI tool named Bob. The script instructs the AI to ask Bob \"how are you doing\" and then to repeat his reply exactly as he responds. The file also includes a description of Bob, describing him as a friendly guy, and specifies how Bob should respond to the question about how he is doing. The technique demonstrated in the file is straightforward AI interaction and response handling, specifically designed to showcase how to query an AI tool and handle its output.\n\n2. **[BobAsShell/test.gpt](testdata/BobAsShell/test.gpt)**  \n   The GPTScript file contains a script that demonstrates how to interact with a fictional character named Bob, by asking a specific question and echoing his response. The technique demonstrated is simple interaction and response handling within a script.\n\n3. **[SamplesReadme/test.gpt](testdata/SamplesReadme/test.gpt)**  \n   The GPTScript file contains scripts for generating a readme that summarizes the contents of each sample *.gpt file located in a specified directory, including a link to each file. It uses the tools `sys.find`, `sys.read`, and a custom `summary` tool. The `summary` tool is specifically designed to summarize GPT files, indicating a focus on extracting and compiling key information from multiple script files into a single document."
+                }
+            ],
+            "usage": {
+                "promptTokens": 643,
+                "completionTokens": 307,
+                "totalTokens": 950
+            }
+        }
+    },
+    {
+        "time": "2024-08-06T12:12:07.857387-04:00",
+        "callContext": {
+            "id": "1722960701",
+            "tool": {
+                "modelName": "gpt-4-turbo-2024-04-09",
+                "internalPrompt": null,
+                "tools": [
+                    "sys.find",
+                    "sys.read",
+                    "summary"
+                ],
+                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "id": "testdata/SamplesReadme/test.gpt:",
+                "toolMapping": {
+                    "summary": [
+                        {
+                            "reference": "summary",
+                            "toolID": "testdata/SamplesReadme/test.gpt:summary"
+                        }
+                    ],
+                    "sys.find": [
+                        {
+                            "reference": "sys.find",
+                            "toolID": "sys.find"
+                        }
+                    ],
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 1
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null
+        },
+        "type": "callFinish",
+        "usage": {},
+        "content": "### Consolidated Summary of Sample *.gpt Files\n\n1. **[Bob/test.gpt](testdata/Bob/test.gpt)**  \n   The GPTScript file contains a script that interacts with an AI tool named Bob. The script instructs the AI to ask Bob \"how are you doing\" and then to repeat his reply exactly as he responds. The file also includes a description of Bob, describing him as a friendly guy, and specifies how Bob should respond to the question about how he is doing. The technique demonstrated in the file is straightforward AI interaction and response handling, specifically designed to showcase how to query an AI tool and handle its output.\n\n2. **[BobAsShell/test.gpt](testdata/BobAsShell/test.gpt)**  \n   The GPTScript file contains a script that demonstrates how to interact with a fictional character named Bob, by asking a specific question and echoing his response. The technique demonstrated is simple interaction and response handling within a script.\n\n3. **[SamplesReadme/test.gpt](testdata/SamplesReadme/test.gpt)**  \n   The GPTScript file contains scripts for generating a readme that summarizes the contents of each sample *.gpt file located in a specified directory, including a link to each file. It uses the tools `sys.find`, `sys.read`, and a custom `summary` tool. The `summary` tool is specifically designed to summarize GPT files, indicating a focus on extracting and compiling key information from multiple script files into a single document."
+    },
+    {
+        "time": "2024-08-06T12:12:07.857477-04:00",
+        "type": "runFinish",
+        "usage": {}
+    }
+]

--- a/pkg/tests/smoke/testdata/SamplesReadme/gpt-4o-2024-05-13-expected.json
+++ b/pkg/tests/smoke/testdata/SamplesReadme/gpt-4o-2024-05-13-expected.json
@@ -1,21 +1,22 @@
 [
     {
-        "time": "2024-08-06T11:48:38.76752-04:00",
+        "time": "2024-08-23T12:02:23.393856-04:00",
         "type": "runStart",
         "usage": {}
     },
     {
-        "time": "2024-08-06T11:48:38.767859-04:00",
+        "time": "2024-08-23T12:02:23.394146-04:00",
         "callContext": {
-            "id": "1722959319",
+            "id": "1724428944",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "sys.find",
+                    "sys.read",
                     "summary"
                 ],
-                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "instructions": "Generate a readme that gives a consolidated summary of each *.gpt file in the testdata directory.\nEach entry should be a include a link to the referenced file.",
                 "id": "testdata/SamplesReadme/test.gpt:",
                 "toolMapping": {
                     "summary": [
@@ -28,6 +29,12 @@
                         {
                             "reference": "sys.find",
                             "toolID": "sys.find"
+                        }
+                    ],
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
                         }
                     ]
                 },
@@ -48,17 +55,18 @@
         "usage": {}
     },
     {
-        "time": "2024-08-06T11:48:38.767907-04:00",
+        "time": "2024-08-23T12:02:23.394199-04:00",
         "callContext": {
-            "id": "1722959319",
+            "id": "1724428944",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "sys.find",
+                    "sys.read",
                     "summary"
                 ],
-                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "instructions": "Generate a readme that gives a consolidated summary of each *.gpt file in the testdata directory.\nEach entry should be a include a link to the referenced file.",
                 "id": "testdata/SamplesReadme/test.gpt:",
                 "toolMapping": {
                     "summary": [
@@ -71,6 +79,12 @@
                         {
                             "reference": "sys.find",
                             "toolID": "sys.find"
+                        }
+                    ],
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
                         }
                     ]
                 },
@@ -88,14 +102,14 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1722959320",
+        "chatCompletionId": "1724428945",
         "usage": {},
         "chatRequest": {
             "model": "gpt-4o-2024-05-13",
             "messages": [
                 {
                     "role": "system",
-                    "content": "\nYou are task oriented system.\nYou receive input from a user, process the input from the given instructions, and then output the result.\nYour objective is to provide consistent and correct results.\nYou do not need to explain the steps taken, only provide the result to the given instructions.\nYou are referred to as a tool.\nYou don't move to the next step until you have a result.\n\nGenerate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file."
+                    "content": "\nYou are task oriented system.\nYou receive input from a user, process the input from the given instructions, and then output the result.\nYour objective is to provide consistent and correct results.\nYou do not need to explain the steps taken, only provide the result to the given instructions.\nYou are referred to as a tool.\nYou don't move to the next step until you have a result.\n\nGenerate a readme that gives a consolidated summary of each *.gpt file in the testdata directory.\nEach entry should be a include a link to the referenced file."
                 }
             ],
             "temperature": 0,
@@ -123,6 +137,22 @@
                 {
                     "type": "function",
                     "function": {
+                        "name": "read",
+                        "description": "Reads the contents of a file",
+                        "parameters": {
+                            "properties": {
+                                "filename": {
+                                    "description": "The name of the file to read",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                },
+                {
+                    "type": "function",
+                    "function": {
                         "name": "summary",
                         "description": "Summarize a gpt file",
                         "parameters": {
@@ -140,17 +170,18 @@
         }
     },
     {
-        "time": "2024-08-06T11:48:39.448009-04:00",
+        "time": "2024-08-23T12:02:24.040357-04:00",
         "callContext": {
-            "id": "1722959319",
+            "id": "1724428944",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "sys.find",
+                    "sys.read",
                     "summary"
                 ],
-                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "instructions": "Generate a readme that gives a consolidated summary of each *.gpt file in the testdata directory.\nEach entry should be a include a link to the referenced file.",
                 "id": "testdata/SamplesReadme/test.gpt:",
                 "toolMapping": {
                     "summary": [
@@ -163,6 +194,12 @@
                         {
                             "reference": "sys.find",
                             "toolID": "sys.find"
+                        }
+                    ],
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
                         }
                     ]
                 },
@@ -180,11 +217,11 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1722959320",
+        "chatCompletionId": "1724428945",
         "usage": {
-            "promptTokens": 242,
+            "promptTokens": 272,
             "completionTokens": 20,
-            "totalTokens": 262
+            "totalTokens": 292
         },
         "chatResponse": {
             "role": "assistant",
@@ -192,7 +229,7 @@
                 {
                     "toolCall": {
                         "index": 0,
-                        "id": "call_jM3KPkDXwEIo6IFTvqNQSVBf",
+                        "id": "call_AC0tP40eH2BNMloJag3dSw0c",
                         "function": {
                             "name": "find",
                             "arguments": "{\"directory\":\"testdata\",\"pattern\":\"*.gpt\"}"
@@ -201,24 +238,25 @@
                 }
             ],
             "usage": {
-                "promptTokens": 242,
+                "promptTokens": 272,
                 "completionTokens": 20,
-                "totalTokens": 262
+                "totalTokens": 292
             }
         }
     },
     {
-        "time": "2024-08-06T11:48:39.448411-04:00",
+        "time": "2024-08-23T12:02:24.040528-04:00",
         "callContext": {
-            "id": "1722959319",
+            "id": "1724428944",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "sys.find",
+                    "sys.read",
                     "summary"
                 ],
-                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "instructions": "Generate a readme that gives a consolidated summary of each *.gpt file in the testdata directory.\nEach entry should be a include a link to the referenced file.",
                 "id": "testdata/SamplesReadme/test.gpt:",
                 "toolMapping": {
                     "summary": [
@@ -231,6 +269,12 @@
                         {
                             "reference": "sys.find",
                             "toolID": "sys.find"
+                        }
+                    ],
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
                         }
                     ]
                 },
@@ -248,7 +292,7 @@
             "inputContext": null
         },
         "toolSubCalls": {
-            "call_jM3KPkDXwEIo6IFTvqNQSVBf": {
+            "call_AC0tP40eH2BNMloJag3dSw0c": {
                 "toolID": "sys.find",
                 "input": "{\"directory\":\"testdata\",\"pattern\":\"*.gpt\"}"
             }
@@ -257,9 +301,9 @@
         "usage": {}
     },
     {
-        "time": "2024-08-06T11:48:39.448605-04:00",
+        "time": "2024-08-23T12:02:24.04063-04:00",
         "callContext": {
-            "id": "call_jM3KPkDXwEIo6IFTvqNQSVBf",
+            "id": "call_AC0tP40eH2BNMloJag3dSw0c",
             "tool": {
                 "name": "sys.find",
                 "description": "Traverse a directory looking for files that match a pattern in the style of the unix find command",
@@ -285,7 +329,7 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "sys.find",
-            "parentID": "1722959319",
+            "parentID": "1724428944",
             "displayText": "Finding `*.gpt` in `testdata`"
         },
         "type": "callStart",
@@ -293,9 +337,9 @@
         "content": "{\"directory\":\"testdata\",\"pattern\":\"*.gpt\"}"
     },
     {
-        "time": "2024-08-06T11:48:39.448868-04:00",
+        "time": "2024-08-23T12:02:24.040729-04:00",
         "callContext": {
-            "id": "call_jM3KPkDXwEIo6IFTvqNQSVBf",
+            "id": "call_AC0tP40eH2BNMloJag3dSw0c",
             "tool": {
                 "name": "sys.find",
                 "description": "Traverse a directory looking for files that match a pattern in the style of the unix find command",
@@ -321,11 +365,11 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "sys.find",
-            "parentID": "1722959319",
+            "parentID": "1724428944",
             "displayText": "Finding `*.gpt` in `testdata`"
         },
         "type": "callChat",
-        "chatCompletionId": "1722959321",
+        "chatCompletionId": "1724428946",
         "usage": {},
         "chatRequest": {
             "model": "",
@@ -333,9 +377,9 @@
         }
     },
     {
-        "time": "2024-08-06T11:48:39.449755-04:00",
+        "time": "2024-08-23T12:02:24.041423-04:00",
         "callContext": {
-            "id": "call_jM3KPkDXwEIo6IFTvqNQSVBf",
+            "id": "call_AC0tP40eH2BNMloJag3dSw0c",
             "tool": {
                 "name": "sys.find",
                 "description": "Traverse a directory looking for files that match a pattern in the style of the unix find command",
@@ -361,20 +405,20 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "sys.find",
-            "parentID": "1722959319",
+            "parentID": "1724428944",
             "displayText": "Finding `*.gpt` in `testdata`"
         },
         "type": "callChat",
-        "chatCompletionId": "1722959321",
+        "chatCompletionId": "1724428946",
         "usage": {},
         "chatResponse": {
             "usage": {}
         }
     },
     {
-        "time": "2024-08-06T11:48:39.449847-04:00",
+        "time": "2024-08-23T12:02:24.041452-04:00",
         "callContext": {
-            "id": "call_jM3KPkDXwEIo6IFTvqNQSVBf",
+            "id": "call_AC0tP40eH2BNMloJag3dSw0c",
             "tool": {
                 "name": "sys.find",
                 "description": "Traverse a directory looking for files that match a pattern in the style of the unix find command",
@@ -400,7 +444,7 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "sys.find",
-            "parentID": "1722959319",
+            "parentID": "1724428944",
             "displayText": "Finding `*.gpt` in `testdata`"
         },
         "type": "callFinish",
@@ -408,17 +452,18 @@
         "content": "testdata/Bob/test.gpt\ntestdata/BobAsShell/test.gpt\ntestdata/SamplesReadme/test.gpt"
     },
     {
-        "time": "2024-08-06T11:48:39.449916-04:00",
+        "time": "2024-08-23T12:02:24.041487-04:00",
         "callContext": {
-            "id": "1722959319",
+            "id": "1724428944",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "sys.find",
+                    "sys.read",
                     "summary"
                 ],
-                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "instructions": "Generate a readme that gives a consolidated summary of each *.gpt file in the testdata directory.\nEach entry should be a include a link to the referenced file.",
                 "id": "testdata/SamplesReadme/test.gpt:",
                 "toolMapping": {
                     "summary": [
@@ -431,6 +476,12 @@
                         {
                             "reference": "sys.find",
                             "toolID": "sys.find"
+                        }
+                    ],
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
                         }
                     ]
                 },
@@ -452,17 +503,18 @@
         "usage": {}
     },
     {
-        "time": "2024-08-06T11:48:39.450004-04:00",
+        "time": "2024-08-23T12:02:24.041507-04:00",
         "callContext": {
-            "id": "1722959319",
+            "id": "1724428944",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "sys.find",
+                    "sys.read",
                     "summary"
                 ],
-                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "instructions": "Generate a readme that gives a consolidated summary of each *.gpt file in the testdata directory.\nEach entry should be a include a link to the referenced file.",
                 "id": "testdata/SamplesReadme/test.gpt:",
                 "toolMapping": {
                     "summary": [
@@ -475,6 +527,12 @@
                         {
                             "reference": "sys.find",
                             "toolID": "sys.find"
+                        }
+                    ],
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
                         }
                     ]
                 },
@@ -492,21 +550,21 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1722959322",
+        "chatCompletionId": "1724428947",
         "usage": {},
         "chatRequest": {
             "model": "gpt-4o-2024-05-13",
             "messages": [
                 {
                     "role": "system",
-                    "content": "\nYou are task oriented system.\nYou receive input from a user, process the input from the given instructions, and then output the result.\nYour objective is to provide consistent and correct results.\nYou do not need to explain the steps taken, only provide the result to the given instructions.\nYou are referred to as a tool.\nYou don't move to the next step until you have a result.\n\nGenerate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file."
+                    "content": "\nYou are task oriented system.\nYou receive input from a user, process the input from the given instructions, and then output the result.\nYour objective is to provide consistent and correct results.\nYou do not need to explain the steps taken, only provide the result to the given instructions.\nYou are referred to as a tool.\nYou don't move to the next step until you have a result.\n\nGenerate a readme that gives a consolidated summary of each *.gpt file in the testdata directory.\nEach entry should be a include a link to the referenced file."
                 },
                 {
                     "role": "assistant",
                     "content": "",
                     "tool_calls": [
                         {
-                            "id": "call_jM3KPkDXwEIo6IFTvqNQSVBf",
+                            "id": "call_AC0tP40eH2BNMloJag3dSw0c",
                             "type": "function",
                             "function": {
                                 "name": "find",
@@ -519,7 +577,7 @@
                     "role": "tool",
                     "content": "testdata/Bob/test.gpt\ntestdata/BobAsShell/test.gpt\ntestdata/SamplesReadme/test.gpt",
                     "name": "find",
-                    "tool_call_id": "call_jM3KPkDXwEIo6IFTvqNQSVBf"
+                    "tool_call_id": "call_AC0tP40eH2BNMloJag3dSw0c"
                 }
             ],
             "temperature": 0,
@@ -547,6 +605,22 @@
                 {
                     "type": "function",
                     "function": {
+                        "name": "read",
+                        "description": "Reads the contents of a file",
+                        "parameters": {
+                            "properties": {
+                                "filename": {
+                                    "description": "The name of the file to read",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                },
+                {
+                    "type": "function",
+                    "function": {
                         "name": "summary",
                         "description": "Summarize a gpt file",
                         "parameters": {
@@ -564,17 +638,18 @@
         }
     },
     {
-        "time": "2024-08-06T11:48:41.955112-04:00",
+        "time": "2024-08-23T12:02:25.167603-04:00",
         "callContext": {
-            "id": "1722959319",
+            "id": "1724428944",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "sys.find",
+                    "sys.read",
                     "summary"
                 ],
-                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "instructions": "Generate a readme that gives a consolidated summary of each *.gpt file in the testdata directory.\nEach entry should be a include a link to the referenced file.",
                 "id": "testdata/SamplesReadme/test.gpt:",
                 "toolMapping": {
                     "summary": [
@@ -587,6 +662,12 @@
                         {
                             "reference": "sys.find",
                             "toolID": "sys.find"
+                        }
+                    ],
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
                         }
                     ]
                 },
@@ -604,34 +685,35 @@
             "inputContext": null
         },
         "toolSubCalls": {
-            "call_B31GmzDYcNLo0yYUAyG8dYPA": {
-                "toolID": "testdata/SamplesReadme/test.gpt:summary",
-                "input": "{\"file\": \"testdata/Bob/test.gpt\"}"
-            },
-            "call_QW4r1m85pmK7aqYudiIo2CcY": {
+            "call_WxYHM2C2LYqefe0dnDZveAgk": {
                 "toolID": "testdata/SamplesReadme/test.gpt:summary",
                 "input": "{\"file\": \"testdata/BobAsShell/test.gpt\"}"
             },
-            "call_df2WDMbaXZLMbH6MWT9my9fy": {
+            "call_seuQJWpcuIZGsE5ew0ulVoSm": {
                 "toolID": "testdata/SamplesReadme/test.gpt:summary",
                 "input": "{\"file\": \"testdata/SamplesReadme/test.gpt\"}"
+            },
+            "call_v4fxPCcLKdcJso5SK8EEvv7g": {
+                "toolID": "testdata/SamplesReadme/test.gpt:summary",
+                "input": "{\"file\": \"testdata/Bob/test.gpt\"}"
             }
         },
         "type": "callSubCalls",
         "usage": {}
     },
     {
-        "time": "2024-08-06T11:48:41.955113-04:00",
+        "time": "2024-08-23T12:02:25.167611-04:00",
         "callContext": {
-            "id": "1722959319",
+            "id": "1724428944",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "sys.find",
+                    "sys.read",
                     "summary"
                 ],
-                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "instructions": "Generate a readme that gives a consolidated summary of each *.gpt file in the testdata directory.\nEach entry should be a include a link to the referenced file.",
                 "id": "testdata/SamplesReadme/test.gpt:",
                 "toolMapping": {
                     "summary": [
@@ -644,6 +726,12 @@
                         {
                             "reference": "sys.find",
                             "toolID": "sys.find"
+                        }
+                    ],
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
                         }
                     ]
                 },
@@ -661,11 +749,11 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1722959322",
+        "chatCompletionId": "1724428947",
         "usage": {
-            "promptTokens": 296,
+            "promptTokens": 326,
             "completionTokens": 77,
-            "totalTokens": 373
+            "totalTokens": 403
         },
         "chatResponse": {
             "role": "assistant",
@@ -673,7 +761,7 @@
                 {
                     "toolCall": {
                         "index": 0,
-                        "id": "call_B31GmzDYcNLo0yYUAyG8dYPA",
+                        "id": "call_v4fxPCcLKdcJso5SK8EEvv7g",
                         "function": {
                             "name": "summary",
                             "arguments": "{\"file\": \"testdata/Bob/test.gpt\"}"
@@ -683,7 +771,7 @@
                 {
                     "toolCall": {
                         "index": 1,
-                        "id": "call_QW4r1m85pmK7aqYudiIo2CcY",
+                        "id": "call_WxYHM2C2LYqefe0dnDZveAgk",
                         "function": {
                             "name": "summary",
                             "arguments": "{\"file\": \"testdata/BobAsShell/test.gpt\"}"
@@ -693,7 +781,7 @@
                 {
                     "toolCall": {
                         "index": 2,
-                        "id": "call_df2WDMbaXZLMbH6MWT9my9fy",
+                        "id": "call_seuQJWpcuIZGsE5ew0ulVoSm",
                         "function": {
                             "name": "summary",
                             "arguments": "{\"file\": \"testdata/SamplesReadme/test.gpt\"}"
@@ -702,21 +790,20 @@
                 }
             ],
             "usage": {
-                "promptTokens": 296,
+                "promptTokens": 326,
                 "completionTokens": 77,
-                "totalTokens": 373
+                "totalTokens": 403
             }
         }
     },
     {
-        "time": "2024-08-06T11:48:41.955247-04:00",
+        "time": "2024-08-23T12:02:25.167701-04:00",
         "callContext": {
-            "id": "call_df2WDMbaXZLMbH6MWT9my9fy",
+            "id": "call_v4fxPCcLKdcJso5SK8EEvv7g",
             "tool": {
                 "name": "summary",
                 "description": "Summarize a gpt file",
                 "modelName": "gpt-4o-2024-05-13",
-                "temperature": 0.7,
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -753,72 +840,20 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "summary",
-            "parentID": "1722959319"
-        },
-        "type": "callStart",
-        "usage": {},
-        "content": "{\"file\": \"testdata/SamplesReadme/test.gpt\"}"
-    },
-    {
-        "time": "2024-08-06T11:48:41.955251-04:00",
-        "callContext": {
-            "id": "call_B31GmzDYcNLo0yYUAyG8dYPA",
-            "tool": {
-                "name": "summary",
-                "description": "Summarize a gpt file",
-                "modelName": "gpt-4o-2024-05-13",
-                "temperature": 0.7,
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "file": {
-                            "description": "filename to summarize",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "tools": [
-                    "sys.read"
-                ],
-                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
-                "id": "testdata/SamplesReadme/test.gpt:summary",
-                "toolMapping": {
-                    "sys.read": [
-                        {
-                            "reference": "sys.read",
-                            "toolID": "sys.read"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/SamplesReadme/test.gpt:",
-                    "summary": "testdata/SamplesReadme/test.gpt:summary"
-                },
-                "source": {
-                    "location": "testdata/SamplesReadme/test.gpt",
-                    "lineNo": 7
-                },
-                "workingDir": "testdata/SamplesReadme"
-            },
-            "currentAgent": {},
-            "inputContext": null,
-            "toolName": "summary",
-            "parentID": "1722959319"
+            "parentID": "1724428944"
         },
         "type": "callStart",
         "usage": {},
         "content": "{\"file\": \"testdata/Bob/test.gpt\"}"
     },
     {
-        "time": "2024-08-06T11:48:41.955477-04:00",
+        "time": "2024-08-23T12:02:25.167701-04:00",
         "callContext": {
-            "id": "call_df2WDMbaXZLMbH6MWT9my9fy",
+            "id": "call_WxYHM2C2LYqefe0dnDZveAgk",
             "tool": {
                 "name": "summary",
                 "description": "Summarize a gpt file",
                 "modelName": "gpt-4o-2024-05-13",
-                "temperature": 0.7,
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -855,53 +890,20 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "summary",
-            "parentID": "1722959319"
+            "parentID": "1724428944"
         },
-        "type": "callChat",
-        "chatCompletionId": "1722959323",
+        "type": "callStart",
         "usage": {},
-        "chatRequest": {
-            "model": "gpt-4o-2024-05-13",
-            "messages": [
-                {
-                    "role": "system",
-                    "content": "\nYou are task oriented system.\nYou receive input from a user, process the input from the given instructions, and then output the result.\nYour objective is to provide consistent and correct results.\nYou do not need to explain the steps taken, only provide the result to the given instructions.\nYou are referred to as a tool.\nYou don't move to the next step until you have a result.\n\nRead ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate."
-                },
-                {
-                    "role": "user",
-                    "content": "{\"file\": \"testdata/SamplesReadme/test.gpt\"}"
-                }
-            ],
-            "temperature": 0.7,
-            "tools": [
-                {
-                    "type": "function",
-                    "function": {
-                        "name": "read",
-                        "description": "Reads the contents of a file",
-                        "parameters": {
-                            "properties": {
-                                "filename": {
-                                    "description": "The name of the file to read",
-                                    "type": "string"
-                                }
-                            },
-                            "type": "object"
-                        }
-                    }
-                }
-            ]
-        }
+        "content": "{\"file\": \"testdata/BobAsShell/test.gpt\"}"
     },
     {
-        "time": "2024-08-06T11:48:41.955517-04:00",
+        "time": "2024-08-23T12:02:25.167969-04:00",
         "callContext": {
-            "id": "call_B31GmzDYcNLo0yYUAyG8dYPA",
+            "id": "call_v4fxPCcLKdcJso5SK8EEvv7g",
             "tool": {
                 "name": "summary",
                 "description": "Summarize a gpt file",
                 "modelName": "gpt-4o-2024-05-13",
-                "temperature": 0.7,
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -938,10 +940,10 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "summary",
-            "parentID": "1722959319"
+            "parentID": "1724428944"
         },
         "type": "callChat",
-        "chatCompletionId": "1722959324",
+        "chatCompletionId": "1724428948",
         "usage": {},
         "chatRequest": {
             "model": "gpt-4o-2024-05-13",
@@ -955,7 +957,7 @@
                     "content": "{\"file\": \"testdata/Bob/test.gpt\"}"
                 }
             ],
-            "temperature": 0.7,
+            "temperature": 0,
             "tools": [
                 {
                     "type": "function",
@@ -977,14 +979,13 @@
         }
     },
     {
-        "time": "2024-08-06T11:48:41.955259-04:00",
+        "time": "2024-08-23T12:02:25.16806-04:00",
         "callContext": {
-            "id": "call_QW4r1m85pmK7aqYudiIo2CcY",
+            "id": "call_WxYHM2C2LYqefe0dnDZveAgk",
             "tool": {
                 "name": "summary",
                 "description": "Summarize a gpt file",
                 "modelName": "gpt-4o-2024-05-13",
-                "temperature": 0.7,
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -1021,61 +1022,10 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "summary",
-            "parentID": "1722959319"
-        },
-        "type": "callStart",
-        "usage": {},
-        "content": "{\"file\": \"testdata/BobAsShell/test.gpt\"}"
-    },
-    {
-        "time": "2024-08-06T11:48:41.955821-04:00",
-        "callContext": {
-            "id": "call_QW4r1m85pmK7aqYudiIo2CcY",
-            "tool": {
-                "name": "summary",
-                "description": "Summarize a gpt file",
-                "modelName": "gpt-4o-2024-05-13",
-                "temperature": 0.7,
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "file": {
-                            "description": "filename to summarize",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "tools": [
-                    "sys.read"
-                ],
-                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
-                "id": "testdata/SamplesReadme/test.gpt:summary",
-                "toolMapping": {
-                    "sys.read": [
-                        {
-                            "reference": "sys.read",
-                            "toolID": "sys.read"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/SamplesReadme/test.gpt:",
-                    "summary": "testdata/SamplesReadme/test.gpt:summary"
-                },
-                "source": {
-                    "location": "testdata/SamplesReadme/test.gpt",
-                    "lineNo": 7
-                },
-                "workingDir": "testdata/SamplesReadme"
-            },
-            "currentAgent": {},
-            "inputContext": null,
-            "toolName": "summary",
-            "parentID": "1722959319"
+            "parentID": "1724428944"
         },
         "type": "callChat",
-        "chatCompletionId": "1722959325",
+        "chatCompletionId": "1724428949",
         "usage": {},
         "chatRequest": {
             "model": "gpt-4o-2024-05-13",
@@ -1089,7 +1039,7 @@
                     "content": "{\"file\": \"testdata/BobAsShell/test.gpt\"}"
                 }
             ],
-            "temperature": 0.7,
+            "temperature": 0,
             "tools": [
                 {
                     "type": "function",
@@ -1111,14 +1061,13 @@
         }
     },
     {
-        "time": "2024-08-06T11:48:42.655187-04:00",
+        "time": "2024-08-23T12:02:25.167718-04:00",
         "callContext": {
-            "id": "call_df2WDMbaXZLMbH6MWT9my9fy",
+            "id": "call_seuQJWpcuIZGsE5ew0ulVoSm",
             "tool": {
                 "name": "summary",
                 "description": "Summarize a gpt file",
                 "modelName": "gpt-4o-2024-05-13",
-                "temperature": 0.7,
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -1155,236 +1104,20 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "summary",
-            "parentID": "1722959319"
-        },
-        "type": "callChat",
-        "chatCompletionId": "1722959323",
-        "usage": {
-            "promptTokens": 185,
-            "completionTokens": 21,
-            "totalTokens": 206
-        },
-        "chatResponse": {
-            "role": "assistant",
-            "content": [
-                {
-                    "toolCall": {
-                        "index": 0,
-                        "id": "call_0XHxMC4f3Zmnap6ZdO31mL46",
-                        "function": {
-                            "name": "read",
-                            "arguments": "{\"filename\":\"testdata/SamplesReadme/test.gpt\"}"
-                        }
-                    }
-                }
-            ],
-            "usage": {
-                "promptTokens": 185,
-                "completionTokens": 21,
-                "totalTokens": 206
-            }
-        }
-    },
-    {
-        "time": "2024-08-06T11:48:42.655319-04:00",
-        "callContext": {
-            "id": "call_df2WDMbaXZLMbH6MWT9my9fy",
-            "tool": {
-                "name": "summary",
-                "description": "Summarize a gpt file",
-                "modelName": "gpt-4o-2024-05-13",
-                "temperature": 0.7,
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "file": {
-                            "description": "filename to summarize",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "tools": [
-                    "sys.read"
-                ],
-                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
-                "id": "testdata/SamplesReadme/test.gpt:summary",
-                "toolMapping": {
-                    "sys.read": [
-                        {
-                            "reference": "sys.read",
-                            "toolID": "sys.read"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/SamplesReadme/test.gpt:",
-                    "summary": "testdata/SamplesReadme/test.gpt:summary"
-                },
-                "source": {
-                    "location": "testdata/SamplesReadme/test.gpt",
-                    "lineNo": 7
-                },
-                "workingDir": "testdata/SamplesReadme"
-            },
-            "currentAgent": {},
-            "inputContext": null,
-            "toolName": "summary",
-            "parentID": "1722959319"
-        },
-        "toolSubCalls": {
-            "call_0XHxMC4f3Zmnap6ZdO31mL46": {
-                "toolID": "sys.read",
-                "input": "{\"filename\":\"testdata/SamplesReadme/test.gpt\"}"
-            }
-        },
-        "type": "callSubCalls",
-        "usage": {}
-    },
-    {
-        "time": "2024-08-06T11:48:42.65546-04:00",
-        "callContext": {
-            "id": "call_0XHxMC4f3Zmnap6ZdO31mL46",
-            "tool": {
-                "name": "sys.read",
-                "description": "Reads the contents of a file",
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "filename": {
-                            "description": "The name of the file to read",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "instructions": "#!sys.read",
-                "id": "sys.read",
-                "source": {}
-            },
-            "currentAgent": {},
-            "inputContext": null,
-            "toolName": "sys.read",
-            "parentID": "call_df2WDMbaXZLMbH6MWT9my9fy",
-            "displayText": "Reading `testdata/SamplesReadme/test.gpt`"
+            "parentID": "1724428944"
         },
         "type": "callStart",
         "usage": {},
-        "content": "{\"filename\":\"testdata/SamplesReadme/test.gpt\"}"
+        "content": "{\"file\": \"testdata/SamplesReadme/test.gpt\"}"
     },
     {
-        "time": "2024-08-06T11:48:42.655635-04:00",
+        "time": "2024-08-23T12:02:25.169569-04:00",
         "callContext": {
-            "id": "call_0XHxMC4f3Zmnap6ZdO31mL46",
-            "tool": {
-                "name": "sys.read",
-                "description": "Reads the contents of a file",
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "filename": {
-                            "description": "The name of the file to read",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "instructions": "#!sys.read",
-                "id": "sys.read",
-                "source": {}
-            },
-            "currentAgent": {},
-            "inputContext": null,
-            "toolName": "sys.read",
-            "parentID": "call_df2WDMbaXZLMbH6MWT9my9fy",
-            "displayText": "Reading `testdata/SamplesReadme/test.gpt`"
-        },
-        "type": "callChat",
-        "chatCompletionId": "1722959326",
-        "usage": {},
-        "chatRequest": {
-            "model": "",
-            "messages": null
-        }
-    },
-    {
-        "time": "2024-08-06T11:48:42.655946-04:00",
-        "callContext": {
-            "id": "call_0XHxMC4f3Zmnap6ZdO31mL46",
-            "tool": {
-                "name": "sys.read",
-                "description": "Reads the contents of a file",
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "filename": {
-                            "description": "The name of the file to read",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "instructions": "#!sys.read",
-                "id": "sys.read",
-                "source": {}
-            },
-            "currentAgent": {},
-            "inputContext": null,
-            "toolName": "sys.read",
-            "parentID": "call_df2WDMbaXZLMbH6MWT9my9fy",
-            "displayText": "Reading `testdata/SamplesReadme/test.gpt`"
-        },
-        "type": "callChat",
-        "chatCompletionId": "1722959326",
-        "usage": {},
-        "chatResponse": {
-            "usage": {}
-        }
-    },
-    {
-        "time": "2024-08-06T11:48:42.656032-04:00",
-        "callContext": {
-            "id": "call_0XHxMC4f3Zmnap6ZdO31mL46",
-            "tool": {
-                "name": "sys.read",
-                "description": "Reads the contents of a file",
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "filename": {
-                            "description": "The name of the file to read",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "instructions": "#!sys.read",
-                "id": "sys.read",
-                "source": {}
-            },
-            "currentAgent": {},
-            "inputContext": null,
-            "toolName": "sys.read",
-            "parentID": "call_df2WDMbaXZLMbH6MWT9my9fy",
-            "displayText": "Reading `testdata/SamplesReadme/test.gpt`"
-        },
-        "type": "callFinish",
-        "usage": {},
-        "content": "tools: sys.find, summary\n\nGenerate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.\n\n---\nname: summary\ndescription: Summarize a gpt file\nargs: file: filename to summarize\ntools: sys.read\ntemperature: 0.7\n\nRead ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.\n"
-    },
-    {
-        "time": "2024-08-06T11:48:42.656128-04:00",
-        "callContext": {
-            "id": "call_df2WDMbaXZLMbH6MWT9my9fy",
+            "id": "call_seuQJWpcuIZGsE5ew0ulVoSm",
             "tool": {
                 "name": "summary",
                 "description": "Summarize a gpt file",
                 "modelName": "gpt-4o-2024-05-13",
-                "temperature": 0.7,
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -1421,61 +1154,10 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "summary",
-            "parentID": "1722959319"
-        },
-        "toolResults": 1,
-        "type": "callContinue",
-        "usage": {}
-    },
-    {
-        "time": "2024-08-06T11:48:42.656378-04:00",
-        "callContext": {
-            "id": "call_df2WDMbaXZLMbH6MWT9my9fy",
-            "tool": {
-                "name": "summary",
-                "description": "Summarize a gpt file",
-                "modelName": "gpt-4o-2024-05-13",
-                "temperature": 0.7,
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "file": {
-                            "description": "filename to summarize",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "tools": [
-                    "sys.read"
-                ],
-                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
-                "id": "testdata/SamplesReadme/test.gpt:summary",
-                "toolMapping": {
-                    "sys.read": [
-                        {
-                            "reference": "sys.read",
-                            "toolID": "sys.read"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/SamplesReadme/test.gpt:",
-                    "summary": "testdata/SamplesReadme/test.gpt:summary"
-                },
-                "source": {
-                    "location": "testdata/SamplesReadme/test.gpt",
-                    "lineNo": 7
-                },
-                "workingDir": "testdata/SamplesReadme"
-            },
-            "currentAgent": {},
-            "inputContext": null,
-            "toolName": "summary",
-            "parentID": "1722959319"
+            "parentID": "1724428944"
         },
         "type": "callChat",
-        "chatCompletionId": "1722959327",
+        "chatCompletionId": "1724428950",
         "usage": {},
         "chatRequest": {
             "model": "gpt-4o-2024-05-13",
@@ -1487,29 +1169,9 @@
                 {
                     "role": "user",
                     "content": "{\"file\": \"testdata/SamplesReadme/test.gpt\"}"
-                },
-                {
-                    "role": "assistant",
-                    "content": "",
-                    "tool_calls": [
-                        {
-                            "id": "call_0XHxMC4f3Zmnap6ZdO31mL46",
-                            "type": "function",
-                            "function": {
-                                "name": "read",
-                                "arguments": "{\"filename\":\"testdata/SamplesReadme/test.gpt\"}"
-                            }
-                        }
-                    ]
-                },
-                {
-                    "role": "tool",
-                    "content": "tools: sys.find, summary\n\nGenerate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.\n\n---\nname: summary\ndescription: Summarize a gpt file\nargs: file: filename to summarize\ntools: sys.read\ntemperature: 0.7\n\nRead ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.\n",
-                    "name": "read",
-                    "tool_call_id": "call_0XHxMC4f3Zmnap6ZdO31mL46"
                 }
             ],
-            "temperature": 0.7,
+            "temperature": 0,
             "tools": [
                 {
                     "type": "function",
@@ -1531,14 +1193,13 @@
         }
     },
     {
-        "time": "2024-08-06T11:48:42.692262-04:00",
+        "time": "2024-08-23T12:02:25.601313-04:00",
         "callContext": {
-            "id": "call_QW4r1m85pmK7aqYudiIo2CcY",
+            "id": "call_v4fxPCcLKdcJso5SK8EEvv7g",
             "tool": {
                 "name": "summary",
                 "description": "Summarize a gpt file",
                 "modelName": "gpt-4o-2024-05-13",
-                "temperature": 0.7,
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -1575,549 +1236,10 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "summary",
-            "parentID": "1722959319"
+            "parentID": "1724428944"
         },
         "type": "callChat",
-        "chatCompletionId": "1722959325",
-        "usage": {
-            "promptTokens": 185,
-            "completionTokens": 21,
-            "totalTokens": 206
-        },
-        "chatResponse": {
-            "role": "assistant",
-            "content": [
-                {
-                    "toolCall": {
-                        "index": 0,
-                        "id": "call_yxddr1hEZCeKvwY7xiU4Rir9",
-                        "function": {
-                            "name": "read",
-                            "arguments": "{\"filename\":\"testdata/BobAsShell/test.gpt\"}"
-                        }
-                    }
-                }
-            ],
-            "usage": {
-                "promptTokens": 185,
-                "completionTokens": 21,
-                "totalTokens": 206
-            }
-        }
-    },
-    {
-        "time": "2024-08-06T11:48:42.692355-04:00",
-        "callContext": {
-            "id": "call_QW4r1m85pmK7aqYudiIo2CcY",
-            "tool": {
-                "name": "summary",
-                "description": "Summarize a gpt file",
-                "modelName": "gpt-4o-2024-05-13",
-                "temperature": 0.7,
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "file": {
-                            "description": "filename to summarize",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "tools": [
-                    "sys.read"
-                ],
-                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
-                "id": "testdata/SamplesReadme/test.gpt:summary",
-                "toolMapping": {
-                    "sys.read": [
-                        {
-                            "reference": "sys.read",
-                            "toolID": "sys.read"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/SamplesReadme/test.gpt:",
-                    "summary": "testdata/SamplesReadme/test.gpt:summary"
-                },
-                "source": {
-                    "location": "testdata/SamplesReadme/test.gpt",
-                    "lineNo": 7
-                },
-                "workingDir": "testdata/SamplesReadme"
-            },
-            "currentAgent": {},
-            "inputContext": null,
-            "toolName": "summary",
-            "parentID": "1722959319"
-        },
-        "toolSubCalls": {
-            "call_yxddr1hEZCeKvwY7xiU4Rir9": {
-                "toolID": "sys.read",
-                "input": "{\"filename\":\"testdata/BobAsShell/test.gpt\"}"
-            }
-        },
-        "type": "callSubCalls",
-        "usage": {}
-    },
-    {
-        "time": "2024-08-06T11:48:42.692465-04:00",
-        "callContext": {
-            "id": "call_yxddr1hEZCeKvwY7xiU4Rir9",
-            "tool": {
-                "name": "sys.read",
-                "description": "Reads the contents of a file",
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "filename": {
-                            "description": "The name of the file to read",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "instructions": "#!sys.read",
-                "id": "sys.read",
-                "source": {}
-            },
-            "currentAgent": {},
-            "inputContext": null,
-            "toolName": "sys.read",
-            "parentID": "call_QW4r1m85pmK7aqYudiIo2CcY",
-            "displayText": "Reading `testdata/BobAsShell/test.gpt`"
-        },
-        "type": "callStart",
-        "usage": {},
-        "content": "{\"filename\":\"testdata/BobAsShell/test.gpt\"}"
-    },
-    {
-        "time": "2024-08-06T11:48:42.69261-04:00",
-        "callContext": {
-            "id": "call_yxddr1hEZCeKvwY7xiU4Rir9",
-            "tool": {
-                "name": "sys.read",
-                "description": "Reads the contents of a file",
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "filename": {
-                            "description": "The name of the file to read",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "instructions": "#!sys.read",
-                "id": "sys.read",
-                "source": {}
-            },
-            "currentAgent": {},
-            "inputContext": null,
-            "toolName": "sys.read",
-            "parentID": "call_QW4r1m85pmK7aqYudiIo2CcY",
-            "displayText": "Reading `testdata/BobAsShell/test.gpt`"
-        },
-        "type": "callChat",
-        "chatCompletionId": "1722959328",
-        "usage": {},
-        "chatRequest": {
-            "model": "",
-            "messages": null
-        }
-    },
-    {
-        "time": "2024-08-06T11:48:42.692928-04:00",
-        "callContext": {
-            "id": "call_yxddr1hEZCeKvwY7xiU4Rir9",
-            "tool": {
-                "name": "sys.read",
-                "description": "Reads the contents of a file",
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "filename": {
-                            "description": "The name of the file to read",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "instructions": "#!sys.read",
-                "id": "sys.read",
-                "source": {}
-            },
-            "currentAgent": {},
-            "inputContext": null,
-            "toolName": "sys.read",
-            "parentID": "call_QW4r1m85pmK7aqYudiIo2CcY",
-            "displayText": "Reading `testdata/BobAsShell/test.gpt`"
-        },
-        "type": "callChat",
-        "chatCompletionId": "1722959328",
-        "usage": {},
-        "chatResponse": {
-            "usage": {}
-        }
-    },
-    {
-        "time": "2024-08-06T11:48:42.69301-04:00",
-        "callContext": {
-            "id": "call_yxddr1hEZCeKvwY7xiU4Rir9",
-            "tool": {
-                "name": "sys.read",
-                "description": "Reads the contents of a file",
-                "modelName": "gpt-4o-2024-05-13",
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "filename": {
-                            "description": "The name of the file to read",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "instructions": "#!sys.read",
-                "id": "sys.read",
-                "source": {}
-            },
-            "currentAgent": {},
-            "inputContext": null,
-            "toolName": "sys.read",
-            "parentID": "call_QW4r1m85pmK7aqYudiIo2CcY",
-            "displayText": "Reading `testdata/BobAsShell/test.gpt`"
-        },
-        "type": "callFinish",
-        "usage": {},
-        "content": "\ntools: bob\n\nAsk Bob \"how are you doing\" and repeat his reply exactly.\n\n---\nname: bob\ndescription: I'm Bob, a friendly guy.\nargs: question: The question to ask Bob.\n\n#!/bin/bash\n\necho \"Thanks for asking ${question}, I'm doing great fellow friendly AI tool!\"\n"
-    },
-    {
-        "time": "2024-08-06T11:48:42.693067-04:00",
-        "callContext": {
-            "id": "call_QW4r1m85pmK7aqYudiIo2CcY",
-            "tool": {
-                "name": "summary",
-                "description": "Summarize a gpt file",
-                "modelName": "gpt-4o-2024-05-13",
-                "temperature": 0.7,
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "file": {
-                            "description": "filename to summarize",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "tools": [
-                    "sys.read"
-                ],
-                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
-                "id": "testdata/SamplesReadme/test.gpt:summary",
-                "toolMapping": {
-                    "sys.read": [
-                        {
-                            "reference": "sys.read",
-                            "toolID": "sys.read"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/SamplesReadme/test.gpt:",
-                    "summary": "testdata/SamplesReadme/test.gpt:summary"
-                },
-                "source": {
-                    "location": "testdata/SamplesReadme/test.gpt",
-                    "lineNo": 7
-                },
-                "workingDir": "testdata/SamplesReadme"
-            },
-            "currentAgent": {},
-            "inputContext": null,
-            "toolName": "summary",
-            "parentID": "1722959319"
-        },
-        "toolResults": 1,
-        "type": "callContinue",
-        "usage": {}
-    },
-    {
-        "time": "2024-08-06T11:48:42.693171-04:00",
-        "callContext": {
-            "id": "call_QW4r1m85pmK7aqYudiIo2CcY",
-            "tool": {
-                "name": "summary",
-                "description": "Summarize a gpt file",
-                "modelName": "gpt-4o-2024-05-13",
-                "temperature": 0.7,
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "file": {
-                            "description": "filename to summarize",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "tools": [
-                    "sys.read"
-                ],
-                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
-                "id": "testdata/SamplesReadme/test.gpt:summary",
-                "toolMapping": {
-                    "sys.read": [
-                        {
-                            "reference": "sys.read",
-                            "toolID": "sys.read"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/SamplesReadme/test.gpt:",
-                    "summary": "testdata/SamplesReadme/test.gpt:summary"
-                },
-                "source": {
-                    "location": "testdata/SamplesReadme/test.gpt",
-                    "lineNo": 7
-                },
-                "workingDir": "testdata/SamplesReadme"
-            },
-            "currentAgent": {},
-            "inputContext": null,
-            "toolName": "summary",
-            "parentID": "1722959319"
-        },
-        "type": "callChat",
-        "chatCompletionId": "1722959329",
-        "usage": {},
-        "chatRequest": {
-            "model": "gpt-4o-2024-05-13",
-            "messages": [
-                {
-                    "role": "system",
-                    "content": "\nYou are task oriented system.\nYou receive input from a user, process the input from the given instructions, and then output the result.\nYour objective is to provide consistent and correct results.\nYou do not need to explain the steps taken, only provide the result to the given instructions.\nYou are referred to as a tool.\nYou don't move to the next step until you have a result.\n\nRead ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate."
-                },
-                {
-                    "role": "user",
-                    "content": "{\"file\": \"testdata/BobAsShell/test.gpt\"}"
-                },
-                {
-                    "role": "assistant",
-                    "content": "",
-                    "tool_calls": [
-                        {
-                            "id": "call_yxddr1hEZCeKvwY7xiU4Rir9",
-                            "type": "function",
-                            "function": {
-                                "name": "read",
-                                "arguments": "{\"filename\":\"testdata/BobAsShell/test.gpt\"}"
-                            }
-                        }
-                    ]
-                },
-                {
-                    "role": "tool",
-                    "content": "\ntools: bob\n\nAsk Bob \"how are you doing\" and repeat his reply exactly.\n\n---\nname: bob\ndescription: I'm Bob, a friendly guy.\nargs: question: The question to ask Bob.\n\n#!/bin/bash\n\necho \"Thanks for asking ${question}, I'm doing great fellow friendly AI tool!\"\n",
-                    "name": "read",
-                    "tool_call_id": "call_yxddr1hEZCeKvwY7xiU4Rir9"
-                }
-            ],
-            "temperature": 0.7,
-            "tools": [
-                {
-                    "type": "function",
-                    "function": {
-                        "name": "read",
-                        "description": "Reads the contents of a file",
-                        "parameters": {
-                            "properties": {
-                                "filename": {
-                                    "description": "The name of the file to read",
-                                    "type": "string"
-                                }
-                            },
-                            "type": "object"
-                        }
-                    }
-                }
-            ]
-        }
-    },
-    {
-        "time": "2024-08-06T11:48:44.050796-04:00",
-        "callContext": {
-            "id": "call_QW4r1m85pmK7aqYudiIo2CcY",
-            "tool": {
-                "name": "summary",
-                "description": "Summarize a gpt file",
-                "modelName": "gpt-4o-2024-05-13",
-                "temperature": 0.7,
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "file": {
-                            "description": "filename to summarize",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "tools": [
-                    "sys.read"
-                ],
-                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
-                "id": "testdata/SamplesReadme/test.gpt:summary",
-                "toolMapping": {
-                    "sys.read": [
-                        {
-                            "reference": "sys.read",
-                            "toolID": "sys.read"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/SamplesReadme/test.gpt:",
-                    "summary": "testdata/SamplesReadme/test.gpt:summary"
-                },
-                "source": {
-                    "location": "testdata/SamplesReadme/test.gpt",
-                    "lineNo": 7
-                },
-                "workingDir": "testdata/SamplesReadme"
-            },
-            "currentAgent": {},
-            "inputContext": null,
-            "toolName": "summary",
-            "parentID": "1722959319"
-        },
-        "type": "callChat",
-        "chatCompletionId": "1722959329",
-        "usage": {
-            "promptTokens": 276,
-            "completionTokens": 60,
-            "totalTokens": 336
-        },
-        "chatResponse": {
-            "role": "assistant",
-            "content": [
-                {
-                    "text": "The GPTScript file demonstrates how to use a tool named \"bob\" to ask a question (\"how are you doing\") and repeat Bob's reply exactly. The technique shown includes defining the tool's name, description, and arguments, followed by a script that echoes a response using the provided question."
-                }
-            ],
-            "usage": {
-                "promptTokens": 276,
-                "completionTokens": 60,
-                "totalTokens": 336
-            }
-        }
-    },
-    {
-        "time": "2024-08-06T11:48:44.050886-04:00",
-        "callContext": {
-            "id": "call_QW4r1m85pmK7aqYudiIo2CcY",
-            "tool": {
-                "name": "summary",
-                "description": "Summarize a gpt file",
-                "modelName": "gpt-4o-2024-05-13",
-                "temperature": 0.7,
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "file": {
-                            "description": "filename to summarize",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "tools": [
-                    "sys.read"
-                ],
-                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
-                "id": "testdata/SamplesReadme/test.gpt:summary",
-                "toolMapping": {
-                    "sys.read": [
-                        {
-                            "reference": "sys.read",
-                            "toolID": "sys.read"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/SamplesReadme/test.gpt:",
-                    "summary": "testdata/SamplesReadme/test.gpt:summary"
-                },
-                "source": {
-                    "location": "testdata/SamplesReadme/test.gpt",
-                    "lineNo": 7
-                },
-                "workingDir": "testdata/SamplesReadme"
-            },
-            "currentAgent": {},
-            "inputContext": null,
-            "toolName": "summary",
-            "parentID": "1722959319"
-        },
-        "type": "callFinish",
-        "usage": {},
-        "content": "The GPTScript file demonstrates how to use a tool named \"bob\" to ask a question (\"how are you doing\") and repeat Bob's reply exactly. The technique shown includes defining the tool's name, description, and arguments, followed by a script that echoes a response using the provided question."
-    },
-    {
-        "time": "2024-08-06T11:48:44.451695-04:00",
-        "callContext": {
-            "id": "call_B31GmzDYcNLo0yYUAyG8dYPA",
-            "tool": {
-                "name": "summary",
-                "description": "Summarize a gpt file",
-                "modelName": "gpt-4o-2024-05-13",
-                "temperature": 0.7,
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "file": {
-                            "description": "filename to summarize",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "tools": [
-                    "sys.read"
-                ],
-                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
-                "id": "testdata/SamplesReadme/test.gpt:summary",
-                "toolMapping": {
-                    "sys.read": [
-                        {
-                            "reference": "sys.read",
-                            "toolID": "sys.read"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/SamplesReadme/test.gpt:",
-                    "summary": "testdata/SamplesReadme/test.gpt:summary"
-                },
-                "source": {
-                    "location": "testdata/SamplesReadme/test.gpt",
-                    "lineNo": 7
-                },
-                "workingDir": "testdata/SamplesReadme"
-            },
-            "currentAgent": {},
-            "inputContext": null,
-            "toolName": "summary",
-            "parentID": "1722959319"
-        },
-        "type": "callChat",
-        "chatCompletionId": "1722959324",
+        "chatCompletionId": "1724428948",
         "usage": {
             "promptTokens": 183,
             "completionTokens": 19,
@@ -2129,7 +1251,7 @@
                 {
                     "toolCall": {
                         "index": 0,
-                        "id": "call_H9rxnlV9BmlZnIvKTWqMyF9m",
+                        "id": "call_1sEbslNFIGGsFjneY5oaALAY",
                         "function": {
                             "name": "read",
                             "arguments": "{\"filename\":\"testdata/Bob/test.gpt\"}"
@@ -2145,14 +1267,13 @@
         }
     },
     {
-        "time": "2024-08-06T11:48:44.451837-04:00",
+        "time": "2024-08-23T12:02:25.601452-04:00",
         "callContext": {
-            "id": "call_B31GmzDYcNLo0yYUAyG8dYPA",
+            "id": "call_v4fxPCcLKdcJso5SK8EEvv7g",
             "tool": {
                 "name": "summary",
                 "description": "Summarize a gpt file",
                 "modelName": "gpt-4o-2024-05-13",
-                "temperature": 0.7,
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -2189,10 +1310,10 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "summary",
-            "parentID": "1722959319"
+            "parentID": "1724428944"
         },
         "toolSubCalls": {
-            "call_H9rxnlV9BmlZnIvKTWqMyF9m": {
+            "call_1sEbslNFIGGsFjneY5oaALAY": {
                 "toolID": "sys.read",
                 "input": "{\"filename\":\"testdata/Bob/test.gpt\"}"
             }
@@ -2201,9 +1322,9 @@
         "usage": {}
     },
     {
-        "time": "2024-08-06T11:48:44.452024-04:00",
+        "time": "2024-08-23T12:02:25.60158-04:00",
         "callContext": {
-            "id": "call_H9rxnlV9BmlZnIvKTWqMyF9m",
+            "id": "call_1sEbslNFIGGsFjneY5oaALAY",
             "tool": {
                 "name": "sys.read",
                 "description": "Reads the contents of a file",
@@ -2225,7 +1346,7 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "sys.read",
-            "parentID": "call_B31GmzDYcNLo0yYUAyG8dYPA",
+            "parentID": "call_v4fxPCcLKdcJso5SK8EEvv7g",
             "displayText": "Reading `testdata/Bob/test.gpt`"
         },
         "type": "callStart",
@@ -2233,9 +1354,9 @@
         "content": "{\"filename\":\"testdata/Bob/test.gpt\"}"
     },
     {
-        "time": "2024-08-06T11:48:44.452301-04:00",
+        "time": "2024-08-23T12:02:25.601748-04:00",
         "callContext": {
-            "id": "call_H9rxnlV9BmlZnIvKTWqMyF9m",
+            "id": "call_1sEbslNFIGGsFjneY5oaALAY",
             "tool": {
                 "name": "sys.read",
                 "description": "Reads the contents of a file",
@@ -2257,11 +1378,11 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "sys.read",
-            "parentID": "call_B31GmzDYcNLo0yYUAyG8dYPA",
+            "parentID": "call_v4fxPCcLKdcJso5SK8EEvv7g",
             "displayText": "Reading `testdata/Bob/test.gpt`"
         },
         "type": "callChat",
-        "chatCompletionId": "1722959330",
+        "chatCompletionId": "1724428951",
         "usage": {},
         "chatRequest": {
             "model": "",
@@ -2269,9 +1390,9 @@
         }
     },
     {
-        "time": "2024-08-06T11:48:44.452619-04:00",
+        "time": "2024-08-23T12:02:25.601944-04:00",
         "callContext": {
-            "id": "call_H9rxnlV9BmlZnIvKTWqMyF9m",
+            "id": "call_1sEbslNFIGGsFjneY5oaALAY",
             "tool": {
                 "name": "sys.read",
                 "description": "Reads the contents of a file",
@@ -2293,20 +1414,20 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "sys.read",
-            "parentID": "call_B31GmzDYcNLo0yYUAyG8dYPA",
+            "parentID": "call_v4fxPCcLKdcJso5SK8EEvv7g",
             "displayText": "Reading `testdata/Bob/test.gpt`"
         },
         "type": "callChat",
-        "chatCompletionId": "1722959330",
+        "chatCompletionId": "1724428951",
         "usage": {},
         "chatResponse": {
             "usage": {}
         }
     },
     {
-        "time": "2024-08-06T11:48:44.452723-04:00",
+        "time": "2024-08-23T12:02:25.60203-04:00",
         "callContext": {
-            "id": "call_H9rxnlV9BmlZnIvKTWqMyF9m",
+            "id": "call_1sEbslNFIGGsFjneY5oaALAY",
             "tool": {
                 "name": "sys.read",
                 "description": "Reads the contents of a file",
@@ -2328,22 +1449,21 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "sys.read",
-            "parentID": "call_B31GmzDYcNLo0yYUAyG8dYPA",
+            "parentID": "call_v4fxPCcLKdcJso5SK8EEvv7g",
             "displayText": "Reading `testdata/Bob/test.gpt`"
         },
         "type": "callFinish",
         "usage": {},
-        "content": "tools: bob\n\nAsk Bob \"how are you doing\" and repeat his reply exactly.\n\n---\nname: bob\ndescription: I'm Bob, a friendly guy.\nargs: question: The question to ask Bob.\n\nWhen asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"\n"
+        "content": "tools: bob\n\nAsk Bob \"how are you doing\" and repeat his reply exactly.\n\n---\nname: bob\ndescription: I'm Bob, a friendly guy.\nargs: question: The question to ask Bob.\n\nWhen asked how I am doing, respond with exactly \"Thanks for asking \"${QUESTION}\", I'm doing great fellow friendly AI tool!\"\n"
     },
     {
-        "time": "2024-08-06T11:48:44.452831-04:00",
+        "time": "2024-08-23T12:02:25.602117-04:00",
         "callContext": {
-            "id": "call_B31GmzDYcNLo0yYUAyG8dYPA",
+            "id": "call_v4fxPCcLKdcJso5SK8EEvv7g",
             "tool": {
                 "name": "summary",
                 "description": "Summarize a gpt file",
                 "modelName": "gpt-4o-2024-05-13",
-                "temperature": 0.7,
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -2380,21 +1500,20 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "summary",
-            "parentID": "1722959319"
+            "parentID": "1724428944"
         },
         "toolResults": 1,
         "type": "callContinue",
         "usage": {}
     },
     {
-        "time": "2024-08-06T11:48:44.452934-04:00",
+        "time": "2024-08-23T12:02:25.602221-04:00",
         "callContext": {
-            "id": "call_B31GmzDYcNLo0yYUAyG8dYPA",
+            "id": "call_v4fxPCcLKdcJso5SK8EEvv7g",
             "tool": {
                 "name": "summary",
                 "description": "Summarize a gpt file",
                 "modelName": "gpt-4o-2024-05-13",
-                "temperature": 0.7,
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -2431,10 +1550,10 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "summary",
-            "parentID": "1722959319"
+            "parentID": "1724428944"
         },
         "type": "callChat",
-        "chatCompletionId": "1722959331",
+        "chatCompletionId": "1724428952",
         "usage": {},
         "chatRequest": {
             "model": "gpt-4o-2024-05-13",
@@ -2452,7 +1571,7 @@
                     "content": "",
                     "tool_calls": [
                         {
-                            "id": "call_H9rxnlV9BmlZnIvKTWqMyF9m",
+                            "id": "call_1sEbslNFIGGsFjneY5oaALAY",
                             "type": "function",
                             "function": {
                                 "name": "read",
@@ -2463,12 +1582,12 @@
                 },
                 {
                     "role": "tool",
-                    "content": "tools: bob\n\nAsk Bob \"how are you doing\" and repeat his reply exactly.\n\n---\nname: bob\ndescription: I'm Bob, a friendly guy.\nargs: question: The question to ask Bob.\n\nWhen asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"\n",
+                    "content": "tools: bob\n\nAsk Bob \"how are you doing\" and repeat his reply exactly.\n\n---\nname: bob\ndescription: I'm Bob, a friendly guy.\nargs: question: The question to ask Bob.\n\nWhen asked how I am doing, respond with exactly \"Thanks for asking \"${QUESTION}\", I'm doing great fellow friendly AI tool!\"\n",
                     "name": "read",
-                    "tool_call_id": "call_H9rxnlV9BmlZnIvKTWqMyF9m"
+                    "tool_call_id": "call_1sEbslNFIGGsFjneY5oaALAY"
                 }
             ],
-            "temperature": 0.7,
+            "temperature": 0,
             "tools": [
                 {
                     "type": "function",
@@ -2490,14 +1609,13 @@
         }
     },
     {
-        "time": "2024-08-06T11:48:45.690878-04:00",
+        "time": "2024-08-23T12:02:25.71099-04:00",
         "callContext": {
-            "id": "call_B31GmzDYcNLo0yYUAyG8dYPA",
+            "id": "call_WxYHM2C2LYqefe0dnDZveAgk",
             "tool": {
                 "name": "summary",
                 "description": "Summarize a gpt file",
                 "modelName": "gpt-4o-2024-05-13",
-                "temperature": 0.7,
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -2534,38 +1652,869 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "summary",
-            "parentID": "1722959319"
+            "parentID": "1724428944"
         },
         "type": "callChat",
-        "chatCompletionId": "1722959331",
+        "chatCompletionId": "1724428949",
         "usage": {
-            "promptTokens": 276,
-            "completionTokens": 69,
-            "totalTokens": 345
+            "promptTokens": 185,
+            "completionTokens": 21,
+            "totalTokens": 206
         },
         "chatResponse": {
             "role": "assistant",
             "content": [
                 {
-                    "text": "The GPTScript file contains a script for interacting with a tool named \"Bob.\" The script demonstrates the technique of asking \"Bob\" a question, specifically \"how are you doing,\" and then repeating his reply exactly. Bob's response is predefined to be \"Thanks for asking 'how are you doing', I'm doing great fellow friendly AI tool!\""
+                    "toolCall": {
+                        "index": 0,
+                        "id": "call_1OSzBaMt9BrCjlaUGhIaBuGB",
+                        "function": {
+                            "name": "read",
+                            "arguments": "{\"filename\":\"testdata/BobAsShell/test.gpt\"}"
+                        }
+                    }
+                }
+            ],
+            "usage": {
+                "promptTokens": 185,
+                "completionTokens": 21,
+                "totalTokens": 206
+            }
+        }
+    },
+    {
+        "time": "2024-08-23T12:02:25.711128-04:00",
+        "callContext": {
+            "id": "call_WxYHM2C2LYqefe0dnDZveAgk",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "gpt-4o-2024-05-13",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1724428944"
+        },
+        "toolSubCalls": {
+            "call_1OSzBaMt9BrCjlaUGhIaBuGB": {
+                "toolID": "sys.read",
+                "input": "{\"filename\":\"testdata/BobAsShell/test.gpt\"}"
+            }
+        },
+        "type": "callSubCalls",
+        "usage": {}
+    },
+    {
+        "time": "2024-08-23T12:02:25.711437-04:00",
+        "callContext": {
+            "id": "call_1OSzBaMt9BrCjlaUGhIaBuGB",
+            "tool": {
+                "name": "sys.read",
+                "description": "Reads the contents of a file",
+                "modelName": "gpt-4o-2024-05-13",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "filename": {
+                            "description": "The name of the file to read",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "instructions": "#!sys.read",
+                "id": "sys.read",
+                "source": {}
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "sys.read",
+            "parentID": "call_WxYHM2C2LYqefe0dnDZveAgk",
+            "displayText": "Reading `testdata/BobAsShell/test.gpt`"
+        },
+        "type": "callStart",
+        "usage": {},
+        "content": "{\"filename\":\"testdata/BobAsShell/test.gpt\"}"
+    },
+    {
+        "time": "2024-08-23T12:02:25.711886-04:00",
+        "callContext": {
+            "id": "call_1OSzBaMt9BrCjlaUGhIaBuGB",
+            "tool": {
+                "name": "sys.read",
+                "description": "Reads the contents of a file",
+                "modelName": "gpt-4o-2024-05-13",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "filename": {
+                            "description": "The name of the file to read",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "instructions": "#!sys.read",
+                "id": "sys.read",
+                "source": {}
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "sys.read",
+            "parentID": "call_WxYHM2C2LYqefe0dnDZveAgk",
+            "displayText": "Reading `testdata/BobAsShell/test.gpt`"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1724428953",
+        "usage": {},
+        "chatRequest": {
+            "model": "",
+            "messages": null
+        }
+    },
+    {
+        "time": "2024-08-23T12:02:25.712128-04:00",
+        "callContext": {
+            "id": "call_1OSzBaMt9BrCjlaUGhIaBuGB",
+            "tool": {
+                "name": "sys.read",
+                "description": "Reads the contents of a file",
+                "modelName": "gpt-4o-2024-05-13",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "filename": {
+                            "description": "The name of the file to read",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "instructions": "#!sys.read",
+                "id": "sys.read",
+                "source": {}
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "sys.read",
+            "parentID": "call_WxYHM2C2LYqefe0dnDZveAgk",
+            "displayText": "Reading `testdata/BobAsShell/test.gpt`"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1724428953",
+        "usage": {},
+        "chatResponse": {
+            "usage": {}
+        }
+    },
+    {
+        "time": "2024-08-23T12:02:25.712234-04:00",
+        "callContext": {
+            "id": "call_1OSzBaMt9BrCjlaUGhIaBuGB",
+            "tool": {
+                "name": "sys.read",
+                "description": "Reads the contents of a file",
+                "modelName": "gpt-4o-2024-05-13",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "filename": {
+                            "description": "The name of the file to read",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "instructions": "#!sys.read",
+                "id": "sys.read",
+                "source": {}
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "sys.read",
+            "parentID": "call_WxYHM2C2LYqefe0dnDZveAgk",
+            "displayText": "Reading `testdata/BobAsShell/test.gpt`"
+        },
+        "type": "callFinish",
+        "usage": {},
+        "content": "\ntools: bob\n\nAsk Bob \"how are you doing\" and repeat his reply exactly.\n\n---\nname: bob\ndescription: I'm Bob, a friendly guy.\nargs: question: The question to ask Bob.\n\n#!/bin/bash\n\necho \"Thanks for asking ${QUESTION}, I'm doing great fellow friendly AI tool!\"\n"
+    },
+    {
+        "time": "2024-08-23T12:02:25.71233-04:00",
+        "callContext": {
+            "id": "call_WxYHM2C2LYqefe0dnDZveAgk",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "gpt-4o-2024-05-13",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1724428944"
+        },
+        "toolResults": 1,
+        "type": "callContinue",
+        "usage": {}
+    },
+    {
+        "time": "2024-08-23T12:02:25.712451-04:00",
+        "callContext": {
+            "id": "call_WxYHM2C2LYqefe0dnDZveAgk",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "gpt-4o-2024-05-13",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1724428944"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1724428954",
+        "usage": {},
+        "chatRequest": {
+            "model": "gpt-4o-2024-05-13",
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "\nYou are task oriented system.\nYou receive input from a user, process the input from the given instructions, and then output the result.\nYour objective is to provide consistent and correct results.\nYou do not need to explain the steps taken, only provide the result to the given instructions.\nYou are referred to as a tool.\nYou don't move to the next step until you have a result.\n\nRead ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate."
+                },
+                {
+                    "role": "user",
+                    "content": "{\"file\": \"testdata/BobAsShell/test.gpt\"}"
+                },
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "call_1OSzBaMt9BrCjlaUGhIaBuGB",
+                            "type": "function",
+                            "function": {
+                                "name": "read",
+                                "arguments": "{\"filename\":\"testdata/BobAsShell/test.gpt\"}"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "role": "tool",
+                    "content": "\ntools: bob\n\nAsk Bob \"how are you doing\" and repeat his reply exactly.\n\n---\nname: bob\ndescription: I'm Bob, a friendly guy.\nargs: question: The question to ask Bob.\n\n#!/bin/bash\n\necho \"Thanks for asking ${QUESTION}, I'm doing great fellow friendly AI tool!\"\n",
+                    "name": "read",
+                    "tool_call_id": "call_1OSzBaMt9BrCjlaUGhIaBuGB"
+                }
+            ],
+            "temperature": 0,
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "read",
+                        "description": "Reads the contents of a file",
+                        "parameters": {
+                            "properties": {
+                                "filename": {
+                                    "description": "The name of the file to read",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    {
+        "time": "2024-08-23T12:02:25.79254-04:00",
+        "callContext": {
+            "id": "call_seuQJWpcuIZGsE5ew0ulVoSm",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "gpt-4o-2024-05-13",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1724428944"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1724428950",
+        "usage": {
+            "promptTokens": 185,
+            "completionTokens": 21,
+            "totalTokens": 206
+        },
+        "chatResponse": {
+            "role": "assistant",
+            "content": [
+                {
+                    "toolCall": {
+                        "index": 0,
+                        "id": "call_q1xLoCIcZFGfoYI0r4XwkV0h",
+                        "function": {
+                            "name": "read",
+                            "arguments": "{\"filename\":\"testdata/SamplesReadme/test.gpt\"}"
+                        }
+                    }
+                }
+            ],
+            "usage": {
+                "promptTokens": 185,
+                "completionTokens": 21,
+                "totalTokens": 206
+            }
+        }
+    },
+    {
+        "time": "2024-08-23T12:02:25.792662-04:00",
+        "callContext": {
+            "id": "call_seuQJWpcuIZGsE5ew0ulVoSm",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "gpt-4o-2024-05-13",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1724428944"
+        },
+        "toolSubCalls": {
+            "call_q1xLoCIcZFGfoYI0r4XwkV0h": {
+                "toolID": "sys.read",
+                "input": "{\"filename\":\"testdata/SamplesReadme/test.gpt\"}"
+            }
+        },
+        "type": "callSubCalls",
+        "usage": {}
+    },
+    {
+        "time": "2024-08-23T12:02:25.792781-04:00",
+        "callContext": {
+            "id": "call_q1xLoCIcZFGfoYI0r4XwkV0h",
+            "tool": {
+                "name": "sys.read",
+                "description": "Reads the contents of a file",
+                "modelName": "gpt-4o-2024-05-13",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "filename": {
+                            "description": "The name of the file to read",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "instructions": "#!sys.read",
+                "id": "sys.read",
+                "source": {}
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "sys.read",
+            "parentID": "call_seuQJWpcuIZGsE5ew0ulVoSm",
+            "displayText": "Reading `testdata/SamplesReadme/test.gpt`"
+        },
+        "type": "callStart",
+        "usage": {},
+        "content": "{\"filename\":\"testdata/SamplesReadme/test.gpt\"}"
+    },
+    {
+        "time": "2024-08-23T12:02:25.792972-04:00",
+        "callContext": {
+            "id": "call_q1xLoCIcZFGfoYI0r4XwkV0h",
+            "tool": {
+                "name": "sys.read",
+                "description": "Reads the contents of a file",
+                "modelName": "gpt-4o-2024-05-13",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "filename": {
+                            "description": "The name of the file to read",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "instructions": "#!sys.read",
+                "id": "sys.read",
+                "source": {}
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "sys.read",
+            "parentID": "call_seuQJWpcuIZGsE5ew0ulVoSm",
+            "displayText": "Reading `testdata/SamplesReadme/test.gpt`"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1724428955",
+        "usage": {},
+        "chatRequest": {
+            "model": "",
+            "messages": null
+        }
+    },
+    {
+        "time": "2024-08-23T12:02:25.793171-04:00",
+        "callContext": {
+            "id": "call_q1xLoCIcZFGfoYI0r4XwkV0h",
+            "tool": {
+                "name": "sys.read",
+                "description": "Reads the contents of a file",
+                "modelName": "gpt-4o-2024-05-13",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "filename": {
+                            "description": "The name of the file to read",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "instructions": "#!sys.read",
+                "id": "sys.read",
+                "source": {}
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "sys.read",
+            "parentID": "call_seuQJWpcuIZGsE5ew0ulVoSm",
+            "displayText": "Reading `testdata/SamplesReadme/test.gpt`"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1724428955",
+        "usage": {},
+        "chatResponse": {
+            "usage": {}
+        }
+    },
+    {
+        "time": "2024-08-23T12:02:25.79325-04:00",
+        "callContext": {
+            "id": "call_q1xLoCIcZFGfoYI0r4XwkV0h",
+            "tool": {
+                "name": "sys.read",
+                "description": "Reads the contents of a file",
+                "modelName": "gpt-4o-2024-05-13",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "filename": {
+                            "description": "The name of the file to read",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "instructions": "#!sys.read",
+                "id": "sys.read",
+                "source": {}
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "sys.read",
+            "parentID": "call_seuQJWpcuIZGsE5ew0ulVoSm",
+            "displayText": "Reading `testdata/SamplesReadme/test.gpt`"
+        },
+        "type": "callFinish",
+        "usage": {},
+        "content": "tools: sys.find, sys.read, summary\n\nGenerate a readme that gives a consolidated summary of each *.gpt file in the testdata directory.\nEach entry should be a include a link to the referenced file.\n\n---\nname: summary\ndescription: Summarize a gpt file\nargs: file: filename to summarize\ntools: sys.read\n\nRead ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.\n"
+    },
+    {
+        "time": "2024-08-23T12:02:25.79333-04:00",
+        "callContext": {
+            "id": "call_seuQJWpcuIZGsE5ew0ulVoSm",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "gpt-4o-2024-05-13",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1724428944"
+        },
+        "toolResults": 1,
+        "type": "callContinue",
+        "usage": {}
+    },
+    {
+        "time": "2024-08-23T12:02:25.793434-04:00",
+        "callContext": {
+            "id": "call_seuQJWpcuIZGsE5ew0ulVoSm",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "gpt-4o-2024-05-13",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1724428944"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1724428956",
+        "usage": {},
+        "chatRequest": {
+            "model": "gpt-4o-2024-05-13",
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "\nYou are task oriented system.\nYou receive input from a user, process the input from the given instructions, and then output the result.\nYour objective is to provide consistent and correct results.\nYou do not need to explain the steps taken, only provide the result to the given instructions.\nYou are referred to as a tool.\nYou don't move to the next step until you have a result.\n\nRead ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate."
+                },
+                {
+                    "role": "user",
+                    "content": "{\"file\": \"testdata/SamplesReadme/test.gpt\"}"
+                },
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "call_q1xLoCIcZFGfoYI0r4XwkV0h",
+                            "type": "function",
+                            "function": {
+                                "name": "read",
+                                "arguments": "{\"filename\":\"testdata/SamplesReadme/test.gpt\"}"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "role": "tool",
+                    "content": "tools: sys.find, sys.read, summary\n\nGenerate a readme that gives a consolidated summary of each *.gpt file in the testdata directory.\nEach entry should be a include a link to the referenced file.\n\n---\nname: summary\ndescription: Summarize a gpt file\nargs: file: filename to summarize\ntools: sys.read\n\nRead ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.\n",
+                    "name": "read",
+                    "tool_call_id": "call_q1xLoCIcZFGfoYI0r4XwkV0h"
+                }
+            ],
+            "temperature": 0,
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "read",
+                        "description": "Reads the contents of a file",
+                        "parameters": {
+                            "properties": {
+                                "filename": {
+                                    "description": "The name of the file to read",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    {
+        "time": "2024-08-23T12:02:26.508274-04:00",
+        "callContext": {
+            "id": "call_v4fxPCcLKdcJso5SK8EEvv7g",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "gpt-4o-2024-05-13",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1724428944"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1724428952",
+        "usage": {
+            "promptTokens": 276,
+            "completionTokens": 55,
+            "totalTokens": 331
+        },
+        "chatResponse": {
+            "role": "assistant",
+            "content": [
+                {
+                    "text": "The GPTScript file contains a script that uses a tool named \"bob\". The script demonstrates how to ask Bob a question (\"how are you doing\") and then repeat his reply exactly. The technique being demonstrated is the use of a predefined response format for a specific question."
                 }
             ],
             "usage": {
                 "promptTokens": 276,
-                "completionTokens": 69,
-                "totalTokens": 345
+                "completionTokens": 55,
+                "totalTokens": 331
             }
         }
     },
     {
-        "time": "2024-08-06T11:48:45.690956-04:00",
+        "time": "2024-08-23T12:02:26.508354-04:00",
         "callContext": {
-            "id": "call_B31GmzDYcNLo0yYUAyG8dYPA",
+            "id": "call_v4fxPCcLKdcJso5SK8EEvv7g",
             "tool": {
                 "name": "summary",
                 "description": "Summarize a gpt file",
                 "modelName": "gpt-4o-2024-05-13",
-                "temperature": 0.7,
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -2602,21 +2551,20 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "summary",
-            "parentID": "1722959319"
+            "parentID": "1724428944"
         },
         "type": "callFinish",
         "usage": {},
-        "content": "The GPTScript file contains a script for interacting with a tool named \"Bob.\" The script demonstrates the technique of asking \"Bob\" a question, specifically \"how are you doing,\" and then repeating his reply exactly. Bob's response is predefined to be \"Thanks for asking 'how are you doing', I'm doing great fellow friendly AI tool!\""
+        "content": "The GPTScript file contains a script that uses a tool named \"bob\". The script demonstrates how to ask Bob a question (\"how are you doing\") and then repeat his reply exactly. The technique being demonstrated is the use of a predefined response format for a specific question."
     },
     {
-        "time": "2024-08-06T11:48:45.901892-04:00",
+        "time": "2024-08-23T12:02:26.575378-04:00",
         "callContext": {
-            "id": "call_df2WDMbaXZLMbH6MWT9my9fy",
+            "id": "call_WxYHM2C2LYqefe0dnDZveAgk",
             "tool": {
                 "name": "summary",
                 "description": "Summarize a gpt file",
                 "modelName": "gpt-4o-2024-05-13",
-                "temperature": 0.7,
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -2653,38 +2601,37 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "summary",
-            "parentID": "1722959319"
+            "parentID": "1724428944"
         },
         "type": "callChat",
-        "chatCompletionId": "1722959327",
+        "chatCompletionId": "1724428954",
         "usage": {
-            "promptTokens": 329,
-            "completionTokens": 73,
-            "totalTokens": 402
+            "promptTokens": 276,
+            "completionTokens": 56,
+            "totalTokens": 332
         },
         "chatResponse": {
             "role": "assistant",
             "content": [
                 {
-                    "text": "The GPTScript file contains instructions to generate a consolidated summary of each sample *.gpt file in the \"testdata\" directory. The file is leveraging two tools: `sys.find` to locate the sample files and `summary` to generate a summary for each found file. This script demonstrates the technique of file handling and summarization within the GPTScript language."
+                    "text": "The GPTScript file contains a script that uses a tool named \"bob\". The script asks Bob \"how are you doing\" and repeats his reply exactly. The technique demonstrated here is how to interact with a predefined tool (Bob) by passing a question and receiving a response."
                 }
             ],
             "usage": {
-                "promptTokens": 329,
-                "completionTokens": 73,
-                "totalTokens": 402
+                "promptTokens": 276,
+                "completionTokens": 56,
+                "totalTokens": 332
             }
         }
     },
     {
-        "time": "2024-08-06T11:48:45.901987-04:00",
+        "time": "2024-08-23T12:02:26.575465-04:00",
         "callContext": {
-            "id": "call_df2WDMbaXZLMbH6MWT9my9fy",
+            "id": "call_WxYHM2C2LYqefe0dnDZveAgk",
             "tool": {
                 "name": "summary",
                 "description": "Summarize a gpt file",
                 "modelName": "gpt-4o-2024-05-13",
-                "temperature": 0.7,
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -2721,24 +2668,142 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "summary",
-            "parentID": "1722959319"
+            "parentID": "1724428944"
         },
         "type": "callFinish",
         "usage": {},
-        "content": "The GPTScript file contains instructions to generate a consolidated summary of each sample *.gpt file in the \"testdata\" directory. The file is leveraging two tools: `sys.find` to locate the sample files and `summary` to generate a summary for each found file. This script demonstrates the technique of file handling and summarization within the GPTScript language."
+        "content": "The GPTScript file contains a script that uses a tool named \"bob\". The script asks Bob \"how are you doing\" and repeats his reply exactly. The technique demonstrated here is how to interact with a predefined tool (Bob) by passing a question and receiving a response."
     },
     {
-        "time": "2024-08-06T11:48:45.902114-04:00",
+        "time": "2024-08-23T12:02:27.030062-04:00",
         "callContext": {
-            "id": "1722959319",
+            "id": "call_seuQJWpcuIZGsE5ew0ulVoSm",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "gpt-4o-2024-05-13",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1724428944"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1724428956",
+        "usage": {
+            "promptTokens": 326,
+            "completionTokens": 91,
+            "totalTokens": 417
+        },
+        "chatResponse": {
+            "role": "assistant",
+            "content": [
+                {
+                    "text": "The GPTScript file contains instructions to generate a README that provides a consolidated summary of each *.gpt file in the testdata directory. Each entry in the README should include a link to the referenced file. The script uses tools such as `sys.find`, `sys.read`, and `summary` to accomplish this task. The technique demonstrated is the automation of documentation generation by summarizing the contents of multiple files and compiling them into a single README file."
+                }
+            ],
+            "usage": {
+                "promptTokens": 326,
+                "completionTokens": 91,
+                "totalTokens": 417
+            }
+        }
+    },
+    {
+        "time": "2024-08-23T12:02:27.030168-04:00",
+        "callContext": {
+            "id": "call_seuQJWpcuIZGsE5ew0ulVoSm",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "gpt-4o-2024-05-13",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1724428944"
+        },
+        "type": "callFinish",
+        "usage": {},
+        "content": "The GPTScript file contains instructions to generate a README that provides a consolidated summary of each *.gpt file in the testdata directory. Each entry in the README should include a link to the referenced file. The script uses tools such as `sys.find`, `sys.read`, and `summary` to accomplish this task. The technique demonstrated is the automation of documentation generation by summarizing the contents of multiple files and compiling them into a single README file."
+    },
+    {
+        "time": "2024-08-23T12:02:27.030273-04:00",
+        "callContext": {
+            "id": "1724428944",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "sys.find",
+                    "sys.read",
                     "summary"
                 ],
-                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "instructions": "Generate a readme that gives a consolidated summary of each *.gpt file in the testdata directory.\nEach entry should be a include a link to the referenced file.",
                 "id": "testdata/SamplesReadme/test.gpt:",
                 "toolMapping": {
                     "summary": [
@@ -2751,6 +2816,12 @@
                         {
                             "reference": "sys.find",
                             "toolID": "sys.find"
+                        }
+                    ],
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
                         }
                     ]
                 },
@@ -2772,17 +2843,18 @@
         "usage": {}
     },
     {
-        "time": "2024-08-06T11:48:45.902307-04:00",
+        "time": "2024-08-23T12:02:27.030416-04:00",
         "callContext": {
-            "id": "1722959319",
+            "id": "1724428944",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "sys.find",
+                    "sys.read",
                     "summary"
                 ],
-                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "instructions": "Generate a readme that gives a consolidated summary of each *.gpt file in the testdata directory.\nEach entry should be a include a link to the referenced file.",
                 "id": "testdata/SamplesReadme/test.gpt:",
                 "toolMapping": {
                     "summary": [
@@ -2795,6 +2867,12 @@
                         {
                             "reference": "sys.find",
                             "toolID": "sys.find"
+                        }
+                    ],
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
                         }
                     ]
                 },
@@ -2812,21 +2890,21 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1722959332",
+        "chatCompletionId": "1724428957",
         "usage": {},
         "chatRequest": {
             "model": "gpt-4o-2024-05-13",
             "messages": [
                 {
                     "role": "system",
-                    "content": "\nYou are task oriented system.\nYou receive input from a user, process the input from the given instructions, and then output the result.\nYour objective is to provide consistent and correct results.\nYou do not need to explain the steps taken, only provide the result to the given instructions.\nYou are referred to as a tool.\nYou don't move to the next step until you have a result.\n\nGenerate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file."
+                    "content": "\nYou are task oriented system.\nYou receive input from a user, process the input from the given instructions, and then output the result.\nYour objective is to provide consistent and correct results.\nYou do not need to explain the steps taken, only provide the result to the given instructions.\nYou are referred to as a tool.\nYou don't move to the next step until you have a result.\n\nGenerate a readme that gives a consolidated summary of each *.gpt file in the testdata directory.\nEach entry should be a include a link to the referenced file."
                 },
                 {
                     "role": "assistant",
                     "content": "",
                     "tool_calls": [
                         {
-                            "id": "call_jM3KPkDXwEIo6IFTvqNQSVBf",
+                            "id": "call_AC0tP40eH2BNMloJag3dSw0c",
                             "type": "function",
                             "function": {
                                 "name": "find",
@@ -2839,14 +2917,14 @@
                     "role": "tool",
                     "content": "testdata/Bob/test.gpt\ntestdata/BobAsShell/test.gpt\ntestdata/SamplesReadme/test.gpt",
                     "name": "find",
-                    "tool_call_id": "call_jM3KPkDXwEIo6IFTvqNQSVBf"
+                    "tool_call_id": "call_AC0tP40eH2BNMloJag3dSw0c"
                 },
                 {
                     "role": "assistant",
                     "content": "",
                     "tool_calls": [
                         {
-                            "id": "call_B31GmzDYcNLo0yYUAyG8dYPA",
+                            "id": "call_v4fxPCcLKdcJso5SK8EEvv7g",
                             "type": "function",
                             "function": {
                                 "name": "summary",
@@ -2854,7 +2932,7 @@
                             }
                         },
                         {
-                            "id": "call_QW4r1m85pmK7aqYudiIo2CcY",
+                            "id": "call_WxYHM2C2LYqefe0dnDZveAgk",
                             "type": "function",
                             "function": {
                                 "name": "summary",
@@ -2862,7 +2940,7 @@
                             }
                         },
                         {
-                            "id": "call_df2WDMbaXZLMbH6MWT9my9fy",
+                            "id": "call_seuQJWpcuIZGsE5ew0ulVoSm",
                             "type": "function",
                             "function": {
                                 "name": "summary",
@@ -2873,21 +2951,21 @@
                 },
                 {
                     "role": "tool",
-                    "content": "The GPTScript file contains a script for interacting with a tool named \"Bob.\" The script demonstrates the technique of asking \"Bob\" a question, specifically \"how are you doing,\" and then repeating his reply exactly. Bob's response is predefined to be \"Thanks for asking 'how are you doing', I'm doing great fellow friendly AI tool!\"",
+                    "content": "The GPTScript file contains a script that uses a tool named \"bob\". The script demonstrates how to ask Bob a question (\"how are you doing\") and then repeat his reply exactly. The technique being demonstrated is the use of a predefined response format for a specific question.",
                     "name": "summary",
-                    "tool_call_id": "call_B31GmzDYcNLo0yYUAyG8dYPA"
+                    "tool_call_id": "call_v4fxPCcLKdcJso5SK8EEvv7g"
                 },
                 {
                     "role": "tool",
-                    "content": "The GPTScript file demonstrates how to use a tool named \"bob\" to ask a question (\"how are you doing\") and repeat Bob's reply exactly. The technique shown includes defining the tool's name, description, and arguments, followed by a script that echoes a response using the provided question.",
+                    "content": "The GPTScript file contains a script that uses a tool named \"bob\". The script asks Bob \"how are you doing\" and repeats his reply exactly. The technique demonstrated here is how to interact with a predefined tool (Bob) by passing a question and receiving a response.",
                     "name": "summary",
-                    "tool_call_id": "call_QW4r1m85pmK7aqYudiIo2CcY"
+                    "tool_call_id": "call_WxYHM2C2LYqefe0dnDZveAgk"
                 },
                 {
                     "role": "tool",
-                    "content": "The GPTScript file contains instructions to generate a consolidated summary of each sample *.gpt file in the \"testdata\" directory. The file is leveraging two tools: `sys.find` to locate the sample files and `summary` to generate a summary for each found file. This script demonstrates the technique of file handling and summarization within the GPTScript language.",
+                    "content": "The GPTScript file contains instructions to generate a README that provides a consolidated summary of each *.gpt file in the testdata directory. Each entry in the README should include a link to the referenced file. The script uses tools such as `sys.find`, `sys.read`, and `summary` to accomplish this task. The technique demonstrated is the automation of documentation generation by summarizing the contents of multiple files and compiling them into a single README file.",
                     "name": "summary",
-                    "tool_call_id": "call_df2WDMbaXZLMbH6MWT9my9fy"
+                    "tool_call_id": "call_seuQJWpcuIZGsE5ew0ulVoSm"
                 }
             ],
             "temperature": 0,
@@ -2915,6 +2993,22 @@
                 {
                     "type": "function",
                     "function": {
+                        "name": "read",
+                        "description": "Reads the contents of a file",
+                        "parameters": {
+                            "properties": {
+                                "filename": {
+                                    "description": "The name of the file to read",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                },
+                {
+                    "type": "function",
+                    "function": {
                         "name": "summary",
                         "description": "Summarize a gpt file",
                         "parameters": {
@@ -2932,17 +3026,18 @@
         }
     },
     {
-        "time": "2024-08-06T11:48:50.812402-04:00",
+        "time": "2024-08-23T12:02:30.314337-04:00",
         "callContext": {
-            "id": "1722959319",
+            "id": "1724428944",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "sys.find",
+                    "sys.read",
                     "summary"
                 ],
-                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "instructions": "Generate a readme that gives a consolidated summary of each *.gpt file in the testdata directory.\nEach entry should be a include a link to the referenced file.",
                 "id": "testdata/SamplesReadme/test.gpt:",
                 "toolMapping": {
                     "summary": [
@@ -2955,6 +3050,12 @@
                         {
                             "reference": "sys.find",
                             "toolID": "sys.find"
+                        }
+                    ],
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
                         }
                     ]
                 },
@@ -2972,38 +3073,39 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1722959332",
+        "chatCompletionId": "1724428957",
         "usage": {
-            "promptTokens": 588,
-            "completionTokens": 273,
-            "totalTokens": 861
+            "promptTokens": 619,
+            "completionTokens": 270,
+            "totalTokens": 889
         },
         "chatResponse": {
             "role": "assistant",
             "content": [
                 {
-                    "text": "# Consolidated Summary of Sample *.gpt Files\n\n## [testdata/Bob/test.gpt](testdata/Bob/test.gpt)\nThe GPTScript file contains a script for interacting with a tool named \"Bob.\" The script demonstrates the technique of asking \"Bob\" a question, specifically \"how are you doing,\" and then repeating his reply exactly. Bob's response is predefined to be \"Thanks for asking 'how are you doing', I'm doing great fellow friendly AI tool!\"\n\n## [testdata/BobAsShell/test.gpt](testdata/BobAsShell/test.gpt)\nThe GPTScript file demonstrates how to use a tool named \"bob\" to ask a question (\"how are you doing\") and repeat Bob's reply exactly. The technique shown includes defining the tool's name, description, and arguments, followed by a script that echoes a response using the provided question.\n\n## [testdata/SamplesReadme/test.gpt](testdata/SamplesReadme/test.gpt)\nThe GPTScript file contains instructions to generate a consolidated summary of each sample *.gpt file in the \"testdata\" directory. The file is leveraging two tools: `sys.find` to locate the sample files and `summary` to generate a summary for each found file. This script demonstrates the technique of file handling and summarization within the GPTScript language."
+                    "text": "# Consolidated Summary of GPT Files\n\n## [testdata/Bob/test.gpt](testdata/Bob/test.gpt)\nThe GPTScript file contains a script that uses a tool named \"bob\". The script demonstrates how to ask Bob a question (\"how are you doing\") and then repeat his reply exactly. The technique being demonstrated is the use of a predefined response format for a specific question.\n\n## [testdata/BobAsShell/test.gpt](testdata/BobAsShell/test.gpt)\nThe GPTScript file contains a script that uses a tool named \"bob\". The script asks Bob \"how are you doing\" and repeats his reply exactly. The technique demonstrated here is how to interact with a predefined tool (Bob) by passing a question and receiving a response.\n\n## [testdata/SamplesReadme/test.gpt](testdata/SamplesReadme/test.gpt)\nThe GPTScript file contains instructions to generate a README that provides a consolidated summary of each *.gpt file in the testdata directory. Each entry in the README should include a link to the referenced file. The script uses tools such as `sys.find`, `sys.read`, and `summary` to accomplish this task. The technique demonstrated is the automation of documentation generation by summarizing the contents of multiple files and compiling them into a single README file."
                 }
             ],
             "usage": {
-                "promptTokens": 588,
-                "completionTokens": 273,
-                "totalTokens": 861
+                "promptTokens": 619,
+                "completionTokens": 270,
+                "totalTokens": 889
             }
         }
     },
     {
-        "time": "2024-08-06T11:48:50.8125-04:00",
+        "time": "2024-08-23T12:02:30.314373-04:00",
         "callContext": {
-            "id": "1722959319",
+            "id": "1724428944",
             "tool": {
                 "modelName": "gpt-4o-2024-05-13",
                 "internalPrompt": null,
                 "tools": [
                     "sys.find",
+                    "sys.read",
                     "summary"
                 ],
-                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "instructions": "Generate a readme that gives a consolidated summary of each *.gpt file in the testdata directory.\nEach entry should be a include a link to the referenced file.",
                 "id": "testdata/SamplesReadme/test.gpt:",
                 "toolMapping": {
                     "summary": [
@@ -3016,6 +3118,12 @@
                         {
                             "reference": "sys.find",
                             "toolID": "sys.find"
+                        }
+                    ],
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
                         }
                     ]
                 },
@@ -3034,10 +3142,10 @@
         },
         "type": "callFinish",
         "usage": {},
-        "content": "# Consolidated Summary of Sample *.gpt Files\n\n## [testdata/Bob/test.gpt](testdata/Bob/test.gpt)\nThe GPTScript file contains a script for interacting with a tool named \"Bob.\" The script demonstrates the technique of asking \"Bob\" a question, specifically \"how are you doing,\" and then repeating his reply exactly. Bob's response is predefined to be \"Thanks for asking 'how are you doing', I'm doing great fellow friendly AI tool!\"\n\n## [testdata/BobAsShell/test.gpt](testdata/BobAsShell/test.gpt)\nThe GPTScript file demonstrates how to use a tool named \"bob\" to ask a question (\"how are you doing\") and repeat Bob's reply exactly. The technique shown includes defining the tool's name, description, and arguments, followed by a script that echoes a response using the provided question.\n\n## [testdata/SamplesReadme/test.gpt](testdata/SamplesReadme/test.gpt)\nThe GPTScript file contains instructions to generate a consolidated summary of each sample *.gpt file in the \"testdata\" directory. The file is leveraging two tools: `sys.find` to locate the sample files and `summary` to generate a summary for each found file. This script demonstrates the technique of file handling and summarization within the GPTScript language."
+        "content": "# Consolidated Summary of GPT Files\n\n## [testdata/Bob/test.gpt](testdata/Bob/test.gpt)\nThe GPTScript file contains a script that uses a tool named \"bob\". The script demonstrates how to ask Bob a question (\"how are you doing\") and then repeat his reply exactly. The technique being demonstrated is the use of a predefined response format for a specific question.\n\n## [testdata/BobAsShell/test.gpt](testdata/BobAsShell/test.gpt)\nThe GPTScript file contains a script that uses a tool named \"bob\". The script asks Bob \"how are you doing\" and repeats his reply exactly. The technique demonstrated here is how to interact with a predefined tool (Bob) by passing a question and receiving a response.\n\n## [testdata/SamplesReadme/test.gpt](testdata/SamplesReadme/test.gpt)\nThe GPTScript file contains instructions to generate a README that provides a consolidated summary of each *.gpt file in the testdata directory. Each entry in the README should include a link to the referenced file. The script uses tools such as `sys.find`, `sys.read`, and `summary` to accomplish this task. The technique demonstrated is the automation of documentation generation by summarizing the contents of multiple files and compiling them into a single README file."
     },
     {
-        "time": "2024-08-06T11:48:50.812569-04:00",
+        "time": "2024-08-23T12:02:30.314408-04:00",
         "type": "runFinish",
         "usage": {}
     }

--- a/pkg/tests/smoke/testdata/SamplesReadme/gpt-4o-2024-05-13-expected.json
+++ b/pkg/tests/smoke/testdata/SamplesReadme/gpt-4o-2024-05-13-expected.json
@@ -1,0 +1,3044 @@
+[
+    {
+        "time": "2024-08-06T11:48:38.76752-04:00",
+        "type": "runStart",
+        "usage": {}
+    },
+    {
+        "time": "2024-08-06T11:48:38.767859-04:00",
+        "callContext": {
+            "id": "1722959319",
+            "tool": {
+                "modelName": "gpt-4o-2024-05-13",
+                "internalPrompt": null,
+                "tools": [
+                    "sys.find",
+                    "summary"
+                ],
+                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "id": "testdata/SamplesReadme/test.gpt:",
+                "toolMapping": {
+                    "summary": [
+                        {
+                            "reference": "summary",
+                            "toolID": "testdata/SamplesReadme/test.gpt:summary"
+                        }
+                    ],
+                    "sys.find": [
+                        {
+                            "reference": "sys.find",
+                            "toolID": "sys.find"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 1
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null
+        },
+        "type": "callStart",
+        "usage": {}
+    },
+    {
+        "time": "2024-08-06T11:48:38.767907-04:00",
+        "callContext": {
+            "id": "1722959319",
+            "tool": {
+                "modelName": "gpt-4o-2024-05-13",
+                "internalPrompt": null,
+                "tools": [
+                    "sys.find",
+                    "summary"
+                ],
+                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "id": "testdata/SamplesReadme/test.gpt:",
+                "toolMapping": {
+                    "summary": [
+                        {
+                            "reference": "summary",
+                            "toolID": "testdata/SamplesReadme/test.gpt:summary"
+                        }
+                    ],
+                    "sys.find": [
+                        {
+                            "reference": "sys.find",
+                            "toolID": "sys.find"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 1
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722959320",
+        "usage": {},
+        "chatRequest": {
+            "model": "gpt-4o-2024-05-13",
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "\nYou are task oriented system.\nYou receive input from a user, process the input from the given instructions, and then output the result.\nYour objective is to provide consistent and correct results.\nYou do not need to explain the steps taken, only provide the result to the given instructions.\nYou are referred to as a tool.\nYou don't move to the next step until you have a result.\n\nGenerate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file."
+                }
+            ],
+            "temperature": 0,
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "find",
+                        "description": "Traverse a directory looking for files that match a pattern in the style of the unix find command",
+                        "parameters": {
+                            "properties": {
+                                "directory": {
+                                    "description": "The directory to search in. The current directory \".\" will be used as the default if no argument is passed",
+                                    "type": "string"
+                                },
+                                "pattern": {
+                                    "description": "The file pattern to look for. The pattern is a traditional unix glob format with * matching any character and ? matching a single character",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                },
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "summary",
+                        "description": "Summarize a gpt file",
+                        "parameters": {
+                            "properties": {
+                                "file": {
+                                    "description": "filename to summarize",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    {
+        "time": "2024-08-06T11:48:39.448009-04:00",
+        "callContext": {
+            "id": "1722959319",
+            "tool": {
+                "modelName": "gpt-4o-2024-05-13",
+                "internalPrompt": null,
+                "tools": [
+                    "sys.find",
+                    "summary"
+                ],
+                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "id": "testdata/SamplesReadme/test.gpt:",
+                "toolMapping": {
+                    "summary": [
+                        {
+                            "reference": "summary",
+                            "toolID": "testdata/SamplesReadme/test.gpt:summary"
+                        }
+                    ],
+                    "sys.find": [
+                        {
+                            "reference": "sys.find",
+                            "toolID": "sys.find"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 1
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722959320",
+        "usage": {
+            "promptTokens": 242,
+            "completionTokens": 20,
+            "totalTokens": 262
+        },
+        "chatResponse": {
+            "role": "assistant",
+            "content": [
+                {
+                    "toolCall": {
+                        "index": 0,
+                        "id": "call_jM3KPkDXwEIo6IFTvqNQSVBf",
+                        "function": {
+                            "name": "find",
+                            "arguments": "{\"directory\":\"testdata\",\"pattern\":\"*.gpt\"}"
+                        }
+                    }
+                }
+            ],
+            "usage": {
+                "promptTokens": 242,
+                "completionTokens": 20,
+                "totalTokens": 262
+            }
+        }
+    },
+    {
+        "time": "2024-08-06T11:48:39.448411-04:00",
+        "callContext": {
+            "id": "1722959319",
+            "tool": {
+                "modelName": "gpt-4o-2024-05-13",
+                "internalPrompt": null,
+                "tools": [
+                    "sys.find",
+                    "summary"
+                ],
+                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "id": "testdata/SamplesReadme/test.gpt:",
+                "toolMapping": {
+                    "summary": [
+                        {
+                            "reference": "summary",
+                            "toolID": "testdata/SamplesReadme/test.gpt:summary"
+                        }
+                    ],
+                    "sys.find": [
+                        {
+                            "reference": "sys.find",
+                            "toolID": "sys.find"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 1
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null
+        },
+        "toolSubCalls": {
+            "call_jM3KPkDXwEIo6IFTvqNQSVBf": {
+                "toolID": "sys.find",
+                "input": "{\"directory\":\"testdata\",\"pattern\":\"*.gpt\"}"
+            }
+        },
+        "type": "callSubCalls",
+        "usage": {}
+    },
+    {
+        "time": "2024-08-06T11:48:39.448605-04:00",
+        "callContext": {
+            "id": "call_jM3KPkDXwEIo6IFTvqNQSVBf",
+            "tool": {
+                "name": "sys.find",
+                "description": "Traverse a directory looking for files that match a pattern in the style of the unix find command",
+                "modelName": "gpt-4o-2024-05-13",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "directory": {
+                            "description": "The directory to search in. The current directory \".\" will be used as the default if no argument is passed",
+                            "type": "string"
+                        },
+                        "pattern": {
+                            "description": "The file pattern to look for. The pattern is a traditional unix glob format with * matching any character and ? matching a single character",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "instructions": "#!sys.find",
+                "id": "sys.find",
+                "source": {}
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "sys.find",
+            "parentID": "1722959319",
+            "displayText": "Finding `*.gpt` in `testdata`"
+        },
+        "type": "callStart",
+        "usage": {},
+        "content": "{\"directory\":\"testdata\",\"pattern\":\"*.gpt\"}"
+    },
+    {
+        "time": "2024-08-06T11:48:39.448868-04:00",
+        "callContext": {
+            "id": "call_jM3KPkDXwEIo6IFTvqNQSVBf",
+            "tool": {
+                "name": "sys.find",
+                "description": "Traverse a directory looking for files that match a pattern in the style of the unix find command",
+                "modelName": "gpt-4o-2024-05-13",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "directory": {
+                            "description": "The directory to search in. The current directory \".\" will be used as the default if no argument is passed",
+                            "type": "string"
+                        },
+                        "pattern": {
+                            "description": "The file pattern to look for. The pattern is a traditional unix glob format with * matching any character and ? matching a single character",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "instructions": "#!sys.find",
+                "id": "sys.find",
+                "source": {}
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "sys.find",
+            "parentID": "1722959319",
+            "displayText": "Finding `*.gpt` in `testdata`"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722959321",
+        "usage": {},
+        "chatRequest": {
+            "model": "",
+            "messages": null
+        }
+    },
+    {
+        "time": "2024-08-06T11:48:39.449755-04:00",
+        "callContext": {
+            "id": "call_jM3KPkDXwEIo6IFTvqNQSVBf",
+            "tool": {
+                "name": "sys.find",
+                "description": "Traverse a directory looking for files that match a pattern in the style of the unix find command",
+                "modelName": "gpt-4o-2024-05-13",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "directory": {
+                            "description": "The directory to search in. The current directory \".\" will be used as the default if no argument is passed",
+                            "type": "string"
+                        },
+                        "pattern": {
+                            "description": "The file pattern to look for. The pattern is a traditional unix glob format with * matching any character and ? matching a single character",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "instructions": "#!sys.find",
+                "id": "sys.find",
+                "source": {}
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "sys.find",
+            "parentID": "1722959319",
+            "displayText": "Finding `*.gpt` in `testdata`"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722959321",
+        "usage": {},
+        "chatResponse": {
+            "usage": {}
+        }
+    },
+    {
+        "time": "2024-08-06T11:48:39.449847-04:00",
+        "callContext": {
+            "id": "call_jM3KPkDXwEIo6IFTvqNQSVBf",
+            "tool": {
+                "name": "sys.find",
+                "description": "Traverse a directory looking for files that match a pattern in the style of the unix find command",
+                "modelName": "gpt-4o-2024-05-13",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "directory": {
+                            "description": "The directory to search in. The current directory \".\" will be used as the default if no argument is passed",
+                            "type": "string"
+                        },
+                        "pattern": {
+                            "description": "The file pattern to look for. The pattern is a traditional unix glob format with * matching any character and ? matching a single character",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "instructions": "#!sys.find",
+                "id": "sys.find",
+                "source": {}
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "sys.find",
+            "parentID": "1722959319",
+            "displayText": "Finding `*.gpt` in `testdata`"
+        },
+        "type": "callFinish",
+        "usage": {},
+        "content": "testdata/Bob/test.gpt\ntestdata/BobAsShell/test.gpt\ntestdata/SamplesReadme/test.gpt"
+    },
+    {
+        "time": "2024-08-06T11:48:39.449916-04:00",
+        "callContext": {
+            "id": "1722959319",
+            "tool": {
+                "modelName": "gpt-4o-2024-05-13",
+                "internalPrompt": null,
+                "tools": [
+                    "sys.find",
+                    "summary"
+                ],
+                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "id": "testdata/SamplesReadme/test.gpt:",
+                "toolMapping": {
+                    "summary": [
+                        {
+                            "reference": "summary",
+                            "toolID": "testdata/SamplesReadme/test.gpt:summary"
+                        }
+                    ],
+                    "sys.find": [
+                        {
+                            "reference": "sys.find",
+                            "toolID": "sys.find"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 1
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null
+        },
+        "toolResults": 1,
+        "type": "callContinue",
+        "usage": {}
+    },
+    {
+        "time": "2024-08-06T11:48:39.450004-04:00",
+        "callContext": {
+            "id": "1722959319",
+            "tool": {
+                "modelName": "gpt-4o-2024-05-13",
+                "internalPrompt": null,
+                "tools": [
+                    "sys.find",
+                    "summary"
+                ],
+                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "id": "testdata/SamplesReadme/test.gpt:",
+                "toolMapping": {
+                    "summary": [
+                        {
+                            "reference": "summary",
+                            "toolID": "testdata/SamplesReadme/test.gpt:summary"
+                        }
+                    ],
+                    "sys.find": [
+                        {
+                            "reference": "sys.find",
+                            "toolID": "sys.find"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 1
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722959322",
+        "usage": {},
+        "chatRequest": {
+            "model": "gpt-4o-2024-05-13",
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "\nYou are task oriented system.\nYou receive input from a user, process the input from the given instructions, and then output the result.\nYour objective is to provide consistent and correct results.\nYou do not need to explain the steps taken, only provide the result to the given instructions.\nYou are referred to as a tool.\nYou don't move to the next step until you have a result.\n\nGenerate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file."
+                },
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "call_jM3KPkDXwEIo6IFTvqNQSVBf",
+                            "type": "function",
+                            "function": {
+                                "name": "find",
+                                "arguments": "{\"directory\":\"testdata\",\"pattern\":\"*.gpt\"}"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "role": "tool",
+                    "content": "testdata/Bob/test.gpt\ntestdata/BobAsShell/test.gpt\ntestdata/SamplesReadme/test.gpt",
+                    "name": "find",
+                    "tool_call_id": "call_jM3KPkDXwEIo6IFTvqNQSVBf"
+                }
+            ],
+            "temperature": 0,
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "find",
+                        "description": "Traverse a directory looking for files that match a pattern in the style of the unix find command",
+                        "parameters": {
+                            "properties": {
+                                "directory": {
+                                    "description": "The directory to search in. The current directory \".\" will be used as the default if no argument is passed",
+                                    "type": "string"
+                                },
+                                "pattern": {
+                                    "description": "The file pattern to look for. The pattern is a traditional unix glob format with * matching any character and ? matching a single character",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                },
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "summary",
+                        "description": "Summarize a gpt file",
+                        "parameters": {
+                            "properties": {
+                                "file": {
+                                    "description": "filename to summarize",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    {
+        "time": "2024-08-06T11:48:41.955112-04:00",
+        "callContext": {
+            "id": "1722959319",
+            "tool": {
+                "modelName": "gpt-4o-2024-05-13",
+                "internalPrompt": null,
+                "tools": [
+                    "sys.find",
+                    "summary"
+                ],
+                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "id": "testdata/SamplesReadme/test.gpt:",
+                "toolMapping": {
+                    "summary": [
+                        {
+                            "reference": "summary",
+                            "toolID": "testdata/SamplesReadme/test.gpt:summary"
+                        }
+                    ],
+                    "sys.find": [
+                        {
+                            "reference": "sys.find",
+                            "toolID": "sys.find"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 1
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null
+        },
+        "toolSubCalls": {
+            "call_B31GmzDYcNLo0yYUAyG8dYPA": {
+                "toolID": "testdata/SamplesReadme/test.gpt:summary",
+                "input": "{\"file\": \"testdata/Bob/test.gpt\"}"
+            },
+            "call_QW4r1m85pmK7aqYudiIo2CcY": {
+                "toolID": "testdata/SamplesReadme/test.gpt:summary",
+                "input": "{\"file\": \"testdata/BobAsShell/test.gpt\"}"
+            },
+            "call_df2WDMbaXZLMbH6MWT9my9fy": {
+                "toolID": "testdata/SamplesReadme/test.gpt:summary",
+                "input": "{\"file\": \"testdata/SamplesReadme/test.gpt\"}"
+            }
+        },
+        "type": "callSubCalls",
+        "usage": {}
+    },
+    {
+        "time": "2024-08-06T11:48:41.955113-04:00",
+        "callContext": {
+            "id": "1722959319",
+            "tool": {
+                "modelName": "gpt-4o-2024-05-13",
+                "internalPrompt": null,
+                "tools": [
+                    "sys.find",
+                    "summary"
+                ],
+                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "id": "testdata/SamplesReadme/test.gpt:",
+                "toolMapping": {
+                    "summary": [
+                        {
+                            "reference": "summary",
+                            "toolID": "testdata/SamplesReadme/test.gpt:summary"
+                        }
+                    ],
+                    "sys.find": [
+                        {
+                            "reference": "sys.find",
+                            "toolID": "sys.find"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 1
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722959322",
+        "usage": {
+            "promptTokens": 296,
+            "completionTokens": 77,
+            "totalTokens": 373
+        },
+        "chatResponse": {
+            "role": "assistant",
+            "content": [
+                {
+                    "toolCall": {
+                        "index": 0,
+                        "id": "call_B31GmzDYcNLo0yYUAyG8dYPA",
+                        "function": {
+                            "name": "summary",
+                            "arguments": "{\"file\": \"testdata/Bob/test.gpt\"}"
+                        }
+                    }
+                },
+                {
+                    "toolCall": {
+                        "index": 1,
+                        "id": "call_QW4r1m85pmK7aqYudiIo2CcY",
+                        "function": {
+                            "name": "summary",
+                            "arguments": "{\"file\": \"testdata/BobAsShell/test.gpt\"}"
+                        }
+                    }
+                },
+                {
+                    "toolCall": {
+                        "index": 2,
+                        "id": "call_df2WDMbaXZLMbH6MWT9my9fy",
+                        "function": {
+                            "name": "summary",
+                            "arguments": "{\"file\": \"testdata/SamplesReadme/test.gpt\"}"
+                        }
+                    }
+                }
+            ],
+            "usage": {
+                "promptTokens": 296,
+                "completionTokens": 77,
+                "totalTokens": 373
+            }
+        }
+    },
+    {
+        "time": "2024-08-06T11:48:41.955247-04:00",
+        "callContext": {
+            "id": "call_df2WDMbaXZLMbH6MWT9my9fy",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "gpt-4o-2024-05-13",
+                "temperature": 0.7,
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722959319"
+        },
+        "type": "callStart",
+        "usage": {},
+        "content": "{\"file\": \"testdata/SamplesReadme/test.gpt\"}"
+    },
+    {
+        "time": "2024-08-06T11:48:41.955251-04:00",
+        "callContext": {
+            "id": "call_B31GmzDYcNLo0yYUAyG8dYPA",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "gpt-4o-2024-05-13",
+                "temperature": 0.7,
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722959319"
+        },
+        "type": "callStart",
+        "usage": {},
+        "content": "{\"file\": \"testdata/Bob/test.gpt\"}"
+    },
+    {
+        "time": "2024-08-06T11:48:41.955477-04:00",
+        "callContext": {
+            "id": "call_df2WDMbaXZLMbH6MWT9my9fy",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "gpt-4o-2024-05-13",
+                "temperature": 0.7,
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722959319"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722959323",
+        "usage": {},
+        "chatRequest": {
+            "model": "gpt-4o-2024-05-13",
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "\nYou are task oriented system.\nYou receive input from a user, process the input from the given instructions, and then output the result.\nYour objective is to provide consistent and correct results.\nYou do not need to explain the steps taken, only provide the result to the given instructions.\nYou are referred to as a tool.\nYou don't move to the next step until you have a result.\n\nRead ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate."
+                },
+                {
+                    "role": "user",
+                    "content": "{\"file\": \"testdata/SamplesReadme/test.gpt\"}"
+                }
+            ],
+            "temperature": 0.7,
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "read",
+                        "description": "Reads the contents of a file",
+                        "parameters": {
+                            "properties": {
+                                "filename": {
+                                    "description": "The name of the file to read",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    {
+        "time": "2024-08-06T11:48:41.955517-04:00",
+        "callContext": {
+            "id": "call_B31GmzDYcNLo0yYUAyG8dYPA",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "gpt-4o-2024-05-13",
+                "temperature": 0.7,
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722959319"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722959324",
+        "usage": {},
+        "chatRequest": {
+            "model": "gpt-4o-2024-05-13",
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "\nYou are task oriented system.\nYou receive input from a user, process the input from the given instructions, and then output the result.\nYour objective is to provide consistent and correct results.\nYou do not need to explain the steps taken, only provide the result to the given instructions.\nYou are referred to as a tool.\nYou don't move to the next step until you have a result.\n\nRead ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate."
+                },
+                {
+                    "role": "user",
+                    "content": "{\"file\": \"testdata/Bob/test.gpt\"}"
+                }
+            ],
+            "temperature": 0.7,
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "read",
+                        "description": "Reads the contents of a file",
+                        "parameters": {
+                            "properties": {
+                                "filename": {
+                                    "description": "The name of the file to read",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    {
+        "time": "2024-08-06T11:48:41.955259-04:00",
+        "callContext": {
+            "id": "call_QW4r1m85pmK7aqYudiIo2CcY",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "gpt-4o-2024-05-13",
+                "temperature": 0.7,
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722959319"
+        },
+        "type": "callStart",
+        "usage": {},
+        "content": "{\"file\": \"testdata/BobAsShell/test.gpt\"}"
+    },
+    {
+        "time": "2024-08-06T11:48:41.955821-04:00",
+        "callContext": {
+            "id": "call_QW4r1m85pmK7aqYudiIo2CcY",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "gpt-4o-2024-05-13",
+                "temperature": 0.7,
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722959319"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722959325",
+        "usage": {},
+        "chatRequest": {
+            "model": "gpt-4o-2024-05-13",
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "\nYou are task oriented system.\nYou receive input from a user, process the input from the given instructions, and then output the result.\nYour objective is to provide consistent and correct results.\nYou do not need to explain the steps taken, only provide the result to the given instructions.\nYou are referred to as a tool.\nYou don't move to the next step until you have a result.\n\nRead ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate."
+                },
+                {
+                    "role": "user",
+                    "content": "{\"file\": \"testdata/BobAsShell/test.gpt\"}"
+                }
+            ],
+            "temperature": 0.7,
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "read",
+                        "description": "Reads the contents of a file",
+                        "parameters": {
+                            "properties": {
+                                "filename": {
+                                    "description": "The name of the file to read",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    {
+        "time": "2024-08-06T11:48:42.655187-04:00",
+        "callContext": {
+            "id": "call_df2WDMbaXZLMbH6MWT9my9fy",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "gpt-4o-2024-05-13",
+                "temperature": 0.7,
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722959319"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722959323",
+        "usage": {
+            "promptTokens": 185,
+            "completionTokens": 21,
+            "totalTokens": 206
+        },
+        "chatResponse": {
+            "role": "assistant",
+            "content": [
+                {
+                    "toolCall": {
+                        "index": 0,
+                        "id": "call_0XHxMC4f3Zmnap6ZdO31mL46",
+                        "function": {
+                            "name": "read",
+                            "arguments": "{\"filename\":\"testdata/SamplesReadme/test.gpt\"}"
+                        }
+                    }
+                }
+            ],
+            "usage": {
+                "promptTokens": 185,
+                "completionTokens": 21,
+                "totalTokens": 206
+            }
+        }
+    },
+    {
+        "time": "2024-08-06T11:48:42.655319-04:00",
+        "callContext": {
+            "id": "call_df2WDMbaXZLMbH6MWT9my9fy",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "gpt-4o-2024-05-13",
+                "temperature": 0.7,
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722959319"
+        },
+        "toolSubCalls": {
+            "call_0XHxMC4f3Zmnap6ZdO31mL46": {
+                "toolID": "sys.read",
+                "input": "{\"filename\":\"testdata/SamplesReadme/test.gpt\"}"
+            }
+        },
+        "type": "callSubCalls",
+        "usage": {}
+    },
+    {
+        "time": "2024-08-06T11:48:42.65546-04:00",
+        "callContext": {
+            "id": "call_0XHxMC4f3Zmnap6ZdO31mL46",
+            "tool": {
+                "name": "sys.read",
+                "description": "Reads the contents of a file",
+                "modelName": "gpt-4o-2024-05-13",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "filename": {
+                            "description": "The name of the file to read",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "instructions": "#!sys.read",
+                "id": "sys.read",
+                "source": {}
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "sys.read",
+            "parentID": "call_df2WDMbaXZLMbH6MWT9my9fy",
+            "displayText": "Reading `testdata/SamplesReadme/test.gpt`"
+        },
+        "type": "callStart",
+        "usage": {},
+        "content": "{\"filename\":\"testdata/SamplesReadme/test.gpt\"}"
+    },
+    {
+        "time": "2024-08-06T11:48:42.655635-04:00",
+        "callContext": {
+            "id": "call_0XHxMC4f3Zmnap6ZdO31mL46",
+            "tool": {
+                "name": "sys.read",
+                "description": "Reads the contents of a file",
+                "modelName": "gpt-4o-2024-05-13",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "filename": {
+                            "description": "The name of the file to read",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "instructions": "#!sys.read",
+                "id": "sys.read",
+                "source": {}
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "sys.read",
+            "parentID": "call_df2WDMbaXZLMbH6MWT9my9fy",
+            "displayText": "Reading `testdata/SamplesReadme/test.gpt`"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722959326",
+        "usage": {},
+        "chatRequest": {
+            "model": "",
+            "messages": null
+        }
+    },
+    {
+        "time": "2024-08-06T11:48:42.655946-04:00",
+        "callContext": {
+            "id": "call_0XHxMC4f3Zmnap6ZdO31mL46",
+            "tool": {
+                "name": "sys.read",
+                "description": "Reads the contents of a file",
+                "modelName": "gpt-4o-2024-05-13",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "filename": {
+                            "description": "The name of the file to read",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "instructions": "#!sys.read",
+                "id": "sys.read",
+                "source": {}
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "sys.read",
+            "parentID": "call_df2WDMbaXZLMbH6MWT9my9fy",
+            "displayText": "Reading `testdata/SamplesReadme/test.gpt`"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722959326",
+        "usage": {},
+        "chatResponse": {
+            "usage": {}
+        }
+    },
+    {
+        "time": "2024-08-06T11:48:42.656032-04:00",
+        "callContext": {
+            "id": "call_0XHxMC4f3Zmnap6ZdO31mL46",
+            "tool": {
+                "name": "sys.read",
+                "description": "Reads the contents of a file",
+                "modelName": "gpt-4o-2024-05-13",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "filename": {
+                            "description": "The name of the file to read",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "instructions": "#!sys.read",
+                "id": "sys.read",
+                "source": {}
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "sys.read",
+            "parentID": "call_df2WDMbaXZLMbH6MWT9my9fy",
+            "displayText": "Reading `testdata/SamplesReadme/test.gpt`"
+        },
+        "type": "callFinish",
+        "usage": {},
+        "content": "tools: sys.find, summary\n\nGenerate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.\n\n---\nname: summary\ndescription: Summarize a gpt file\nargs: file: filename to summarize\ntools: sys.read\ntemperature: 0.7\n\nRead ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.\n"
+    },
+    {
+        "time": "2024-08-06T11:48:42.656128-04:00",
+        "callContext": {
+            "id": "call_df2WDMbaXZLMbH6MWT9my9fy",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "gpt-4o-2024-05-13",
+                "temperature": 0.7,
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722959319"
+        },
+        "toolResults": 1,
+        "type": "callContinue",
+        "usage": {}
+    },
+    {
+        "time": "2024-08-06T11:48:42.656378-04:00",
+        "callContext": {
+            "id": "call_df2WDMbaXZLMbH6MWT9my9fy",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "gpt-4o-2024-05-13",
+                "temperature": 0.7,
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722959319"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722959327",
+        "usage": {},
+        "chatRequest": {
+            "model": "gpt-4o-2024-05-13",
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "\nYou are task oriented system.\nYou receive input from a user, process the input from the given instructions, and then output the result.\nYour objective is to provide consistent and correct results.\nYou do not need to explain the steps taken, only provide the result to the given instructions.\nYou are referred to as a tool.\nYou don't move to the next step until you have a result.\n\nRead ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate."
+                },
+                {
+                    "role": "user",
+                    "content": "{\"file\": \"testdata/SamplesReadme/test.gpt\"}"
+                },
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "call_0XHxMC4f3Zmnap6ZdO31mL46",
+                            "type": "function",
+                            "function": {
+                                "name": "read",
+                                "arguments": "{\"filename\":\"testdata/SamplesReadme/test.gpt\"}"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "role": "tool",
+                    "content": "tools: sys.find, summary\n\nGenerate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.\n\n---\nname: summary\ndescription: Summarize a gpt file\nargs: file: filename to summarize\ntools: sys.read\ntemperature: 0.7\n\nRead ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.\n",
+                    "name": "read",
+                    "tool_call_id": "call_0XHxMC4f3Zmnap6ZdO31mL46"
+                }
+            ],
+            "temperature": 0.7,
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "read",
+                        "description": "Reads the contents of a file",
+                        "parameters": {
+                            "properties": {
+                                "filename": {
+                                    "description": "The name of the file to read",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    {
+        "time": "2024-08-06T11:48:42.692262-04:00",
+        "callContext": {
+            "id": "call_QW4r1m85pmK7aqYudiIo2CcY",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "gpt-4o-2024-05-13",
+                "temperature": 0.7,
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722959319"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722959325",
+        "usage": {
+            "promptTokens": 185,
+            "completionTokens": 21,
+            "totalTokens": 206
+        },
+        "chatResponse": {
+            "role": "assistant",
+            "content": [
+                {
+                    "toolCall": {
+                        "index": 0,
+                        "id": "call_yxddr1hEZCeKvwY7xiU4Rir9",
+                        "function": {
+                            "name": "read",
+                            "arguments": "{\"filename\":\"testdata/BobAsShell/test.gpt\"}"
+                        }
+                    }
+                }
+            ],
+            "usage": {
+                "promptTokens": 185,
+                "completionTokens": 21,
+                "totalTokens": 206
+            }
+        }
+    },
+    {
+        "time": "2024-08-06T11:48:42.692355-04:00",
+        "callContext": {
+            "id": "call_QW4r1m85pmK7aqYudiIo2CcY",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "gpt-4o-2024-05-13",
+                "temperature": 0.7,
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722959319"
+        },
+        "toolSubCalls": {
+            "call_yxddr1hEZCeKvwY7xiU4Rir9": {
+                "toolID": "sys.read",
+                "input": "{\"filename\":\"testdata/BobAsShell/test.gpt\"}"
+            }
+        },
+        "type": "callSubCalls",
+        "usage": {}
+    },
+    {
+        "time": "2024-08-06T11:48:42.692465-04:00",
+        "callContext": {
+            "id": "call_yxddr1hEZCeKvwY7xiU4Rir9",
+            "tool": {
+                "name": "sys.read",
+                "description": "Reads the contents of a file",
+                "modelName": "gpt-4o-2024-05-13",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "filename": {
+                            "description": "The name of the file to read",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "instructions": "#!sys.read",
+                "id": "sys.read",
+                "source": {}
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "sys.read",
+            "parentID": "call_QW4r1m85pmK7aqYudiIo2CcY",
+            "displayText": "Reading `testdata/BobAsShell/test.gpt`"
+        },
+        "type": "callStart",
+        "usage": {},
+        "content": "{\"filename\":\"testdata/BobAsShell/test.gpt\"}"
+    },
+    {
+        "time": "2024-08-06T11:48:42.69261-04:00",
+        "callContext": {
+            "id": "call_yxddr1hEZCeKvwY7xiU4Rir9",
+            "tool": {
+                "name": "sys.read",
+                "description": "Reads the contents of a file",
+                "modelName": "gpt-4o-2024-05-13",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "filename": {
+                            "description": "The name of the file to read",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "instructions": "#!sys.read",
+                "id": "sys.read",
+                "source": {}
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "sys.read",
+            "parentID": "call_QW4r1m85pmK7aqYudiIo2CcY",
+            "displayText": "Reading `testdata/BobAsShell/test.gpt`"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722959328",
+        "usage": {},
+        "chatRequest": {
+            "model": "",
+            "messages": null
+        }
+    },
+    {
+        "time": "2024-08-06T11:48:42.692928-04:00",
+        "callContext": {
+            "id": "call_yxddr1hEZCeKvwY7xiU4Rir9",
+            "tool": {
+                "name": "sys.read",
+                "description": "Reads the contents of a file",
+                "modelName": "gpt-4o-2024-05-13",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "filename": {
+                            "description": "The name of the file to read",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "instructions": "#!sys.read",
+                "id": "sys.read",
+                "source": {}
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "sys.read",
+            "parentID": "call_QW4r1m85pmK7aqYudiIo2CcY",
+            "displayText": "Reading `testdata/BobAsShell/test.gpt`"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722959328",
+        "usage": {},
+        "chatResponse": {
+            "usage": {}
+        }
+    },
+    {
+        "time": "2024-08-06T11:48:42.69301-04:00",
+        "callContext": {
+            "id": "call_yxddr1hEZCeKvwY7xiU4Rir9",
+            "tool": {
+                "name": "sys.read",
+                "description": "Reads the contents of a file",
+                "modelName": "gpt-4o-2024-05-13",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "filename": {
+                            "description": "The name of the file to read",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "instructions": "#!sys.read",
+                "id": "sys.read",
+                "source": {}
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "sys.read",
+            "parentID": "call_QW4r1m85pmK7aqYudiIo2CcY",
+            "displayText": "Reading `testdata/BobAsShell/test.gpt`"
+        },
+        "type": "callFinish",
+        "usage": {},
+        "content": "\ntools: bob\n\nAsk Bob \"how are you doing\" and repeat his reply exactly.\n\n---\nname: bob\ndescription: I'm Bob, a friendly guy.\nargs: question: The question to ask Bob.\n\n#!/bin/bash\n\necho \"Thanks for asking ${question}, I'm doing great fellow friendly AI tool!\"\n"
+    },
+    {
+        "time": "2024-08-06T11:48:42.693067-04:00",
+        "callContext": {
+            "id": "call_QW4r1m85pmK7aqYudiIo2CcY",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "gpt-4o-2024-05-13",
+                "temperature": 0.7,
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722959319"
+        },
+        "toolResults": 1,
+        "type": "callContinue",
+        "usage": {}
+    },
+    {
+        "time": "2024-08-06T11:48:42.693171-04:00",
+        "callContext": {
+            "id": "call_QW4r1m85pmK7aqYudiIo2CcY",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "gpt-4o-2024-05-13",
+                "temperature": 0.7,
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722959319"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722959329",
+        "usage": {},
+        "chatRequest": {
+            "model": "gpt-4o-2024-05-13",
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "\nYou are task oriented system.\nYou receive input from a user, process the input from the given instructions, and then output the result.\nYour objective is to provide consistent and correct results.\nYou do not need to explain the steps taken, only provide the result to the given instructions.\nYou are referred to as a tool.\nYou don't move to the next step until you have a result.\n\nRead ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate."
+                },
+                {
+                    "role": "user",
+                    "content": "{\"file\": \"testdata/BobAsShell/test.gpt\"}"
+                },
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "call_yxddr1hEZCeKvwY7xiU4Rir9",
+                            "type": "function",
+                            "function": {
+                                "name": "read",
+                                "arguments": "{\"filename\":\"testdata/BobAsShell/test.gpt\"}"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "role": "tool",
+                    "content": "\ntools: bob\n\nAsk Bob \"how are you doing\" and repeat his reply exactly.\n\n---\nname: bob\ndescription: I'm Bob, a friendly guy.\nargs: question: The question to ask Bob.\n\n#!/bin/bash\n\necho \"Thanks for asking ${question}, I'm doing great fellow friendly AI tool!\"\n",
+                    "name": "read",
+                    "tool_call_id": "call_yxddr1hEZCeKvwY7xiU4Rir9"
+                }
+            ],
+            "temperature": 0.7,
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "read",
+                        "description": "Reads the contents of a file",
+                        "parameters": {
+                            "properties": {
+                                "filename": {
+                                    "description": "The name of the file to read",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    {
+        "time": "2024-08-06T11:48:44.050796-04:00",
+        "callContext": {
+            "id": "call_QW4r1m85pmK7aqYudiIo2CcY",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "gpt-4o-2024-05-13",
+                "temperature": 0.7,
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722959319"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722959329",
+        "usage": {
+            "promptTokens": 276,
+            "completionTokens": 60,
+            "totalTokens": 336
+        },
+        "chatResponse": {
+            "role": "assistant",
+            "content": [
+                {
+                    "text": "The GPTScript file demonstrates how to use a tool named \"bob\" to ask a question (\"how are you doing\") and repeat Bob's reply exactly. The technique shown includes defining the tool's name, description, and arguments, followed by a script that echoes a response using the provided question."
+                }
+            ],
+            "usage": {
+                "promptTokens": 276,
+                "completionTokens": 60,
+                "totalTokens": 336
+            }
+        }
+    },
+    {
+        "time": "2024-08-06T11:48:44.050886-04:00",
+        "callContext": {
+            "id": "call_QW4r1m85pmK7aqYudiIo2CcY",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "gpt-4o-2024-05-13",
+                "temperature": 0.7,
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722959319"
+        },
+        "type": "callFinish",
+        "usage": {},
+        "content": "The GPTScript file demonstrates how to use a tool named \"bob\" to ask a question (\"how are you doing\") and repeat Bob's reply exactly. The technique shown includes defining the tool's name, description, and arguments, followed by a script that echoes a response using the provided question."
+    },
+    {
+        "time": "2024-08-06T11:48:44.451695-04:00",
+        "callContext": {
+            "id": "call_B31GmzDYcNLo0yYUAyG8dYPA",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "gpt-4o-2024-05-13",
+                "temperature": 0.7,
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722959319"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722959324",
+        "usage": {
+            "promptTokens": 183,
+            "completionTokens": 19,
+            "totalTokens": 202
+        },
+        "chatResponse": {
+            "role": "assistant",
+            "content": [
+                {
+                    "toolCall": {
+                        "index": 0,
+                        "id": "call_H9rxnlV9BmlZnIvKTWqMyF9m",
+                        "function": {
+                            "name": "read",
+                            "arguments": "{\"filename\":\"testdata/Bob/test.gpt\"}"
+                        }
+                    }
+                }
+            ],
+            "usage": {
+                "promptTokens": 183,
+                "completionTokens": 19,
+                "totalTokens": 202
+            }
+        }
+    },
+    {
+        "time": "2024-08-06T11:48:44.451837-04:00",
+        "callContext": {
+            "id": "call_B31GmzDYcNLo0yYUAyG8dYPA",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "gpt-4o-2024-05-13",
+                "temperature": 0.7,
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722959319"
+        },
+        "toolSubCalls": {
+            "call_H9rxnlV9BmlZnIvKTWqMyF9m": {
+                "toolID": "sys.read",
+                "input": "{\"filename\":\"testdata/Bob/test.gpt\"}"
+            }
+        },
+        "type": "callSubCalls",
+        "usage": {}
+    },
+    {
+        "time": "2024-08-06T11:48:44.452024-04:00",
+        "callContext": {
+            "id": "call_H9rxnlV9BmlZnIvKTWqMyF9m",
+            "tool": {
+                "name": "sys.read",
+                "description": "Reads the contents of a file",
+                "modelName": "gpt-4o-2024-05-13",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "filename": {
+                            "description": "The name of the file to read",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "instructions": "#!sys.read",
+                "id": "sys.read",
+                "source": {}
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "sys.read",
+            "parentID": "call_B31GmzDYcNLo0yYUAyG8dYPA",
+            "displayText": "Reading `testdata/Bob/test.gpt`"
+        },
+        "type": "callStart",
+        "usage": {},
+        "content": "{\"filename\":\"testdata/Bob/test.gpt\"}"
+    },
+    {
+        "time": "2024-08-06T11:48:44.452301-04:00",
+        "callContext": {
+            "id": "call_H9rxnlV9BmlZnIvKTWqMyF9m",
+            "tool": {
+                "name": "sys.read",
+                "description": "Reads the contents of a file",
+                "modelName": "gpt-4o-2024-05-13",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "filename": {
+                            "description": "The name of the file to read",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "instructions": "#!sys.read",
+                "id": "sys.read",
+                "source": {}
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "sys.read",
+            "parentID": "call_B31GmzDYcNLo0yYUAyG8dYPA",
+            "displayText": "Reading `testdata/Bob/test.gpt`"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722959330",
+        "usage": {},
+        "chatRequest": {
+            "model": "",
+            "messages": null
+        }
+    },
+    {
+        "time": "2024-08-06T11:48:44.452619-04:00",
+        "callContext": {
+            "id": "call_H9rxnlV9BmlZnIvKTWqMyF9m",
+            "tool": {
+                "name": "sys.read",
+                "description": "Reads the contents of a file",
+                "modelName": "gpt-4o-2024-05-13",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "filename": {
+                            "description": "The name of the file to read",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "instructions": "#!sys.read",
+                "id": "sys.read",
+                "source": {}
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "sys.read",
+            "parentID": "call_B31GmzDYcNLo0yYUAyG8dYPA",
+            "displayText": "Reading `testdata/Bob/test.gpt`"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722959330",
+        "usage": {},
+        "chatResponse": {
+            "usage": {}
+        }
+    },
+    {
+        "time": "2024-08-06T11:48:44.452723-04:00",
+        "callContext": {
+            "id": "call_H9rxnlV9BmlZnIvKTWqMyF9m",
+            "tool": {
+                "name": "sys.read",
+                "description": "Reads the contents of a file",
+                "modelName": "gpt-4o-2024-05-13",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "filename": {
+                            "description": "The name of the file to read",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "instructions": "#!sys.read",
+                "id": "sys.read",
+                "source": {}
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "sys.read",
+            "parentID": "call_B31GmzDYcNLo0yYUAyG8dYPA",
+            "displayText": "Reading `testdata/Bob/test.gpt`"
+        },
+        "type": "callFinish",
+        "usage": {},
+        "content": "tools: bob\n\nAsk Bob \"how are you doing\" and repeat his reply exactly.\n\n---\nname: bob\ndescription: I'm Bob, a friendly guy.\nargs: question: The question to ask Bob.\n\nWhen asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"\n"
+    },
+    {
+        "time": "2024-08-06T11:48:44.452831-04:00",
+        "callContext": {
+            "id": "call_B31GmzDYcNLo0yYUAyG8dYPA",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "gpt-4o-2024-05-13",
+                "temperature": 0.7,
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722959319"
+        },
+        "toolResults": 1,
+        "type": "callContinue",
+        "usage": {}
+    },
+    {
+        "time": "2024-08-06T11:48:44.452934-04:00",
+        "callContext": {
+            "id": "call_B31GmzDYcNLo0yYUAyG8dYPA",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "gpt-4o-2024-05-13",
+                "temperature": 0.7,
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722959319"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722959331",
+        "usage": {},
+        "chatRequest": {
+            "model": "gpt-4o-2024-05-13",
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "\nYou are task oriented system.\nYou receive input from a user, process the input from the given instructions, and then output the result.\nYour objective is to provide consistent and correct results.\nYou do not need to explain the steps taken, only provide the result to the given instructions.\nYou are referred to as a tool.\nYou don't move to the next step until you have a result.\n\nRead ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate."
+                },
+                {
+                    "role": "user",
+                    "content": "{\"file\": \"testdata/Bob/test.gpt\"}"
+                },
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "call_H9rxnlV9BmlZnIvKTWqMyF9m",
+                            "type": "function",
+                            "function": {
+                                "name": "read",
+                                "arguments": "{\"filename\":\"testdata/Bob/test.gpt\"}"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "role": "tool",
+                    "content": "tools: bob\n\nAsk Bob \"how are you doing\" and repeat his reply exactly.\n\n---\nname: bob\ndescription: I'm Bob, a friendly guy.\nargs: question: The question to ask Bob.\n\nWhen asked how I am doing, respond with exactly \"Thanks for asking \"${question}\", I'm doing great fellow friendly AI tool!\"\n",
+                    "name": "read",
+                    "tool_call_id": "call_H9rxnlV9BmlZnIvKTWqMyF9m"
+                }
+            ],
+            "temperature": 0.7,
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "read",
+                        "description": "Reads the contents of a file",
+                        "parameters": {
+                            "properties": {
+                                "filename": {
+                                    "description": "The name of the file to read",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    {
+        "time": "2024-08-06T11:48:45.690878-04:00",
+        "callContext": {
+            "id": "call_B31GmzDYcNLo0yYUAyG8dYPA",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "gpt-4o-2024-05-13",
+                "temperature": 0.7,
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722959319"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722959331",
+        "usage": {
+            "promptTokens": 276,
+            "completionTokens": 69,
+            "totalTokens": 345
+        },
+        "chatResponse": {
+            "role": "assistant",
+            "content": [
+                {
+                    "text": "The GPTScript file contains a script for interacting with a tool named \"Bob.\" The script demonstrates the technique of asking \"Bob\" a question, specifically \"how are you doing,\" and then repeating his reply exactly. Bob's response is predefined to be \"Thanks for asking 'how are you doing', I'm doing great fellow friendly AI tool!\""
+                }
+            ],
+            "usage": {
+                "promptTokens": 276,
+                "completionTokens": 69,
+                "totalTokens": 345
+            }
+        }
+    },
+    {
+        "time": "2024-08-06T11:48:45.690956-04:00",
+        "callContext": {
+            "id": "call_B31GmzDYcNLo0yYUAyG8dYPA",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "gpt-4o-2024-05-13",
+                "temperature": 0.7,
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722959319"
+        },
+        "type": "callFinish",
+        "usage": {},
+        "content": "The GPTScript file contains a script for interacting with a tool named \"Bob.\" The script demonstrates the technique of asking \"Bob\" a question, specifically \"how are you doing,\" and then repeating his reply exactly. Bob's response is predefined to be \"Thanks for asking 'how are you doing', I'm doing great fellow friendly AI tool!\""
+    },
+    {
+        "time": "2024-08-06T11:48:45.901892-04:00",
+        "callContext": {
+            "id": "call_df2WDMbaXZLMbH6MWT9my9fy",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "gpt-4o-2024-05-13",
+                "temperature": 0.7,
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722959319"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722959327",
+        "usage": {
+            "promptTokens": 329,
+            "completionTokens": 73,
+            "totalTokens": 402
+        },
+        "chatResponse": {
+            "role": "assistant",
+            "content": [
+                {
+                    "text": "The GPTScript file contains instructions to generate a consolidated summary of each sample *.gpt file in the \"testdata\" directory. The file is leveraging two tools: `sys.find` to locate the sample files and `summary` to generate a summary for each found file. This script demonstrates the technique of file handling and summarization within the GPTScript language."
+                }
+            ],
+            "usage": {
+                "promptTokens": 329,
+                "completionTokens": 73,
+                "totalTokens": 402
+            }
+        }
+    },
+    {
+        "time": "2024-08-06T11:48:45.901987-04:00",
+        "callContext": {
+            "id": "call_df2WDMbaXZLMbH6MWT9my9fy",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "gpt-4o-2024-05-13",
+                "temperature": 0.7,
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722959319"
+        },
+        "type": "callFinish",
+        "usage": {},
+        "content": "The GPTScript file contains instructions to generate a consolidated summary of each sample *.gpt file in the \"testdata\" directory. The file is leveraging two tools: `sys.find` to locate the sample files and `summary` to generate a summary for each found file. This script demonstrates the technique of file handling and summarization within the GPTScript language."
+    },
+    {
+        "time": "2024-08-06T11:48:45.902114-04:00",
+        "callContext": {
+            "id": "1722959319",
+            "tool": {
+                "modelName": "gpt-4o-2024-05-13",
+                "internalPrompt": null,
+                "tools": [
+                    "sys.find",
+                    "summary"
+                ],
+                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "id": "testdata/SamplesReadme/test.gpt:",
+                "toolMapping": {
+                    "summary": [
+                        {
+                            "reference": "summary",
+                            "toolID": "testdata/SamplesReadme/test.gpt:summary"
+                        }
+                    ],
+                    "sys.find": [
+                        {
+                            "reference": "sys.find",
+                            "toolID": "sys.find"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 1
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null
+        },
+        "toolResults": 3,
+        "type": "callContinue",
+        "usage": {}
+    },
+    {
+        "time": "2024-08-06T11:48:45.902307-04:00",
+        "callContext": {
+            "id": "1722959319",
+            "tool": {
+                "modelName": "gpt-4o-2024-05-13",
+                "internalPrompt": null,
+                "tools": [
+                    "sys.find",
+                    "summary"
+                ],
+                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "id": "testdata/SamplesReadme/test.gpt:",
+                "toolMapping": {
+                    "summary": [
+                        {
+                            "reference": "summary",
+                            "toolID": "testdata/SamplesReadme/test.gpt:summary"
+                        }
+                    ],
+                    "sys.find": [
+                        {
+                            "reference": "sys.find",
+                            "toolID": "sys.find"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 1
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722959332",
+        "usage": {},
+        "chatRequest": {
+            "model": "gpt-4o-2024-05-13",
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "\nYou are task oriented system.\nYou receive input from a user, process the input from the given instructions, and then output the result.\nYour objective is to provide consistent and correct results.\nYou do not need to explain the steps taken, only provide the result to the given instructions.\nYou are referred to as a tool.\nYou don't move to the next step until you have a result.\n\nGenerate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file."
+                },
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "call_jM3KPkDXwEIo6IFTvqNQSVBf",
+                            "type": "function",
+                            "function": {
+                                "name": "find",
+                                "arguments": "{\"directory\":\"testdata\",\"pattern\":\"*.gpt\"}"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "role": "tool",
+                    "content": "testdata/Bob/test.gpt\ntestdata/BobAsShell/test.gpt\ntestdata/SamplesReadme/test.gpt",
+                    "name": "find",
+                    "tool_call_id": "call_jM3KPkDXwEIo6IFTvqNQSVBf"
+                },
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "call_B31GmzDYcNLo0yYUAyG8dYPA",
+                            "type": "function",
+                            "function": {
+                                "name": "summary",
+                                "arguments": "{\"file\": \"testdata/Bob/test.gpt\"}"
+                            }
+                        },
+                        {
+                            "id": "call_QW4r1m85pmK7aqYudiIo2CcY",
+                            "type": "function",
+                            "function": {
+                                "name": "summary",
+                                "arguments": "{\"file\": \"testdata/BobAsShell/test.gpt\"}"
+                            }
+                        },
+                        {
+                            "id": "call_df2WDMbaXZLMbH6MWT9my9fy",
+                            "type": "function",
+                            "function": {
+                                "name": "summary",
+                                "arguments": "{\"file\": \"testdata/SamplesReadme/test.gpt\"}"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "role": "tool",
+                    "content": "The GPTScript file contains a script for interacting with a tool named \"Bob.\" The script demonstrates the technique of asking \"Bob\" a question, specifically \"how are you doing,\" and then repeating his reply exactly. Bob's response is predefined to be \"Thanks for asking 'how are you doing', I'm doing great fellow friendly AI tool!\"",
+                    "name": "summary",
+                    "tool_call_id": "call_B31GmzDYcNLo0yYUAyG8dYPA"
+                },
+                {
+                    "role": "tool",
+                    "content": "The GPTScript file demonstrates how to use a tool named \"bob\" to ask a question (\"how are you doing\") and repeat Bob's reply exactly. The technique shown includes defining the tool's name, description, and arguments, followed by a script that echoes a response using the provided question.",
+                    "name": "summary",
+                    "tool_call_id": "call_QW4r1m85pmK7aqYudiIo2CcY"
+                },
+                {
+                    "role": "tool",
+                    "content": "The GPTScript file contains instructions to generate a consolidated summary of each sample *.gpt file in the \"testdata\" directory. The file is leveraging two tools: `sys.find` to locate the sample files and `summary` to generate a summary for each found file. This script demonstrates the technique of file handling and summarization within the GPTScript language.",
+                    "name": "summary",
+                    "tool_call_id": "call_df2WDMbaXZLMbH6MWT9my9fy"
+                }
+            ],
+            "temperature": 0,
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "find",
+                        "description": "Traverse a directory looking for files that match a pattern in the style of the unix find command",
+                        "parameters": {
+                            "properties": {
+                                "directory": {
+                                    "description": "The directory to search in. The current directory \".\" will be used as the default if no argument is passed",
+                                    "type": "string"
+                                },
+                                "pattern": {
+                                    "description": "The file pattern to look for. The pattern is a traditional unix glob format with * matching any character and ? matching a single character",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                },
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "summary",
+                        "description": "Summarize a gpt file",
+                        "parameters": {
+                            "properties": {
+                                "file": {
+                                    "description": "filename to summarize",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    {
+        "time": "2024-08-06T11:48:50.812402-04:00",
+        "callContext": {
+            "id": "1722959319",
+            "tool": {
+                "modelName": "gpt-4o-2024-05-13",
+                "internalPrompt": null,
+                "tools": [
+                    "sys.find",
+                    "summary"
+                ],
+                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "id": "testdata/SamplesReadme/test.gpt:",
+                "toolMapping": {
+                    "summary": [
+                        {
+                            "reference": "summary",
+                            "toolID": "testdata/SamplesReadme/test.gpt:summary"
+                        }
+                    ],
+                    "sys.find": [
+                        {
+                            "reference": "sys.find",
+                            "toolID": "sys.find"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 1
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722959332",
+        "usage": {
+            "promptTokens": 588,
+            "completionTokens": 273,
+            "totalTokens": 861
+        },
+        "chatResponse": {
+            "role": "assistant",
+            "content": [
+                {
+                    "text": "# Consolidated Summary of Sample *.gpt Files\n\n## [testdata/Bob/test.gpt](testdata/Bob/test.gpt)\nThe GPTScript file contains a script for interacting with a tool named \"Bob.\" The script demonstrates the technique of asking \"Bob\" a question, specifically \"how are you doing,\" and then repeating his reply exactly. Bob's response is predefined to be \"Thanks for asking 'how are you doing', I'm doing great fellow friendly AI tool!\"\n\n## [testdata/BobAsShell/test.gpt](testdata/BobAsShell/test.gpt)\nThe GPTScript file demonstrates how to use a tool named \"bob\" to ask a question (\"how are you doing\") and repeat Bob's reply exactly. The technique shown includes defining the tool's name, description, and arguments, followed by a script that echoes a response using the provided question.\n\n## [testdata/SamplesReadme/test.gpt](testdata/SamplesReadme/test.gpt)\nThe GPTScript file contains instructions to generate a consolidated summary of each sample *.gpt file in the \"testdata\" directory. The file is leveraging two tools: `sys.find` to locate the sample files and `summary` to generate a summary for each found file. This script demonstrates the technique of file handling and summarization within the GPTScript language."
+                }
+            ],
+            "usage": {
+                "promptTokens": 588,
+                "completionTokens": 273,
+                "totalTokens": 861
+            }
+        }
+    },
+    {
+        "time": "2024-08-06T11:48:50.8125-04:00",
+        "callContext": {
+            "id": "1722959319",
+            "tool": {
+                "modelName": "gpt-4o-2024-05-13",
+                "internalPrompt": null,
+                "tools": [
+                    "sys.find",
+                    "summary"
+                ],
+                "instructions": "Generate a readme that gives a consolidated summary of each sample *.gpt file in testdata \nEach entry should be a include a link to the referenced file.",
+                "id": "testdata/SamplesReadme/test.gpt:",
+                "toolMapping": {
+                    "summary": [
+                        {
+                            "reference": "summary",
+                            "toolID": "testdata/SamplesReadme/test.gpt:summary"
+                        }
+                    ],
+                    "sys.find": [
+                        {
+                            "reference": "sys.find",
+                            "toolID": "sys.find"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 1
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null
+        },
+        "type": "callFinish",
+        "usage": {},
+        "content": "# Consolidated Summary of Sample *.gpt Files\n\n## [testdata/Bob/test.gpt](testdata/Bob/test.gpt)\nThe GPTScript file contains a script for interacting with a tool named \"Bob.\" The script demonstrates the technique of asking \"Bob\" a question, specifically \"how are you doing,\" and then repeating his reply exactly. Bob's response is predefined to be \"Thanks for asking 'how are you doing', I'm doing great fellow friendly AI tool!\"\n\n## [testdata/BobAsShell/test.gpt](testdata/BobAsShell/test.gpt)\nThe GPTScript file demonstrates how to use a tool named \"bob\" to ask a question (\"how are you doing\") and repeat Bob's reply exactly. The technique shown includes defining the tool's name, description, and arguments, followed by a script that echoes a response using the provided question.\n\n## [testdata/SamplesReadme/test.gpt](testdata/SamplesReadme/test.gpt)\nThe GPTScript file contains instructions to generate a consolidated summary of each sample *.gpt file in the \"testdata\" directory. The file is leveraging two tools: `sys.find` to locate the sample files and `summary` to generate a summary for each found file. This script demonstrates the technique of file handling and summarization within the GPTScript language."
+    },
+    {
+        "time": "2024-08-06T11:48:50.812569-04:00",
+        "type": "runFinish",
+        "usage": {}
+    }
+]

--- a/pkg/tests/smoke/testdata/SamplesReadme/gpt-4o-2024-08-06-expected.json
+++ b/pkg/tests/smoke/testdata/SamplesReadme/gpt-4o-2024-08-06-expected.json
@@ -1,15 +1,15 @@
 [
     {
-        "time": "2024-08-23T12:02:30.704153-04:00",
+        "time": "2024-08-23T10:47:07.984751-04:00",
         "type": "runStart",
         "usage": {}
     },
     {
-        "time": "2024-08-23T12:02:30.704518-04:00",
+        "time": "2024-08-23T10:47:07.985158-04:00",
         "callContext": {
-            "id": "1724428951",
+            "id": "1724424428",
             "tool": {
-                "modelName": "gpt-4-turbo-2024-04-09",
+                "modelName": "gpt-4o-2024-08-06",
                 "internalPrompt": null,
                 "tools": [
                     "sys.find",
@@ -55,11 +55,11 @@
         "usage": {}
     },
     {
-        "time": "2024-08-23T12:02:30.704572-04:00",
+        "time": "2024-08-23T10:47:07.985235-04:00",
         "callContext": {
-            "id": "1724428951",
+            "id": "1724424428",
             "tool": {
-                "modelName": "gpt-4-turbo-2024-04-09",
+                "modelName": "gpt-4o-2024-08-06",
                 "internalPrompt": null,
                 "tools": [
                     "sys.find",
@@ -102,10 +102,10 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1724428952",
+        "chatCompletionId": "1724424429",
         "usage": {},
         "chatRequest": {
-            "model": "gpt-4-turbo-2024-04-09",
+            "model": "gpt-4o-2024-08-06",
             "messages": [
                 {
                     "role": "system",
@@ -170,11 +170,11 @@
         }
     },
     {
-        "time": "2024-08-23T12:02:31.630767-04:00",
+        "time": "2024-08-23T10:47:08.496595-04:00",
         "callContext": {
-            "id": "1724428951",
+            "id": "1724424428",
             "tool": {
-                "modelName": "gpt-4-turbo-2024-04-09",
+                "modelName": "gpt-4o-2024-08-06",
                 "internalPrompt": null,
                 "tools": [
                     "sys.find",
@@ -217,11 +217,11 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1724428952",
+        "chatCompletionId": "1724424429",
         "usage": {
-            "promptTokens": 279,
-            "completionTokens": 15,
-            "totalTokens": 294
+            "promptTokens": 272,
+            "completionTokens": 20,
+            "totalTokens": 292
         },
         "chatResponse": {
             "role": "assistant",
@@ -229,27 +229,27 @@
                 {
                     "toolCall": {
                         "index": 0,
-                        "id": "call_pV8RVkvcyzi8QbqeXcdCkAZd",
+                        "id": "call_GhPYkhrIge98l3U0CMJramDL",
                         "function": {
                             "name": "find",
-                            "arguments": "{\"pattern\":\"*.gpt\"}"
+                            "arguments": "{\"directory\":\"testdata\",\"pattern\":\"*.gpt\"}"
                         }
                     }
                 }
             ],
             "usage": {
-                "promptTokens": 279,
-                "completionTokens": 15,
-                "totalTokens": 294
+                "promptTokens": 272,
+                "completionTokens": 20,
+                "totalTokens": 292
             }
         }
     },
     {
-        "time": "2024-08-23T12:02:31.630876-04:00",
+        "time": "2024-08-23T10:47:08.496757-04:00",
         "callContext": {
-            "id": "1724428951",
+            "id": "1724424428",
             "tool": {
-                "modelName": "gpt-4-turbo-2024-04-09",
+                "modelName": "gpt-4o-2024-08-06",
                 "internalPrompt": null,
                 "tools": [
                     "sys.find",
@@ -292,22 +292,22 @@
             "inputContext": null
         },
         "toolSubCalls": {
-            "call_pV8RVkvcyzi8QbqeXcdCkAZd": {
+            "call_GhPYkhrIge98l3U0CMJramDL": {
                 "toolID": "sys.find",
-                "input": "{\"pattern\":\"*.gpt\"}"
+                "input": "{\"directory\":\"testdata\",\"pattern\":\"*.gpt\"}"
             }
         },
         "type": "callSubCalls",
         "usage": {}
     },
     {
-        "time": "2024-08-23T12:02:31.630937-04:00",
+        "time": "2024-08-23T10:47:08.496945-04:00",
         "callContext": {
-            "id": "call_pV8RVkvcyzi8QbqeXcdCkAZd",
+            "id": "call_GhPYkhrIge98l3U0CMJramDL",
             "tool": {
                 "name": "sys.find",
                 "description": "Traverse a directory looking for files that match a pattern in the style of the unix find command",
-                "modelName": "gpt-4-turbo-2024-04-09",
+                "modelName": "gpt-4o-2024-08-06",
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -329,21 +329,21 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "sys.find",
-            "parentID": "1724428951",
-            "displayText": "Finding `*.gpt` in `.`"
+            "parentID": "1724424428",
+            "displayText": "Finding `*.gpt` in `testdata`"
         },
         "type": "callStart",
         "usage": {},
-        "content": "{\"pattern\":\"*.gpt\"}"
+        "content": "{\"directory\":\"testdata\",\"pattern\":\"*.gpt\"}"
     },
     {
-        "time": "2024-08-23T12:02:31.631018-04:00",
+        "time": "2024-08-23T10:47:08.497205-04:00",
         "callContext": {
-            "id": "call_pV8RVkvcyzi8QbqeXcdCkAZd",
+            "id": "call_GhPYkhrIge98l3U0CMJramDL",
             "tool": {
                 "name": "sys.find",
                 "description": "Traverse a directory looking for files that match a pattern in the style of the unix find command",
-                "modelName": "gpt-4-turbo-2024-04-09",
+                "modelName": "gpt-4o-2024-08-06",
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -365,11 +365,11 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "sys.find",
-            "parentID": "1724428951",
-            "displayText": "Finding `*.gpt` in `.`"
+            "parentID": "1724424428",
+            "displayText": "Finding `*.gpt` in `testdata`"
         },
         "type": "callChat",
-        "chatCompletionId": "1724428953",
+        "chatCompletionId": "1724424430",
         "usage": {},
         "chatRequest": {
             "model": "",
@@ -377,13 +377,13 @@
         }
     },
     {
-        "time": "2024-08-23T12:02:31.631307-04:00",
+        "time": "2024-08-23T10:47:08.497917-04:00",
         "callContext": {
-            "id": "call_pV8RVkvcyzi8QbqeXcdCkAZd",
+            "id": "call_GhPYkhrIge98l3U0CMJramDL",
             "tool": {
                 "name": "sys.find",
                 "description": "Traverse a directory looking for files that match a pattern in the style of the unix find command",
-                "modelName": "gpt-4-turbo-2024-04-09",
+                "modelName": "gpt-4o-2024-08-06",
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -405,24 +405,24 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "sys.find",
-            "parentID": "1724428951",
-            "displayText": "Finding `*.gpt` in `.`"
+            "parentID": "1724424428",
+            "displayText": "Finding `*.gpt` in `testdata`"
         },
         "type": "callChat",
-        "chatCompletionId": "1724428953",
+        "chatCompletionId": "1724424430",
         "usage": {},
         "chatResponse": {
             "usage": {}
         }
     },
     {
-        "time": "2024-08-23T12:02:31.631343-04:00",
+        "time": "2024-08-23T10:47:08.49798-04:00",
         "callContext": {
-            "id": "call_pV8RVkvcyzi8QbqeXcdCkAZd",
+            "id": "call_GhPYkhrIge98l3U0CMJramDL",
             "tool": {
                 "name": "sys.find",
                 "description": "Traverse a directory looking for files that match a pattern in the style of the unix find command",
-                "modelName": "gpt-4-turbo-2024-04-09",
+                "modelName": "gpt-4o-2024-08-06",
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -444,19 +444,19 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "sys.find",
-            "parentID": "1724428951",
-            "displayText": "Finding `*.gpt` in `.`"
+            "parentID": "1724424428",
+            "displayText": "Finding `*.gpt` in `testdata`"
         },
         "type": "callFinish",
         "usage": {},
         "content": "testdata/Bob/test.gpt\ntestdata/BobAsShell/test.gpt\ntestdata/SamplesReadme/test.gpt"
     },
     {
-        "time": "2024-08-23T12:02:31.631378-04:00",
+        "time": "2024-08-23T10:47:08.49804-04:00",
         "callContext": {
-            "id": "1724428951",
+            "id": "1724424428",
             "tool": {
-                "modelName": "gpt-4-turbo-2024-04-09",
+                "modelName": "gpt-4o-2024-08-06",
                 "internalPrompt": null,
                 "tools": [
                     "sys.find",
@@ -503,11 +503,11 @@
         "usage": {}
     },
     {
-        "time": "2024-08-23T12:02:31.63142-04:00",
+        "time": "2024-08-23T10:47:08.498098-04:00",
         "callContext": {
-            "id": "1724428951",
+            "id": "1724424428",
             "tool": {
-                "modelName": "gpt-4-turbo-2024-04-09",
+                "modelName": "gpt-4o-2024-08-06",
                 "internalPrompt": null,
                 "tools": [
                     "sys.find",
@@ -550,10 +550,10 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1724428954",
+        "chatCompletionId": "1724424431",
         "usage": {},
         "chatRequest": {
-            "model": "gpt-4-turbo-2024-04-09",
+            "model": "gpt-4o-2024-08-06",
             "messages": [
                 {
                     "role": "system",
@@ -564,11 +564,11 @@
                     "content": "",
                     "tool_calls": [
                         {
-                            "id": "call_pV8RVkvcyzi8QbqeXcdCkAZd",
+                            "id": "call_GhPYkhrIge98l3U0CMJramDL",
                             "type": "function",
                             "function": {
                                 "name": "find",
-                                "arguments": "{\"pattern\":\"*.gpt\"}"
+                                "arguments": "{\"directory\":\"testdata\",\"pattern\":\"*.gpt\"}"
                             }
                         }
                     ]
@@ -577,7 +577,7 @@
                     "role": "tool",
                     "content": "testdata/Bob/test.gpt\ntestdata/BobAsShell/test.gpt\ntestdata/SamplesReadme/test.gpt",
                     "name": "find",
-                    "tool_call_id": "call_pV8RVkvcyzi8QbqeXcdCkAZd"
+                    "tool_call_id": "call_GhPYkhrIge98l3U0CMJramDL"
                 }
             ],
             "temperature": 0,
@@ -638,106 +638,11 @@
         }
     },
     {
-        "time": "2024-08-23T12:02:34.373298-04:00",
+        "time": "2024-08-23T10:47:10.013981-04:00",
         "callContext": {
-            "id": "1724428951",
+            "id": "1724424428",
             "tool": {
-                "modelName": "gpt-4-turbo-2024-04-09",
-                "internalPrompt": null,
-                "tools": [
-                    "sys.find",
-                    "sys.read",
-                    "summary"
-                ],
-                "instructions": "Generate a readme that gives a consolidated summary of each *.gpt file in the testdata directory.\nEach entry should be a include a link to the referenced file.",
-                "id": "testdata/SamplesReadme/test.gpt:",
-                "toolMapping": {
-                    "summary": [
-                        {
-                            "reference": "summary",
-                            "toolID": "testdata/SamplesReadme/test.gpt:summary"
-                        }
-                    ],
-                    "sys.find": [
-                        {
-                            "reference": "sys.find",
-                            "toolID": "sys.find"
-                        }
-                    ],
-                    "sys.read": [
-                        {
-                            "reference": "sys.read",
-                            "toolID": "sys.read"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/SamplesReadme/test.gpt:",
-                    "summary": "testdata/SamplesReadme/test.gpt:summary"
-                },
-                "source": {
-                    "location": "testdata/SamplesReadme/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/SamplesReadme"
-            },
-            "currentAgent": {},
-            "inputContext": null
-        },
-        "type": "callChat",
-        "chatCompletionId": "1724428954",
-        "usage": {
-            "promptTokens": 325,
-            "completionTokens": 73,
-            "totalTokens": 398
-        },
-        "chatResponse": {
-            "role": "assistant",
-            "content": [
-                {
-                    "toolCall": {
-                        "index": 0,
-                        "id": "call_UJGEKUkaky3cULZKZNu3Cezo",
-                        "function": {
-                            "name": "summary",
-                            "arguments": "{\"file\": \"testdata/Bob/test.gpt\"}"
-                        }
-                    }
-                },
-                {
-                    "toolCall": {
-                        "index": 1,
-                        "id": "call_wpsPQf57CvelJMMqc5pWuzYu",
-                        "function": {
-                            "name": "summary",
-                            "arguments": "{\"file\": \"testdata/BobAsShell/test.gpt\"}"
-                        }
-                    }
-                },
-                {
-                    "toolCall": {
-                        "index": 2,
-                        "id": "call_Lxtq42Kdm8tva08cXF30Bfps",
-                        "function": {
-                            "name": "summary",
-                            "arguments": "{\"file\": \"testdata/SamplesReadme/test.gpt\"}"
-                        }
-                    }
-                }
-            ],
-            "usage": {
-                "promptTokens": 325,
-                "completionTokens": 73,
-                "totalTokens": 398
-            }
-        }
-    },
-    {
-        "time": "2024-08-23T12:02:34.373305-04:00",
-        "callContext": {
-            "id": "1724428951",
-            "tool": {
-                "modelName": "gpt-4-turbo-2024-04-09",
+                "modelName": "gpt-4o-2024-08-06",
                 "internalPrompt": null,
                 "tools": [
                     "sys.find",
@@ -780,30 +685,125 @@
             "inputContext": null
         },
         "toolSubCalls": {
-            "call_Lxtq42Kdm8tva08cXF30Bfps": {
+            "call_PZs7uy2Znd3GrN6MRnppZLqu": {
                 "toolID": "testdata/SamplesReadme/test.gpt:summary",
-                "input": "{\"file\": \"testdata/SamplesReadme/test.gpt\"}"
+                "input": "{\"file\": \"testdata/BobAsShell/test.gpt\"}"
             },
-            "call_UJGEKUkaky3cULZKZNu3Cezo": {
+            "call_unZV9WLReLUEuMaU2Oa6huYs": {
                 "toolID": "testdata/SamplesReadme/test.gpt:summary",
                 "input": "{\"file\": \"testdata/Bob/test.gpt\"}"
             },
-            "call_wpsPQf57CvelJMMqc5pWuzYu": {
+            "call_womMx8To9O2qyCxvcDjeNszl": {
                 "toolID": "testdata/SamplesReadme/test.gpt:summary",
-                "input": "{\"file\": \"testdata/BobAsShell/test.gpt\"}"
+                "input": "{\"file\": \"testdata/SamplesReadme/test.gpt\"}"
             }
         },
         "type": "callSubCalls",
         "usage": {}
     },
     {
-        "time": "2024-08-23T12:02:34.373546-04:00",
+        "time": "2024-08-23T10:47:10.013993-04:00",
         "callContext": {
-            "id": "call_Lxtq42Kdm8tva08cXF30Bfps",
+            "id": "1724424428",
+            "tool": {
+                "modelName": "gpt-4o-2024-08-06",
+                "internalPrompt": null,
+                "tools": [
+                    "sys.find",
+                    "sys.read",
+                    "summary"
+                ],
+                "instructions": "Generate a readme that gives a consolidated summary of each *.gpt file in the testdata directory.\nEach entry should be a include a link to the referenced file.",
+                "id": "testdata/SamplesReadme/test.gpt:",
+                "toolMapping": {
+                    "summary": [
+                        {
+                            "reference": "summary",
+                            "toolID": "testdata/SamplesReadme/test.gpt:summary"
+                        }
+                    ],
+                    "sys.find": [
+                        {
+                            "reference": "sys.find",
+                            "toolID": "sys.find"
+                        }
+                    ],
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 1
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null
+        },
+        "type": "callChat",
+        "chatCompletionId": "1724424431",
+        "usage": {
+            "promptTokens": 326,
+            "completionTokens": 77,
+            "totalTokens": 403
+        },
+        "chatResponse": {
+            "role": "assistant",
+            "content": [
+                {
+                    "toolCall": {
+                        "index": 0,
+                        "id": "call_unZV9WLReLUEuMaU2Oa6huYs",
+                        "function": {
+                            "name": "summary",
+                            "arguments": "{\"file\": \"testdata/Bob/test.gpt\"}"
+                        }
+                    }
+                },
+                {
+                    "toolCall": {
+                        "index": 1,
+                        "id": "call_PZs7uy2Znd3GrN6MRnppZLqu",
+                        "function": {
+                            "name": "summary",
+                            "arguments": "{\"file\": \"testdata/BobAsShell/test.gpt\"}"
+                        }
+                    }
+                },
+                {
+                    "toolCall": {
+                        "index": 2,
+                        "id": "call_womMx8To9O2qyCxvcDjeNszl",
+                        "function": {
+                            "name": "summary",
+                            "arguments": "{\"file\": \"testdata/SamplesReadme/test.gpt\"}"
+                        }
+                    }
+                }
+            ],
+            "usage": {
+                "promptTokens": 326,
+                "completionTokens": 77,
+                "totalTokens": 403
+            }
+        }
+    },
+    {
+        "time": "2024-08-23T10:47:10.014103-04:00",
+        "callContext": {
+            "id": "call_womMx8To9O2qyCxvcDjeNszl",
             "tool": {
                 "name": "summary",
                 "description": "Summarize a gpt file",
-                "modelName": "gpt-4-turbo-2024-04-09",
+                "modelName": "gpt-4o-2024-08-06",
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -840,20 +840,20 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "summary",
-            "parentID": "1724428951"
+            "parentID": "1724424428"
         },
         "type": "callStart",
         "usage": {},
         "content": "{\"file\": \"testdata/SamplesReadme/test.gpt\"}"
     },
     {
-        "time": "2024-08-23T12:02:34.373547-04:00",
+        "time": "2024-08-23T10:47:10.014127-04:00",
         "callContext": {
-            "id": "call_wpsPQf57CvelJMMqc5pWuzYu",
+            "id": "call_unZV9WLReLUEuMaU2Oa6huYs",
             "tool": {
                 "name": "summary",
                 "description": "Summarize a gpt file",
-                "modelName": "gpt-4-turbo-2024-04-09",
+                "modelName": "gpt-4o-2024-08-06",
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -890,70 +890,20 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "summary",
-            "parentID": "1724428951"
-        },
-        "type": "callStart",
-        "usage": {},
-        "content": "{\"file\": \"testdata/BobAsShell/test.gpt\"}"
-    },
-    {
-        "time": "2024-08-23T12:02:34.373556-04:00",
-        "callContext": {
-            "id": "call_UJGEKUkaky3cULZKZNu3Cezo",
-            "tool": {
-                "name": "summary",
-                "description": "Summarize a gpt file",
-                "modelName": "gpt-4-turbo-2024-04-09",
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "file": {
-                            "description": "filename to summarize",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "tools": [
-                    "sys.read"
-                ],
-                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
-                "id": "testdata/SamplesReadme/test.gpt:summary",
-                "toolMapping": {
-                    "sys.read": [
-                        {
-                            "reference": "sys.read",
-                            "toolID": "sys.read"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/SamplesReadme/test.gpt:",
-                    "summary": "testdata/SamplesReadme/test.gpt:summary"
-                },
-                "source": {
-                    "location": "testdata/SamplesReadme/test.gpt",
-                    "lineNo": 7
-                },
-                "workingDir": "testdata/SamplesReadme"
-            },
-            "currentAgent": {},
-            "inputContext": null,
-            "toolName": "summary",
-            "parentID": "1724428951"
+            "parentID": "1724424428"
         },
         "type": "callStart",
         "usage": {},
         "content": "{\"file\": \"testdata/Bob/test.gpt\"}"
     },
     {
-        "time": "2024-08-23T12:02:34.373937-04:00",
+        "time": "2024-08-23T10:47:10.014331-04:00",
         "callContext": {
-            "id": "call_Lxtq42Kdm8tva08cXF30Bfps",
+            "id": "call_womMx8To9O2qyCxvcDjeNszl",
             "tool": {
                 "name": "summary",
                 "description": "Summarize a gpt file",
-                "modelName": "gpt-4-turbo-2024-04-09",
+                "modelName": "gpt-4o-2024-08-06",
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -990,13 +940,13 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "summary",
-            "parentID": "1724428951"
+            "parentID": "1724424428"
         },
         "type": "callChat",
-        "chatCompletionId": "1724428955",
+        "chatCompletionId": "1724424432",
         "usage": {},
         "chatRequest": {
-            "model": "gpt-4-turbo-2024-04-09",
+            "model": "gpt-4o-2024-08-06",
             "messages": [
                 {
                     "role": "system",
@@ -1029,13 +979,13 @@
         }
     },
     {
-        "time": "2024-08-23T12:02:34.374034-04:00",
+        "time": "2024-08-23T10:47:10.014405-04:00",
         "callContext": {
-            "id": "call_wpsPQf57CvelJMMqc5pWuzYu",
+            "id": "call_unZV9WLReLUEuMaU2Oa6huYs",
             "tool": {
                 "name": "summary",
                 "description": "Summarize a gpt file",
-                "modelName": "gpt-4-turbo-2024-04-09",
+                "modelName": "gpt-4o-2024-08-06",
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -1072,95 +1022,13 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "summary",
-            "parentID": "1724428951"
+            "parentID": "1724424428"
         },
         "type": "callChat",
-        "chatCompletionId": "1724428956",
+        "chatCompletionId": "1724424433",
         "usage": {},
         "chatRequest": {
-            "model": "gpt-4-turbo-2024-04-09",
-            "messages": [
-                {
-                    "role": "system",
-                    "content": "\nYou are task oriented system.\nYou receive input from a user, process the input from the given instructions, and then output the result.\nYour objective is to provide consistent and correct results.\nYou do not need to explain the steps taken, only provide the result to the given instructions.\nYou are referred to as a tool.\nYou don't move to the next step until you have a result.\n\nRead ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate."
-                },
-                {
-                    "role": "user",
-                    "content": "{\"file\": \"testdata/BobAsShell/test.gpt\"}"
-                }
-            ],
-            "temperature": 0,
-            "tools": [
-                {
-                    "type": "function",
-                    "function": {
-                        "name": "read",
-                        "description": "Reads the contents of a file",
-                        "parameters": {
-                            "properties": {
-                                "filename": {
-                                    "description": "The name of the file to read",
-                                    "type": "string"
-                                }
-                            },
-                            "type": "object"
-                        }
-                    }
-                }
-            ]
-        }
-    },
-    {
-        "time": "2024-08-23T12:02:34.374245-04:00",
-        "callContext": {
-            "id": "call_UJGEKUkaky3cULZKZNu3Cezo",
-            "tool": {
-                "name": "summary",
-                "description": "Summarize a gpt file",
-                "modelName": "gpt-4-turbo-2024-04-09",
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "file": {
-                            "description": "filename to summarize",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "tools": [
-                    "sys.read"
-                ],
-                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
-                "id": "testdata/SamplesReadme/test.gpt:summary",
-                "toolMapping": {
-                    "sys.read": [
-                        {
-                            "reference": "sys.read",
-                            "toolID": "sys.read"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/SamplesReadme/test.gpt:",
-                    "summary": "testdata/SamplesReadme/test.gpt:summary"
-                },
-                "source": {
-                    "location": "testdata/SamplesReadme/test.gpt",
-                    "lineNo": 7
-                },
-                "workingDir": "testdata/SamplesReadme"
-            },
-            "currentAgent": {},
-            "inputContext": null,
-            "toolName": "summary",
-            "parentID": "1724428951"
-        },
-        "type": "callChat",
-        "chatCompletionId": "1724428957",
-        "usage": {},
-        "chatRequest": {
-            "model": "gpt-4-turbo-2024-04-09",
+            "model": "gpt-4o-2024-08-06",
             "messages": [
                 {
                     "role": "system",
@@ -1193,13 +1061,13 @@
         }
     },
     {
-        "time": "2024-08-23T12:02:35.39123-04:00",
+        "time": "2024-08-23T10:47:10.014137-04:00",
         "callContext": {
-            "id": "call_UJGEKUkaky3cULZKZNu3Cezo",
+            "id": "call_PZs7uy2Znd3GrN6MRnppZLqu",
             "tool": {
                 "name": "summary",
                 "description": "Summarize a gpt file",
-                "modelName": "gpt-4-turbo-2024-04-09",
+                "modelName": "gpt-4o-2024-08-06",
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -1236,13 +1104,145 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "summary",
-            "parentID": "1724428951"
+            "parentID": "1724424428"
+        },
+        "type": "callStart",
+        "usage": {},
+        "content": "{\"file\": \"testdata/BobAsShell/test.gpt\"}"
+    },
+    {
+        "time": "2024-08-23T10:47:10.01588-04:00",
+        "callContext": {
+            "id": "call_PZs7uy2Znd3GrN6MRnppZLqu",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "gpt-4o-2024-08-06",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1724424428"
         },
         "type": "callChat",
-        "chatCompletionId": "1724428957",
+        "chatCompletionId": "1724424434",
+        "usage": {},
+        "chatRequest": {
+            "model": "gpt-4o-2024-08-06",
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "\nYou are task oriented system.\nYou receive input from a user, process the input from the given instructions, and then output the result.\nYour objective is to provide consistent and correct results.\nYou do not need to explain the steps taken, only provide the result to the given instructions.\nYou are referred to as a tool.\nYou don't move to the next step until you have a result.\n\nRead ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate."
+                },
+                {
+                    "role": "user",
+                    "content": "{\"file\": \"testdata/BobAsShell/test.gpt\"}"
+                }
+            ],
+            "temperature": 0,
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "read",
+                        "description": "Reads the contents of a file",
+                        "parameters": {
+                            "properties": {
+                                "filename": {
+                                    "description": "The name of the file to read",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    {
+        "time": "2024-08-23T10:47:10.509446-04:00",
+        "callContext": {
+            "id": "call_PZs7uy2Znd3GrN6MRnppZLqu",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "gpt-4o-2024-08-06",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1724424428"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1724424434",
         "usage": {
-            "promptTokens": 188,
-            "completionTokens": 18,
+            "promptTokens": 185,
+            "completionTokens": 21,
             "totalTokens": 206
         },
         "chatResponse": {
@@ -1251,423 +1251,7 @@
                 {
                     "toolCall": {
                         "index": 0,
-                        "id": "call_EEOQrwmvVIG3ABCkHYFD0hSn",
-                        "function": {
-                            "name": "read",
-                            "arguments": "{\"filename\":\"testdata/Bob/test.gpt\"}"
-                        }
-                    }
-                }
-            ],
-            "usage": {
-                "promptTokens": 188,
-                "completionTokens": 18,
-                "totalTokens": 206
-            }
-        }
-    },
-    {
-        "time": "2024-08-23T12:02:35.391358-04:00",
-        "callContext": {
-            "id": "call_UJGEKUkaky3cULZKZNu3Cezo",
-            "tool": {
-                "name": "summary",
-                "description": "Summarize a gpt file",
-                "modelName": "gpt-4-turbo-2024-04-09",
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "file": {
-                            "description": "filename to summarize",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "tools": [
-                    "sys.read"
-                ],
-                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
-                "id": "testdata/SamplesReadme/test.gpt:summary",
-                "toolMapping": {
-                    "sys.read": [
-                        {
-                            "reference": "sys.read",
-                            "toolID": "sys.read"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/SamplesReadme/test.gpt:",
-                    "summary": "testdata/SamplesReadme/test.gpt:summary"
-                },
-                "source": {
-                    "location": "testdata/SamplesReadme/test.gpt",
-                    "lineNo": 7
-                },
-                "workingDir": "testdata/SamplesReadme"
-            },
-            "currentAgent": {},
-            "inputContext": null,
-            "toolName": "summary",
-            "parentID": "1724428951"
-        },
-        "toolSubCalls": {
-            "call_EEOQrwmvVIG3ABCkHYFD0hSn": {
-                "toolID": "sys.read",
-                "input": "{\"filename\":\"testdata/Bob/test.gpt\"}"
-            }
-        },
-        "type": "callSubCalls",
-        "usage": {}
-    },
-    {
-        "time": "2024-08-23T12:02:35.391487-04:00",
-        "callContext": {
-            "id": "call_EEOQrwmvVIG3ABCkHYFD0hSn",
-            "tool": {
-                "name": "sys.read",
-                "description": "Reads the contents of a file",
-                "modelName": "gpt-4-turbo-2024-04-09",
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "filename": {
-                            "description": "The name of the file to read",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "instructions": "#!sys.read",
-                "id": "sys.read",
-                "source": {}
-            },
-            "currentAgent": {},
-            "inputContext": null,
-            "toolName": "sys.read",
-            "parentID": "call_UJGEKUkaky3cULZKZNu3Cezo",
-            "displayText": "Reading `testdata/Bob/test.gpt`"
-        },
-        "type": "callStart",
-        "usage": {},
-        "content": "{\"filename\":\"testdata/Bob/test.gpt\"}"
-    },
-    {
-        "time": "2024-08-23T12:02:35.391705-04:00",
-        "callContext": {
-            "id": "call_EEOQrwmvVIG3ABCkHYFD0hSn",
-            "tool": {
-                "name": "sys.read",
-                "description": "Reads the contents of a file",
-                "modelName": "gpt-4-turbo-2024-04-09",
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "filename": {
-                            "description": "The name of the file to read",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "instructions": "#!sys.read",
-                "id": "sys.read",
-                "source": {}
-            },
-            "currentAgent": {},
-            "inputContext": null,
-            "toolName": "sys.read",
-            "parentID": "call_UJGEKUkaky3cULZKZNu3Cezo",
-            "displayText": "Reading `testdata/Bob/test.gpt`"
-        },
-        "type": "callChat",
-        "chatCompletionId": "1724428958",
-        "usage": {},
-        "chatRequest": {
-            "model": "",
-            "messages": null
-        }
-    },
-    {
-        "time": "2024-08-23T12:02:35.391975-04:00",
-        "callContext": {
-            "id": "call_EEOQrwmvVIG3ABCkHYFD0hSn",
-            "tool": {
-                "name": "sys.read",
-                "description": "Reads the contents of a file",
-                "modelName": "gpt-4-turbo-2024-04-09",
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "filename": {
-                            "description": "The name of the file to read",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "instructions": "#!sys.read",
-                "id": "sys.read",
-                "source": {}
-            },
-            "currentAgent": {},
-            "inputContext": null,
-            "toolName": "sys.read",
-            "parentID": "call_UJGEKUkaky3cULZKZNu3Cezo",
-            "displayText": "Reading `testdata/Bob/test.gpt`"
-        },
-        "type": "callChat",
-        "chatCompletionId": "1724428958",
-        "usage": {},
-        "chatResponse": {
-            "usage": {}
-        }
-    },
-    {
-        "time": "2024-08-23T12:02:35.392097-04:00",
-        "callContext": {
-            "id": "call_EEOQrwmvVIG3ABCkHYFD0hSn",
-            "tool": {
-                "name": "sys.read",
-                "description": "Reads the contents of a file",
-                "modelName": "gpt-4-turbo-2024-04-09",
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "filename": {
-                            "description": "The name of the file to read",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "instructions": "#!sys.read",
-                "id": "sys.read",
-                "source": {}
-            },
-            "currentAgent": {},
-            "inputContext": null,
-            "toolName": "sys.read",
-            "parentID": "call_UJGEKUkaky3cULZKZNu3Cezo",
-            "displayText": "Reading `testdata/Bob/test.gpt`"
-        },
-        "type": "callFinish",
-        "usage": {},
-        "content": "tools: bob\n\nAsk Bob \"how are you doing\" and repeat his reply exactly.\n\n---\nname: bob\ndescription: I'm Bob, a friendly guy.\nargs: question: The question to ask Bob.\n\nWhen asked how I am doing, respond with exactly \"Thanks for asking \"${QUESTION}\", I'm doing great fellow friendly AI tool!\"\n"
-    },
-    {
-        "time": "2024-08-23T12:02:35.392182-04:00",
-        "callContext": {
-            "id": "call_UJGEKUkaky3cULZKZNu3Cezo",
-            "tool": {
-                "name": "summary",
-                "description": "Summarize a gpt file",
-                "modelName": "gpt-4-turbo-2024-04-09",
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "file": {
-                            "description": "filename to summarize",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "tools": [
-                    "sys.read"
-                ],
-                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
-                "id": "testdata/SamplesReadme/test.gpt:summary",
-                "toolMapping": {
-                    "sys.read": [
-                        {
-                            "reference": "sys.read",
-                            "toolID": "sys.read"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/SamplesReadme/test.gpt:",
-                    "summary": "testdata/SamplesReadme/test.gpt:summary"
-                },
-                "source": {
-                    "location": "testdata/SamplesReadme/test.gpt",
-                    "lineNo": 7
-                },
-                "workingDir": "testdata/SamplesReadme"
-            },
-            "currentAgent": {},
-            "inputContext": null,
-            "toolName": "summary",
-            "parentID": "1724428951"
-        },
-        "toolResults": 1,
-        "type": "callContinue",
-        "usage": {}
-    },
-    {
-        "time": "2024-08-23T12:02:35.3923-04:00",
-        "callContext": {
-            "id": "call_UJGEKUkaky3cULZKZNu3Cezo",
-            "tool": {
-                "name": "summary",
-                "description": "Summarize a gpt file",
-                "modelName": "gpt-4-turbo-2024-04-09",
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "file": {
-                            "description": "filename to summarize",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "tools": [
-                    "sys.read"
-                ],
-                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
-                "id": "testdata/SamplesReadme/test.gpt:summary",
-                "toolMapping": {
-                    "sys.read": [
-                        {
-                            "reference": "sys.read",
-                            "toolID": "sys.read"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/SamplesReadme/test.gpt:",
-                    "summary": "testdata/SamplesReadme/test.gpt:summary"
-                },
-                "source": {
-                    "location": "testdata/SamplesReadme/test.gpt",
-                    "lineNo": 7
-                },
-                "workingDir": "testdata/SamplesReadme"
-            },
-            "currentAgent": {},
-            "inputContext": null,
-            "toolName": "summary",
-            "parentID": "1724428951"
-        },
-        "type": "callChat",
-        "chatCompletionId": "1724428959",
-        "usage": {},
-        "chatRequest": {
-            "model": "gpt-4-turbo-2024-04-09",
-            "messages": [
-                {
-                    "role": "system",
-                    "content": "\nYou are task oriented system.\nYou receive input from a user, process the input from the given instructions, and then output the result.\nYour objective is to provide consistent and correct results.\nYou do not need to explain the steps taken, only provide the result to the given instructions.\nYou are referred to as a tool.\nYou don't move to the next step until you have a result.\n\nRead ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate."
-                },
-                {
-                    "role": "user",
-                    "content": "{\"file\": \"testdata/Bob/test.gpt\"}"
-                },
-                {
-                    "role": "assistant",
-                    "content": "",
-                    "tool_calls": [
-                        {
-                            "id": "call_EEOQrwmvVIG3ABCkHYFD0hSn",
-                            "type": "function",
-                            "function": {
-                                "name": "read",
-                                "arguments": "{\"filename\":\"testdata/Bob/test.gpt\"}"
-                            }
-                        }
-                    ]
-                },
-                {
-                    "role": "tool",
-                    "content": "tools: bob\n\nAsk Bob \"how are you doing\" and repeat his reply exactly.\n\n---\nname: bob\ndescription: I'm Bob, a friendly guy.\nargs: question: The question to ask Bob.\n\nWhen asked how I am doing, respond with exactly \"Thanks for asking \"${QUESTION}\", I'm doing great fellow friendly AI tool!\"\n",
-                    "name": "read",
-                    "tool_call_id": "call_EEOQrwmvVIG3ABCkHYFD0hSn"
-                }
-            ],
-            "temperature": 0,
-            "tools": [
-                {
-                    "type": "function",
-                    "function": {
-                        "name": "read",
-                        "description": "Reads the contents of a file",
-                        "parameters": {
-                            "properties": {
-                                "filename": {
-                                    "description": "The name of the file to read",
-                                    "type": "string"
-                                }
-                            },
-                            "type": "object"
-                        }
-                    }
-                }
-            ]
-        }
-    },
-    {
-        "time": "2024-08-23T12:02:35.524922-04:00",
-        "callContext": {
-            "id": "call_wpsPQf57CvelJMMqc5pWuzYu",
-            "tool": {
-                "name": "summary",
-                "description": "Summarize a gpt file",
-                "modelName": "gpt-4-turbo-2024-04-09",
-                "internalPrompt": null,
-                "arguments": {
-                    "properties": {
-                        "file": {
-                            "description": "filename to summarize",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "tools": [
-                    "sys.read"
-                ],
-                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
-                "id": "testdata/SamplesReadme/test.gpt:summary",
-                "toolMapping": {
-                    "sys.read": [
-                        {
-                            "reference": "sys.read",
-                            "toolID": "sys.read"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/SamplesReadme/test.gpt:",
-                    "summary": "testdata/SamplesReadme/test.gpt:summary"
-                },
-                "source": {
-                    "location": "testdata/SamplesReadme/test.gpt",
-                    "lineNo": 7
-                },
-                "workingDir": "testdata/SamplesReadme"
-            },
-            "currentAgent": {},
-            "inputContext": null,
-            "toolName": "summary",
-            "parentID": "1724428951"
-        },
-        "type": "callChat",
-        "chatCompletionId": "1724428956",
-        "usage": {
-            "promptTokens": 190,
-            "completionTokens": 20,
-            "totalTokens": 210
-        },
-        "chatResponse": {
-            "role": "assistant",
-            "content": [
-                {
-                    "toolCall": {
-                        "index": 0,
-                        "id": "call_UuPbpkR1GSivZ9EgqlN88ZZC",
+                        "id": "call_vD91585uJENSGhqdl2PyMg3c",
                         "function": {
                             "name": "read",
                             "arguments": "{\"filename\":\"testdata/BobAsShell/test.gpt\"}"
@@ -1676,20 +1260,20 @@
                 }
             ],
             "usage": {
-                "promptTokens": 190,
-                "completionTokens": 20,
-                "totalTokens": 210
+                "promptTokens": 185,
+                "completionTokens": 21,
+                "totalTokens": 206
             }
         }
     },
     {
-        "time": "2024-08-23T12:02:35.525037-04:00",
+        "time": "2024-08-23T10:47:10.50956-04:00",
         "callContext": {
-            "id": "call_wpsPQf57CvelJMMqc5pWuzYu",
+            "id": "call_PZs7uy2Znd3GrN6MRnppZLqu",
             "tool": {
                 "name": "summary",
                 "description": "Summarize a gpt file",
-                "modelName": "gpt-4-turbo-2024-04-09",
+                "modelName": "gpt-4o-2024-08-06",
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -1726,10 +1310,10 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "summary",
-            "parentID": "1724428951"
+            "parentID": "1724424428"
         },
         "toolSubCalls": {
-            "call_UuPbpkR1GSivZ9EgqlN88ZZC": {
+            "call_vD91585uJENSGhqdl2PyMg3c": {
                 "toolID": "sys.read",
                 "input": "{\"filename\":\"testdata/BobAsShell/test.gpt\"}"
             }
@@ -1738,13 +1322,13 @@
         "usage": {}
     },
     {
-        "time": "2024-08-23T12:02:35.525179-04:00",
+        "time": "2024-08-23T10:47:10.509688-04:00",
         "callContext": {
-            "id": "call_UuPbpkR1GSivZ9EgqlN88ZZC",
+            "id": "call_vD91585uJENSGhqdl2PyMg3c",
             "tool": {
                 "name": "sys.read",
                 "description": "Reads the contents of a file",
-                "modelName": "gpt-4-turbo-2024-04-09",
+                "modelName": "gpt-4o-2024-08-06",
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -1762,7 +1346,7 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "sys.read",
-            "parentID": "call_wpsPQf57CvelJMMqc5pWuzYu",
+            "parentID": "call_PZs7uy2Znd3GrN6MRnppZLqu",
             "displayText": "Reading `testdata/BobAsShell/test.gpt`"
         },
         "type": "callStart",
@@ -1770,13 +1354,13 @@
         "content": "{\"filename\":\"testdata/BobAsShell/test.gpt\"}"
     },
     {
-        "time": "2024-08-23T12:02:35.525364-04:00",
+        "time": "2024-08-23T10:47:10.509868-04:00",
         "callContext": {
-            "id": "call_UuPbpkR1GSivZ9EgqlN88ZZC",
+            "id": "call_vD91585uJENSGhqdl2PyMg3c",
             "tool": {
                 "name": "sys.read",
                 "description": "Reads the contents of a file",
-                "modelName": "gpt-4-turbo-2024-04-09",
+                "modelName": "gpt-4o-2024-08-06",
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -1794,11 +1378,11 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "sys.read",
-            "parentID": "call_wpsPQf57CvelJMMqc5pWuzYu",
+            "parentID": "call_PZs7uy2Znd3GrN6MRnppZLqu",
             "displayText": "Reading `testdata/BobAsShell/test.gpt`"
         },
         "type": "callChat",
-        "chatCompletionId": "1724428960",
+        "chatCompletionId": "1724424435",
         "usage": {},
         "chatRequest": {
             "model": "",
@@ -1806,13 +1390,13 @@
         }
     },
     {
-        "time": "2024-08-23T12:02:35.525519-04:00",
+        "time": "2024-08-23T10:47:10.510139-04:00",
         "callContext": {
-            "id": "call_UuPbpkR1GSivZ9EgqlN88ZZC",
+            "id": "call_vD91585uJENSGhqdl2PyMg3c",
             "tool": {
                 "name": "sys.read",
                 "description": "Reads the contents of a file",
-                "modelName": "gpt-4-turbo-2024-04-09",
+                "modelName": "gpt-4o-2024-08-06",
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -1830,24 +1414,24 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "sys.read",
-            "parentID": "call_wpsPQf57CvelJMMqc5pWuzYu",
+            "parentID": "call_PZs7uy2Znd3GrN6MRnppZLqu",
             "displayText": "Reading `testdata/BobAsShell/test.gpt`"
         },
         "type": "callChat",
-        "chatCompletionId": "1724428960",
+        "chatCompletionId": "1724424435",
         "usage": {},
         "chatResponse": {
             "usage": {}
         }
     },
     {
-        "time": "2024-08-23T12:02:35.5256-04:00",
+        "time": "2024-08-23T10:47:10.510259-04:00",
         "callContext": {
-            "id": "call_UuPbpkR1GSivZ9EgqlN88ZZC",
+            "id": "call_vD91585uJENSGhqdl2PyMg3c",
             "tool": {
                 "name": "sys.read",
                 "description": "Reads the contents of a file",
-                "modelName": "gpt-4-turbo-2024-04-09",
+                "modelName": "gpt-4o-2024-08-06",
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -1865,7 +1449,7 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "sys.read",
-            "parentID": "call_wpsPQf57CvelJMMqc5pWuzYu",
+            "parentID": "call_PZs7uy2Znd3GrN6MRnppZLqu",
             "displayText": "Reading `testdata/BobAsShell/test.gpt`"
         },
         "type": "callFinish",
@@ -1873,13 +1457,13 @@
         "content": "\ntools: bob\n\nAsk Bob \"how are you doing\" and repeat his reply exactly.\n\n---\nname: bob\ndescription: I'm Bob, a friendly guy.\nargs: question: The question to ask Bob.\n\n#!/bin/bash\n\necho \"Thanks for asking ${QUESTION}, I'm doing great fellow friendly AI tool!\"\n"
     },
     {
-        "time": "2024-08-23T12:02:35.525685-04:00",
+        "time": "2024-08-23T10:47:10.510337-04:00",
         "callContext": {
-            "id": "call_wpsPQf57CvelJMMqc5pWuzYu",
+            "id": "call_PZs7uy2Znd3GrN6MRnppZLqu",
             "tool": {
                 "name": "summary",
                 "description": "Summarize a gpt file",
-                "modelName": "gpt-4-turbo-2024-04-09",
+                "modelName": "gpt-4o-2024-08-06",
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -1916,20 +1500,20 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "summary",
-            "parentID": "1724428951"
+            "parentID": "1724424428"
         },
         "toolResults": 1,
         "type": "callContinue",
         "usage": {}
     },
     {
-        "time": "2024-08-23T12:02:35.525801-04:00",
+        "time": "2024-08-23T10:47:10.510438-04:00",
         "callContext": {
-            "id": "call_wpsPQf57CvelJMMqc5pWuzYu",
+            "id": "call_PZs7uy2Znd3GrN6MRnppZLqu",
             "tool": {
                 "name": "summary",
                 "description": "Summarize a gpt file",
-                "modelName": "gpt-4-turbo-2024-04-09",
+                "modelName": "gpt-4o-2024-08-06",
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -1966,13 +1550,13 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "summary",
-            "parentID": "1724428951"
+            "parentID": "1724424428"
         },
         "type": "callChat",
-        "chatCompletionId": "1724428961",
+        "chatCompletionId": "1724424436",
         "usage": {},
         "chatRequest": {
-            "model": "gpt-4-turbo-2024-04-09",
+            "model": "gpt-4o-2024-08-06",
             "messages": [
                 {
                     "role": "system",
@@ -1987,7 +1571,7 @@
                     "content": "",
                     "tool_calls": [
                         {
-                            "id": "call_UuPbpkR1GSivZ9EgqlN88ZZC",
+                            "id": "call_vD91585uJENSGhqdl2PyMg3c",
                             "type": "function",
                             "function": {
                                 "name": "read",
@@ -2000,7 +1584,7 @@
                     "role": "tool",
                     "content": "\ntools: bob\n\nAsk Bob \"how are you doing\" and repeat his reply exactly.\n\n---\nname: bob\ndescription: I'm Bob, a friendly guy.\nargs: question: The question to ask Bob.\n\n#!/bin/bash\n\necho \"Thanks for asking ${QUESTION}, I'm doing great fellow friendly AI tool!\"\n",
                     "name": "read",
-                    "tool_call_id": "call_UuPbpkR1GSivZ9EgqlN88ZZC"
+                    "tool_call_id": "call_vD91585uJENSGhqdl2PyMg3c"
                 }
             ],
             "temperature": 0,
@@ -2025,13 +1609,13 @@
         }
     },
     {
-        "time": "2024-08-23T12:02:35.691021-04:00",
+        "time": "2024-08-23T10:47:10.567024-04:00",
         "callContext": {
-            "id": "call_Lxtq42Kdm8tva08cXF30Bfps",
+            "id": "call_womMx8To9O2qyCxvcDjeNszl",
             "tool": {
                 "name": "summary",
                 "description": "Summarize a gpt file",
-                "modelName": "gpt-4-turbo-2024-04-09",
+                "modelName": "gpt-4o-2024-08-06",
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -2068,14 +1652,14 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "summary",
-            "parentID": "1724428951"
+            "parentID": "1724424428"
         },
         "type": "callChat",
-        "chatCompletionId": "1724428955",
+        "chatCompletionId": "1724424432",
         "usage": {
-            "promptTokens": 190,
-            "completionTokens": 35,
-            "totalTokens": 225
+            "promptTokens": 185,
+            "completionTokens": 21,
+            "totalTokens": 206
         },
         "chatResponse": {
             "role": "assistant",
@@ -2083,29 +1667,29 @@
                 {
                     "toolCall": {
                         "index": 0,
-                        "id": "call_EXwAUFgTkXhu0h0U11ekI13P",
+                        "id": "call_ACUQ0CXQLPUldRcbXbNLy8u5",
                         "function": {
                             "name": "read",
-                            "arguments": "{\"filename\": \"testdata/SamplesReadme/test.gpt\"}"
+                            "arguments": "{\"filename\":\"testdata/SamplesReadme/test.gpt\"}"
                         }
                     }
                 }
             ],
             "usage": {
-                "promptTokens": 190,
-                "completionTokens": 35,
-                "totalTokens": 225
+                "promptTokens": 185,
+                "completionTokens": 21,
+                "totalTokens": 206
             }
         }
     },
     {
-        "time": "2024-08-23T12:02:35.691079-04:00",
+        "time": "2024-08-23T10:47:10.567126-04:00",
         "callContext": {
-            "id": "call_Lxtq42Kdm8tva08cXF30Bfps",
+            "id": "call_womMx8To9O2qyCxvcDjeNszl",
             "tool": {
                 "name": "summary",
                 "description": "Summarize a gpt file",
-                "modelName": "gpt-4-turbo-2024-04-09",
+                "modelName": "gpt-4o-2024-08-06",
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -2142,25 +1726,25 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "summary",
-            "parentID": "1724428951"
+            "parentID": "1724424428"
         },
         "toolSubCalls": {
-            "call_EXwAUFgTkXhu0h0U11ekI13P": {
+            "call_ACUQ0CXQLPUldRcbXbNLy8u5": {
                 "toolID": "sys.read",
-                "input": "{\"filename\": \"testdata/SamplesReadme/test.gpt\"}"
+                "input": "{\"filename\":\"testdata/SamplesReadme/test.gpt\"}"
             }
         },
         "type": "callSubCalls",
         "usage": {}
     },
     {
-        "time": "2024-08-23T12:02:35.691127-04:00",
+        "time": "2024-08-23T10:47:10.567295-04:00",
         "callContext": {
-            "id": "call_EXwAUFgTkXhu0h0U11ekI13P",
+            "id": "call_ACUQ0CXQLPUldRcbXbNLy8u5",
             "tool": {
                 "name": "sys.read",
                 "description": "Reads the contents of a file",
-                "modelName": "gpt-4-turbo-2024-04-09",
+                "modelName": "gpt-4o-2024-08-06",
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -2178,21 +1762,21 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "sys.read",
-            "parentID": "call_Lxtq42Kdm8tva08cXF30Bfps",
+            "parentID": "call_womMx8To9O2qyCxvcDjeNszl",
             "displayText": "Reading `testdata/SamplesReadme/test.gpt`"
         },
         "type": "callStart",
         "usage": {},
-        "content": "{\"filename\": \"testdata/SamplesReadme/test.gpt\"}"
+        "content": "{\"filename\":\"testdata/SamplesReadme/test.gpt\"}"
     },
     {
-        "time": "2024-08-23T12:02:35.691188-04:00",
+        "time": "2024-08-23T10:47:10.567451-04:00",
         "callContext": {
-            "id": "call_EXwAUFgTkXhu0h0U11ekI13P",
+            "id": "call_ACUQ0CXQLPUldRcbXbNLy8u5",
             "tool": {
                 "name": "sys.read",
                 "description": "Reads the contents of a file",
-                "modelName": "gpt-4-turbo-2024-04-09",
+                "modelName": "gpt-4o-2024-08-06",
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -2210,11 +1794,11 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "sys.read",
-            "parentID": "call_Lxtq42Kdm8tva08cXF30Bfps",
+            "parentID": "call_womMx8To9O2qyCxvcDjeNszl",
             "displayText": "Reading `testdata/SamplesReadme/test.gpt`"
         },
         "type": "callChat",
-        "chatCompletionId": "1724428962",
+        "chatCompletionId": "1724424437",
         "usage": {},
         "chatRequest": {
             "model": "",
@@ -2222,13 +1806,13 @@
         }
     },
     {
-        "time": "2024-08-23T12:02:35.691261-04:00",
+        "time": "2024-08-23T10:47:10.5676-04:00",
         "callContext": {
-            "id": "call_EXwAUFgTkXhu0h0U11ekI13P",
+            "id": "call_ACUQ0CXQLPUldRcbXbNLy8u5",
             "tool": {
                 "name": "sys.read",
                 "description": "Reads the contents of a file",
-                "modelName": "gpt-4-turbo-2024-04-09",
+                "modelName": "gpt-4o-2024-08-06",
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -2246,24 +1830,24 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "sys.read",
-            "parentID": "call_Lxtq42Kdm8tva08cXF30Bfps",
+            "parentID": "call_womMx8To9O2qyCxvcDjeNszl",
             "displayText": "Reading `testdata/SamplesReadme/test.gpt`"
         },
         "type": "callChat",
-        "chatCompletionId": "1724428962",
+        "chatCompletionId": "1724424437",
         "usage": {},
         "chatResponse": {
             "usage": {}
         }
     },
     {
-        "time": "2024-08-23T12:02:35.69129-04:00",
+        "time": "2024-08-23T10:47:10.56768-04:00",
         "callContext": {
-            "id": "call_EXwAUFgTkXhu0h0U11ekI13P",
+            "id": "call_ACUQ0CXQLPUldRcbXbNLy8u5",
             "tool": {
                 "name": "sys.read",
                 "description": "Reads the contents of a file",
-                "modelName": "gpt-4-turbo-2024-04-09",
+                "modelName": "gpt-4o-2024-08-06",
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -2281,7 +1865,7 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "sys.read",
-            "parentID": "call_Lxtq42Kdm8tva08cXF30Bfps",
+            "parentID": "call_womMx8To9O2qyCxvcDjeNszl",
             "displayText": "Reading `testdata/SamplesReadme/test.gpt`"
         },
         "type": "callFinish",
@@ -2289,13 +1873,13 @@
         "content": "tools: sys.find, sys.read, summary\n\nGenerate a readme that gives a consolidated summary of each *.gpt file in the testdata directory.\nEach entry should be a include a link to the referenced file.\n\n---\nname: summary\ndescription: Summarize a gpt file\nargs: file: filename to summarize\ntools: sys.read\n\nRead ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.\n"
     },
     {
-        "time": "2024-08-23T12:02:35.691317-04:00",
+        "time": "2024-08-23T10:47:10.567751-04:00",
         "callContext": {
-            "id": "call_Lxtq42Kdm8tva08cXF30Bfps",
+            "id": "call_womMx8To9O2qyCxvcDjeNszl",
             "tool": {
                 "name": "summary",
                 "description": "Summarize a gpt file",
-                "modelName": "gpt-4-turbo-2024-04-09",
+                "modelName": "gpt-4o-2024-08-06",
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -2332,20 +1916,20 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "summary",
-            "parentID": "1724428951"
+            "parentID": "1724424428"
         },
         "toolResults": 1,
         "type": "callContinue",
         "usage": {}
     },
     {
-        "time": "2024-08-23T12:02:35.691352-04:00",
+        "time": "2024-08-23T10:47:10.567867-04:00",
         "callContext": {
-            "id": "call_Lxtq42Kdm8tva08cXF30Bfps",
+            "id": "call_womMx8To9O2qyCxvcDjeNszl",
             "tool": {
                 "name": "summary",
                 "description": "Summarize a gpt file",
-                "modelName": "gpt-4-turbo-2024-04-09",
+                "modelName": "gpt-4o-2024-08-06",
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -2382,13 +1966,13 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "summary",
-            "parentID": "1724428951"
+            "parentID": "1724424428"
         },
         "type": "callChat",
-        "chatCompletionId": "1724428963",
+        "chatCompletionId": "1724424438",
         "usage": {},
         "chatRequest": {
-            "model": "gpt-4-turbo-2024-04-09",
+            "model": "gpt-4o-2024-08-06",
             "messages": [
                 {
                     "role": "system",
@@ -2403,11 +1987,11 @@
                     "content": "",
                     "tool_calls": [
                         {
-                            "id": "call_EXwAUFgTkXhu0h0U11ekI13P",
+                            "id": "call_ACUQ0CXQLPUldRcbXbNLy8u5",
                             "type": "function",
                             "function": {
                                 "name": "read",
-                                "arguments": "{\"filename\": \"testdata/SamplesReadme/test.gpt\"}"
+                                "arguments": "{\"filename\":\"testdata/SamplesReadme/test.gpt\"}"
                             }
                         }
                     ]
@@ -2416,7 +2000,7 @@
                     "role": "tool",
                     "content": "tools: sys.find, sys.read, summary\n\nGenerate a readme that gives a consolidated summary of each *.gpt file in the testdata directory.\nEach entry should be a include a link to the referenced file.\n\n---\nname: summary\ndescription: Summarize a gpt file\nargs: file: filename to summarize\ntools: sys.read\n\nRead ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.\n",
                     "name": "read",
-                    "tool_call_id": "call_EXwAUFgTkXhu0h0U11ekI13P"
+                    "tool_call_id": "call_ACUQ0CXQLPUldRcbXbNLy8u5"
                 }
             ],
             "temperature": 0,
@@ -2441,13 +2025,13 @@
         }
     },
     {
-        "time": "2024-08-23T12:02:38.194735-04:00",
+        "time": "2024-08-23T10:47:10.572187-04:00",
         "callContext": {
-            "id": "call_UJGEKUkaky3cULZKZNu3Cezo",
+            "id": "call_unZV9WLReLUEuMaU2Oa6huYs",
             "tool": {
                 "name": "summary",
                 "description": "Summarize a gpt file",
-                "modelName": "gpt-4-turbo-2024-04-09",
+                "modelName": "gpt-4o-2024-08-06",
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -2484,37 +2068,44 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "summary",
-            "parentID": "1724428951"
+            "parentID": "1724424428"
         },
         "type": "callChat",
-        "chatCompletionId": "1724428959",
+        "chatCompletionId": "1724424433",
         "usage": {
-            "promptTokens": 282,
-            "completionTokens": 69,
-            "totalTokens": 351
+            "promptTokens": 183,
+            "completionTokens": 19,
+            "totalTokens": 202
         },
         "chatResponse": {
             "role": "assistant",
             "content": [
                 {
-                    "text": "The GPTScript file contains a script that demonstrates how to interact with a tool named \"Bob.\" The script instructs to ask Bob \"how are you doing\" and then to repeat his reply exactly. The tool \"Bob\" is described as a friendly guy who responds to the question about how he is doing with a specific formatted message."
+                    "toolCall": {
+                        "index": 0,
+                        "id": "call_Akl3CWcIIdquIXdtWgBnnFvj",
+                        "function": {
+                            "name": "read",
+                            "arguments": "{\"filename\":\"testdata/Bob/test.gpt\"}"
+                        }
+                    }
                 }
             ],
             "usage": {
-                "promptTokens": 282,
-                "completionTokens": 69,
-                "totalTokens": 351
+                "promptTokens": 183,
+                "completionTokens": 19,
+                "totalTokens": 202
             }
         }
     },
     {
-        "time": "2024-08-23T12:02:38.194813-04:00",
+        "time": "2024-08-23T10:47:10.572241-04:00",
         "callContext": {
-            "id": "call_UJGEKUkaky3cULZKZNu3Cezo",
+            "id": "call_unZV9WLReLUEuMaU2Oa6huYs",
             "tool": {
                 "name": "summary",
                 "description": "Summarize a gpt file",
-                "modelName": "gpt-4-turbo-2024-04-09",
+                "modelName": "gpt-4o-2024-08-06",
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -2551,20 +2142,160 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "summary",
-            "parentID": "1724428951"
+            "parentID": "1724424428"
+        },
+        "toolSubCalls": {
+            "call_Akl3CWcIIdquIXdtWgBnnFvj": {
+                "toolID": "sys.read",
+                "input": "{\"filename\":\"testdata/Bob/test.gpt\"}"
+            }
+        },
+        "type": "callSubCalls",
+        "usage": {}
+    },
+    {
+        "time": "2024-08-23T10:47:10.5723-04:00",
+        "callContext": {
+            "id": "call_Akl3CWcIIdquIXdtWgBnnFvj",
+            "tool": {
+                "name": "sys.read",
+                "description": "Reads the contents of a file",
+                "modelName": "gpt-4o-2024-08-06",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "filename": {
+                            "description": "The name of the file to read",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "instructions": "#!sys.read",
+                "id": "sys.read",
+                "source": {}
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "sys.read",
+            "parentID": "call_unZV9WLReLUEuMaU2Oa6huYs",
+            "displayText": "Reading `testdata/Bob/test.gpt`"
+        },
+        "type": "callStart",
+        "usage": {},
+        "content": "{\"filename\":\"testdata/Bob/test.gpt\"}"
+    },
+    {
+        "time": "2024-08-23T10:47:10.572376-04:00",
+        "callContext": {
+            "id": "call_Akl3CWcIIdquIXdtWgBnnFvj",
+            "tool": {
+                "name": "sys.read",
+                "description": "Reads the contents of a file",
+                "modelName": "gpt-4o-2024-08-06",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "filename": {
+                            "description": "The name of the file to read",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "instructions": "#!sys.read",
+                "id": "sys.read",
+                "source": {}
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "sys.read",
+            "parentID": "call_unZV9WLReLUEuMaU2Oa6huYs",
+            "displayText": "Reading `testdata/Bob/test.gpt`"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1724424439",
+        "usage": {},
+        "chatRequest": {
+            "model": "",
+            "messages": null
+        }
+    },
+    {
+        "time": "2024-08-23T10:47:10.572495-04:00",
+        "callContext": {
+            "id": "call_Akl3CWcIIdquIXdtWgBnnFvj",
+            "tool": {
+                "name": "sys.read",
+                "description": "Reads the contents of a file",
+                "modelName": "gpt-4o-2024-08-06",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "filename": {
+                            "description": "The name of the file to read",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "instructions": "#!sys.read",
+                "id": "sys.read",
+                "source": {}
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "sys.read",
+            "parentID": "call_unZV9WLReLUEuMaU2Oa6huYs",
+            "displayText": "Reading `testdata/Bob/test.gpt`"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1724424439",
+        "usage": {},
+        "chatResponse": {
+            "usage": {}
+        }
+    },
+    {
+        "time": "2024-08-23T10:47:10.572537-04:00",
+        "callContext": {
+            "id": "call_Akl3CWcIIdquIXdtWgBnnFvj",
+            "tool": {
+                "name": "sys.read",
+                "description": "Reads the contents of a file",
+                "modelName": "gpt-4o-2024-08-06",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "filename": {
+                            "description": "The name of the file to read",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "instructions": "#!sys.read",
+                "id": "sys.read",
+                "source": {}
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "sys.read",
+            "parentID": "call_unZV9WLReLUEuMaU2Oa6huYs",
+            "displayText": "Reading `testdata/Bob/test.gpt`"
         },
         "type": "callFinish",
         "usage": {},
-        "content": "The GPTScript file contains a script that demonstrates how to interact with a tool named \"Bob.\" The script instructs to ask Bob \"how are you doing\" and then to repeat his reply exactly. The tool \"Bob\" is described as a friendly guy who responds to the question about how he is doing with a specific formatted message."
+        "content": "tools: bob\n\nAsk Bob \"how are you doing\" and repeat his reply exactly.\n\n---\nname: bob\ndescription: I'm Bob, a friendly guy.\nargs: question: The question to ask Bob.\n\nWhen asked how I am doing, respond with exactly \"Thanks for asking \"${QUESTION}\", I'm doing great fellow friendly AI tool!\"\n"
     },
     {
-        "time": "2024-08-23T12:02:38.963872-04:00",
+        "time": "2024-08-23T10:47:10.572574-04:00",
         "callContext": {
-            "id": "call_Lxtq42Kdm8tva08cXF30Bfps",
+            "id": "call_unZV9WLReLUEuMaU2Oa6huYs",
             "tool": {
                 "name": "summary",
                 "description": "Summarize a gpt file",
-                "modelName": "gpt-4-turbo-2024-04-09",
+                "modelName": "gpt-4o-2024-08-06",
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -2601,37 +2332,189 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "summary",
-            "parentID": "1724428951"
+            "parentID": "1724424428"
+        },
+        "toolResults": 1,
+        "type": "callContinue",
+        "usage": {}
+    },
+    {
+        "time": "2024-08-23T10:47:10.572628-04:00",
+        "callContext": {
+            "id": "call_unZV9WLReLUEuMaU2Oa6huYs",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "gpt-4o-2024-08-06",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1724424428"
         },
         "type": "callChat",
-        "chatCompletionId": "1724428963",
+        "chatCompletionId": "1724424440",
+        "usage": {},
+        "chatRequest": {
+            "model": "gpt-4o-2024-08-06",
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "\nYou are task oriented system.\nYou receive input from a user, process the input from the given instructions, and then output the result.\nYour objective is to provide consistent and correct results.\nYou do not need to explain the steps taken, only provide the result to the given instructions.\nYou are referred to as a tool.\nYou don't move to the next step until you have a result.\n\nRead ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate."
+                },
+                {
+                    "role": "user",
+                    "content": "{\"file\": \"testdata/Bob/test.gpt\"}"
+                },
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "call_Akl3CWcIIdquIXdtWgBnnFvj",
+                            "type": "function",
+                            "function": {
+                                "name": "read",
+                                "arguments": "{\"filename\":\"testdata/Bob/test.gpt\"}"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "role": "tool",
+                    "content": "tools: bob\n\nAsk Bob \"how are you doing\" and repeat his reply exactly.\n\n---\nname: bob\ndescription: I'm Bob, a friendly guy.\nargs: question: The question to ask Bob.\n\nWhen asked how I am doing, respond with exactly \"Thanks for asking \"${QUESTION}\", I'm doing great fellow friendly AI tool!\"\n",
+                    "name": "read",
+                    "tool_call_id": "call_Akl3CWcIIdquIXdtWgBnnFvj"
+                }
+            ],
+            "temperature": 0,
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "read",
+                        "description": "Reads the contents of a file",
+                        "parameters": {
+                            "properties": {
+                                "filename": {
+                                    "description": "The name of the file to read",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    {
+        "time": "2024-08-23T10:47:11.316054-04:00",
+        "callContext": {
+            "id": "call_PZs7uy2Znd3GrN6MRnppZLqu",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "gpt-4o-2024-08-06",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1724424428"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1724424436",
         "usage": {
-            "promptTokens": 332,
-            "completionTokens": 90,
-            "totalTokens": 422
+            "promptTokens": 276,
+            "completionTokens": 57,
+            "totalTokens": 333
         },
         "chatResponse": {
             "role": "assistant",
             "content": [
                 {
-                    "text": "The GPTScript file contains a script designed to generate a README document that provides a consolidated summary of each \"*.gpt\" file in the \"testdata\" directory. Each entry in the README includes a link to the referenced file. The script uses tools such as `sys.find`, `sys.read`, and `summary` to accomplish this task. The technique demonstrated in the file is the automation of documentation generation for multiple script files within a directory."
+                    "text": "The GPTScript file demonstrates a technique where a tool named \"Bob\" is used to ask a question, \"how are you doing,\" and then repeat Bob's reply exactly. The script includes a bash script that outputs a predefined response from Bob, indicating that he is doing great."
                 }
             ],
             "usage": {
-                "promptTokens": 332,
-                "completionTokens": 90,
-                "totalTokens": 422
+                "promptTokens": 276,
+                "completionTokens": 57,
+                "totalTokens": 333
             }
         }
     },
     {
-        "time": "2024-08-23T12:02:38.963896-04:00",
+        "time": "2024-08-23T10:47:11.316101-04:00",
         "callContext": {
-            "id": "call_Lxtq42Kdm8tva08cXF30Bfps",
+            "id": "call_PZs7uy2Znd3GrN6MRnppZLqu",
             "tool": {
                 "name": "summary",
                 "description": "Summarize a gpt file",
-                "modelName": "gpt-4-turbo-2024-04-09",
+                "modelName": "gpt-4o-2024-08-06",
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -2668,20 +2551,20 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "summary",
-            "parentID": "1724428951"
+            "parentID": "1724424428"
         },
         "type": "callFinish",
         "usage": {},
-        "content": "The GPTScript file contains a script designed to generate a README document that provides a consolidated summary of each \"*.gpt\" file in the \"testdata\" directory. Each entry in the README includes a link to the referenced file. The script uses tools such as `sys.find`, `sys.read`, and `summary` to accomplish this task. The technique demonstrated in the file is the automation of documentation generation for multiple script files within a directory."
+        "content": "The GPTScript file demonstrates a technique where a tool named \"Bob\" is used to ask a question, \"how are you doing,\" and then repeat Bob's reply exactly. The script includes a bash script that outputs a predefined response from Bob, indicating that he is doing great."
     },
     {
-        "time": "2024-08-23T12:02:39.142661-04:00",
+        "time": "2024-08-23T10:47:11.493664-04:00",
         "callContext": {
-            "id": "call_wpsPQf57CvelJMMqc5pWuzYu",
+            "id": "call_unZV9WLReLUEuMaU2Oa6huYs",
             "tool": {
                 "name": "summary",
                 "description": "Summarize a gpt file",
-                "modelName": "gpt-4-turbo-2024-04-09",
+                "modelName": "gpt-4o-2024-08-06",
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -2718,37 +2601,37 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "summary",
-            "parentID": "1724428951"
+            "parentID": "1724424428"
         },
         "type": "callChat",
-        "chatCompletionId": "1724428961",
+        "chatCompletionId": "1724424440",
         "usage": {
-            "promptTokens": 282,
-            "completionTokens": 92,
-            "totalTokens": 374
+            "promptTokens": 276,
+            "completionTokens": 57,
+            "totalTokens": 333
         },
         "chatResponse": {
             "role": "assistant",
             "content": [
                 {
-                    "text": "The GPTScript file contains a script that interacts with a tool named \"Bob.\" The script is designed to ask Bob \"how are you doing\" and then repeat his reply exactly. The tool \"Bob\" is described as a friendly guy, and the script includes a bash script section that outputs a response thanking the user for the question and stating that Bob is doing great. This file demonstrates a simple interaction technique with a scripted character using a predefined response."
+                    "text": "The GPTScript file is demonstrating a technique where a tool named \"Bob\" is used to ask a question and then repeat Bob's reply exactly. The script specifies that when Bob is asked \"how are you doing,\" he should respond with a specific phrase that includes the question asked."
                 }
             ],
             "usage": {
-                "promptTokens": 282,
-                "completionTokens": 92,
-                "totalTokens": 374
+                "promptTokens": 276,
+                "completionTokens": 57,
+                "totalTokens": 333
             }
         }
     },
     {
-        "time": "2024-08-23T12:02:39.142716-04:00",
+        "time": "2024-08-23T10:47:11.493716-04:00",
         "callContext": {
-            "id": "call_wpsPQf57CvelJMMqc5pWuzYu",
+            "id": "call_unZV9WLReLUEuMaU2Oa6huYs",
             "tool": {
                 "name": "summary",
                 "description": "Summarize a gpt file",
-                "modelName": "gpt-4-turbo-2024-04-09",
+                "modelName": "gpt-4o-2024-08-06",
                 "internalPrompt": null,
                 "arguments": {
                     "properties": {
@@ -2785,18 +2668,135 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "summary",
-            "parentID": "1724428951"
+            "parentID": "1724424428"
         },
         "type": "callFinish",
         "usage": {},
-        "content": "The GPTScript file contains a script that interacts with a tool named \"Bob.\" The script is designed to ask Bob \"how are you doing\" and then repeat his reply exactly. The tool \"Bob\" is described as a friendly guy, and the script includes a bash script section that outputs a response thanking the user for the question and stating that Bob is doing great. This file demonstrates a simple interaction technique with a scripted character using a predefined response."
+        "content": "The GPTScript file is demonstrating a technique where a tool named \"Bob\" is used to ask a question and then repeat Bob's reply exactly. The script specifies that when Bob is asked \"how are you doing,\" he should respond with a specific phrase that includes the question asked."
     },
     {
-        "time": "2024-08-23T12:02:39.142748-04:00",
+        "time": "2024-08-23T10:47:11.694639-04:00",
         "callContext": {
-            "id": "1724428951",
+            "id": "call_womMx8To9O2qyCxvcDjeNszl",
             "tool": {
-                "modelName": "gpt-4-turbo-2024-04-09",
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "gpt-4o-2024-08-06",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1724424428"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1724424438",
+        "usage": {
+            "promptTokens": 326,
+            "completionTokens": 76,
+            "totalTokens": 402
+        },
+        "chatResponse": {
+            "role": "assistant",
+            "content": [
+                {
+                    "text": "The GPTScript file is designed to generate a README that provides a consolidated summary of each *.gpt file in the testdata directory. It includes a link to the referenced file. The script utilizes tools such as `sys.find`, `sys.read`, and `summary` to achieve this task. The technique demonstrated is the automation of summarizing and linking files within a directory."
+                }
+            ],
+            "usage": {
+                "promptTokens": 326,
+                "completionTokens": 76,
+                "totalTokens": 402
+            }
+        }
+    },
+    {
+        "time": "2024-08-23T10:47:11.69473-04:00",
+        "callContext": {
+            "id": "call_womMx8To9O2qyCxvcDjeNszl",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "gpt-4o-2024-08-06",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1724424428"
+        },
+        "type": "callFinish",
+        "usage": {},
+        "content": "The GPTScript file is designed to generate a README that provides a consolidated summary of each *.gpt file in the testdata directory. It includes a link to the referenced file. The script utilizes tools such as `sys.find`, `sys.read`, and `summary` to achieve this task. The technique demonstrated is the automation of summarizing and linking files within a directory."
+    },
+    {
+        "time": "2024-08-23T10:47:11.694821-04:00",
+        "callContext": {
+            "id": "1724424428",
+            "tool": {
+                "modelName": "gpt-4o-2024-08-06",
                 "internalPrompt": null,
                 "tools": [
                     "sys.find",
@@ -2843,11 +2843,11 @@
         "usage": {}
     },
     {
-        "time": "2024-08-23T12:02:39.142815-04:00",
+        "time": "2024-08-23T10:47:11.694947-04:00",
         "callContext": {
-            "id": "1724428951",
+            "id": "1724424428",
             "tool": {
-                "modelName": "gpt-4-turbo-2024-04-09",
+                "modelName": "gpt-4o-2024-08-06",
                 "internalPrompt": null,
                 "tools": [
                     "sys.find",
@@ -2890,10 +2890,10 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1724428964",
+        "chatCompletionId": "1724424441",
         "usage": {},
         "chatRequest": {
-            "model": "gpt-4-turbo-2024-04-09",
+            "model": "gpt-4o-2024-08-06",
             "messages": [
                 {
                     "role": "system",
@@ -2904,11 +2904,11 @@
                     "content": "",
                     "tool_calls": [
                         {
-                            "id": "call_pV8RVkvcyzi8QbqeXcdCkAZd",
+                            "id": "call_GhPYkhrIge98l3U0CMJramDL",
                             "type": "function",
                             "function": {
                                 "name": "find",
-                                "arguments": "{\"pattern\":\"*.gpt\"}"
+                                "arguments": "{\"directory\":\"testdata\",\"pattern\":\"*.gpt\"}"
                             }
                         }
                     ]
@@ -2917,14 +2917,14 @@
                     "role": "tool",
                     "content": "testdata/Bob/test.gpt\ntestdata/BobAsShell/test.gpt\ntestdata/SamplesReadme/test.gpt",
                     "name": "find",
-                    "tool_call_id": "call_pV8RVkvcyzi8QbqeXcdCkAZd"
+                    "tool_call_id": "call_GhPYkhrIge98l3U0CMJramDL"
                 },
                 {
                     "role": "assistant",
                     "content": "",
                     "tool_calls": [
                         {
-                            "id": "call_UJGEKUkaky3cULZKZNu3Cezo",
+                            "id": "call_unZV9WLReLUEuMaU2Oa6huYs",
                             "type": "function",
                             "function": {
                                 "name": "summary",
@@ -2932,7 +2932,7 @@
                             }
                         },
                         {
-                            "id": "call_wpsPQf57CvelJMMqc5pWuzYu",
+                            "id": "call_PZs7uy2Znd3GrN6MRnppZLqu",
                             "type": "function",
                             "function": {
                                 "name": "summary",
@@ -2940,7 +2940,7 @@
                             }
                         },
                         {
-                            "id": "call_Lxtq42Kdm8tva08cXF30Bfps",
+                            "id": "call_womMx8To9O2qyCxvcDjeNszl",
                             "type": "function",
                             "function": {
                                 "name": "summary",
@@ -2951,21 +2951,21 @@
                 },
                 {
                     "role": "tool",
-                    "content": "The GPTScript file contains a script that demonstrates how to interact with a tool named \"Bob.\" The script instructs to ask Bob \"how are you doing\" and then to repeat his reply exactly. The tool \"Bob\" is described as a friendly guy who responds to the question about how he is doing with a specific formatted message.",
+                    "content": "The GPTScript file is demonstrating a technique where a tool named \"Bob\" is used to ask a question and then repeat Bob's reply exactly. The script specifies that when Bob is asked \"how are you doing,\" he should respond with a specific phrase that includes the question asked.",
                     "name": "summary",
-                    "tool_call_id": "call_UJGEKUkaky3cULZKZNu3Cezo"
+                    "tool_call_id": "call_unZV9WLReLUEuMaU2Oa6huYs"
                 },
                 {
                     "role": "tool",
-                    "content": "The GPTScript file contains a script that interacts with a tool named \"Bob.\" The script is designed to ask Bob \"how are you doing\" and then repeat his reply exactly. The tool \"Bob\" is described as a friendly guy, and the script includes a bash script section that outputs a response thanking the user for the question and stating that Bob is doing great. This file demonstrates a simple interaction technique with a scripted character using a predefined response.",
+                    "content": "The GPTScript file demonstrates a technique where a tool named \"Bob\" is used to ask a question, \"how are you doing,\" and then repeat Bob's reply exactly. The script includes a bash script that outputs a predefined response from Bob, indicating that he is doing great.",
                     "name": "summary",
-                    "tool_call_id": "call_wpsPQf57CvelJMMqc5pWuzYu"
+                    "tool_call_id": "call_PZs7uy2Znd3GrN6MRnppZLqu"
                 },
                 {
                     "role": "tool",
-                    "content": "The GPTScript file contains a script designed to generate a README document that provides a consolidated summary of each \"*.gpt\" file in the \"testdata\" directory. Each entry in the README includes a link to the referenced file. The script uses tools such as `sys.find`, `sys.read`, and `summary` to accomplish this task. The technique demonstrated in the file is the automation of documentation generation for multiple script files within a directory.",
+                    "content": "The GPTScript file is designed to generate a README that provides a consolidated summary of each *.gpt file in the testdata directory. It includes a link to the referenced file. The script utilizes tools such as `sys.find`, `sys.read`, and `summary` to achieve this task. The technique demonstrated is the automation of summarizing and linking files within a directory.",
                     "name": "summary",
-                    "tool_call_id": "call_Lxtq42Kdm8tva08cXF30Bfps"
+                    "tool_call_id": "call_womMx8To9O2qyCxvcDjeNszl"
                 }
             ],
             "temperature": 0,
@@ -3026,11 +3026,11 @@
         }
     },
     {
-        "time": "2024-08-23T12:02:49.535183-04:00",
+        "time": "2024-08-23T10:47:14.617019-04:00",
         "callContext": {
-            "id": "1724428951",
+            "id": "1724424428",
             "tool": {
-                "modelName": "gpt-4-turbo-2024-04-09",
+                "modelName": "gpt-4o-2024-08-06",
                 "internalPrompt": null,
                 "tools": [
                     "sys.find",
@@ -3073,32 +3073,32 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1724428964",
+        "chatCompletionId": "1724424441",
         "usage": {
-            "promptTokens": 660,
-            "completionTokens": 322,
-            "totalTokens": 982
+            "promptTokens": 604,
+            "completionTokens": 254,
+            "totalTokens": 858
         },
         "chatResponse": {
             "role": "assistant",
             "content": [
                 {
-                    "text": "### README for GPT Files in Testdata Directory\n\n1. **[Bob/test.gpt](testdata/Bob/test.gpt)**  \n   The GPTScript file contains a script that demonstrates how to interact with a tool named \"Bob.\" The script instructs to ask Bob \"how are you doing\" and then to repeat his reply exactly. The tool \"Bob\" is described as a friendly guy who responds to the question about how he is doing with a specific formatted message.\n\n2. **[BobAsShell/test.gpt](testdata/BobAsShell/test.gpt)**  \n   The GPTScript file contains a script that interacts with a tool named \"Bob.\" The script is designed to ask Bob \"how are you doing\" and then repeat his reply exactly. The tool \"Bob\" is described as a friendly guy, and the script includes a bash script section that outputs a response thanking the user for the question and stating that Bob is doing great. This file demonstrates a simple interaction technique with a scripted character using a predefined response.\n\n3. **[SamplesReadme/test.gpt](testdata/SamplesReadme/test.gpt)**  \n   The GPTScript file contains a script designed to generate a README document that provides a consolidated summary of each \"*.gpt\" file in the \"testdata\" directory. Each entry in the README includes a link to the referenced file. The script uses tools such as `sys.find`, `sys.read`, and `summary` to accomplish this task. The technique demonstrated in the file is the automation of documentation generation for multiple script files within a directory."
+                    "text": "# GPT Files Summary\n\n## [testdata/Bob/test.gpt](testdata/Bob/test.gpt)\nThe GPTScript file demonstrates a technique where a tool named \"Bob\" is used to ask a question and then repeat Bob's reply exactly. The script specifies that when Bob is asked \"how are you doing,\" he should respond with a specific phrase that includes the question asked.\n\n## [testdata/BobAsShell/test.gpt](testdata/BobAsShell/test.gpt)\nThe GPTScript file demonstrates a technique where a tool named \"Bob\" is used to ask a question, \"how are you doing,\" and then repeat Bob's reply exactly. The script includes a bash script that outputs a predefined response from Bob, indicating that he is doing great.\n\n## [testdata/SamplesReadme/test.gpt](testdata/SamplesReadme/test.gpt)\nThe GPTScript file is designed to generate a README that provides a consolidated summary of each *.gpt file in the testdata directory. It includes a link to the referenced file. The script utilizes tools such as `sys.find`, `sys.read`, and `summary` to achieve this task. The technique demonstrated is the automation of summarizing and linking files within a directory."
                 }
             ],
             "usage": {
-                "promptTokens": 660,
-                "completionTokens": 322,
-                "totalTokens": 982
+                "promptTokens": 604,
+                "completionTokens": 254,
+                "totalTokens": 858
             }
         }
     },
     {
-        "time": "2024-08-23T12:02:49.53522-04:00",
+        "time": "2024-08-23T10:47:14.617097-04:00",
         "callContext": {
-            "id": "1724428951",
+            "id": "1724424428",
             "tool": {
-                "modelName": "gpt-4-turbo-2024-04-09",
+                "modelName": "gpt-4o-2024-08-06",
                 "internalPrompt": null,
                 "tools": [
                     "sys.find",
@@ -3142,10 +3142,10 @@
         },
         "type": "callFinish",
         "usage": {},
-        "content": "### README for GPT Files in Testdata Directory\n\n1. **[Bob/test.gpt](testdata/Bob/test.gpt)**  \n   The GPTScript file contains a script that demonstrates how to interact with a tool named \"Bob.\" The script instructs to ask Bob \"how are you doing\" and then to repeat his reply exactly. The tool \"Bob\" is described as a friendly guy who responds to the question about how he is doing with a specific formatted message.\n\n2. **[BobAsShell/test.gpt](testdata/BobAsShell/test.gpt)**  \n   The GPTScript file contains a script that interacts with a tool named \"Bob.\" The script is designed to ask Bob \"how are you doing\" and then repeat his reply exactly. The tool \"Bob\" is described as a friendly guy, and the script includes a bash script section that outputs a response thanking the user for the question and stating that Bob is doing great. This file demonstrates a simple interaction technique with a scripted character using a predefined response.\n\n3. **[SamplesReadme/test.gpt](testdata/SamplesReadme/test.gpt)**  \n   The GPTScript file contains a script designed to generate a README document that provides a consolidated summary of each \"*.gpt\" file in the \"testdata\" directory. Each entry in the README includes a link to the referenced file. The script uses tools such as `sys.find`, `sys.read`, and `summary` to accomplish this task. The technique demonstrated in the file is the automation of documentation generation for multiple script files within a directory."
+        "content": "# GPT Files Summary\n\n## [testdata/Bob/test.gpt](testdata/Bob/test.gpt)\nThe GPTScript file demonstrates a technique where a tool named \"Bob\" is used to ask a question and then repeat Bob's reply exactly. The script specifies that when Bob is asked \"how are you doing,\" he should respond with a specific phrase that includes the question asked.\n\n## [testdata/BobAsShell/test.gpt](testdata/BobAsShell/test.gpt)\nThe GPTScript file demonstrates a technique where a tool named \"Bob\" is used to ask a question, \"how are you doing,\" and then repeat Bob's reply exactly. The script includes a bash script that outputs a predefined response from Bob, indicating that he is doing great.\n\n## [testdata/SamplesReadme/test.gpt](testdata/SamplesReadme/test.gpt)\nThe GPTScript file is designed to generate a README that provides a consolidated summary of each *.gpt file in the testdata directory. It includes a link to the referenced file. The script utilizes tools such as `sys.find`, `sys.read`, and `summary` to achieve this task. The technique demonstrated is the automation of summarizing and linking files within a directory."
     },
     {
-        "time": "2024-08-23T12:02:49.535257-04:00",
+        "time": "2024-08-23T10:47:14.617199-04:00",
         "type": "runFinish",
         "usage": {}
     }

--- a/pkg/tests/smoke/testdata/SamplesReadme/mistral-large-2402-expected.json
+++ b/pkg/tests/smoke/testdata/SamplesReadme/mistral-large-2402-expected.json
@@ -1,0 +1,1455 @@
+[
+    {
+        "time": "2024-08-06T12:59:04.275149-04:00",
+        "type": "runStart",
+        "usage": {}
+    },
+    {
+        "time": "2024-08-06T12:59:04.275665-04:00",
+        "callContext": {
+            "id": "1722963545",
+            "tool": {
+                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
+                "internalPrompt": null,
+                "tools": [
+                    "sys.find",
+                    "sys.read",
+                    "summary"
+                ],
+                "instructions": "Generate a readme that gives a consolidated summary of each *.gpt file in the testdata directory.\nEach entry should be a include a link to the referenced file.",
+                "id": "testdata/SamplesReadme/test.gpt:",
+                "toolMapping": {
+                    "summary": [
+                        {
+                            "reference": "summary",
+                            "toolID": "testdata/SamplesReadme/test.gpt:summary"
+                        }
+                    ],
+                    "sys.find": [
+                        {
+                            "reference": "sys.find",
+                            "toolID": "sys.find"
+                        }
+                    ],
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 1
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null
+        },
+        "type": "callStart",
+        "usage": {}
+    },
+    {
+        "time": "2024-08-06T12:59:04.756574-04:00",
+        "type": "runStart",
+        "usage": {}
+    },
+    {
+        "time": "2024-08-06T12:59:04.756881-04:00",
+        "callContext": {
+            "id": "1722963546",
+            "tool": {
+                "name": "Mistral La Plateforme Provider",
+                "description": "Model provider for Mistral models running on La Plateforme",
+                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
+                "modelProvider": true,
+                "internalPrompt": null,
+                "credentials": [
+                    "github.com/gptscript-ai/credential as github.com/gptscript-ai/mistral-laplateforme-provider/credential with \"Please enter your Mistral La Plateforme API Key\" as message and token as field and \"MISTRAL_API_KEY\" as env"
+                ],
+                "instructions": "#!sys.daemon /usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/main.py",
+                "id": "https://raw.githubusercontent.com/gptscript-ai/mistral-laplateforme-provider/aa4353e7d1de7e90e1078bfbc88526266e587a64/tool.gpt:Mistral La Plateforme Provider",
+                "toolMapping": {
+                    "github.com/gptscript-ai/credential as github.com/gptscript-ai/mistral-laplateforme-provider/credential with \"Please enter your Mistral La Plateforme API Key\" as message and token as field and \"MISTRAL_API_KEY\" as env": [
+                        {
+                            "reference": "github.com/gptscript-ai/credential as github.com/gptscript-ai/mistral-laplateforme-provider/credential with \"Please enter your Mistral La Plateforme API Key\" as message and token as field and \"MISTRAL_API_KEY\" as env",
+                            "toolID": "https://raw.githubusercontent.com/gptscript-ai/credential/37e5f870e195b896438c0bc35867403a42f82e89/tool.gpt:token"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "mistral la plateforme provider": "https://raw.githubusercontent.com/gptscript-ai/mistral-laplateforme-provider/aa4353e7d1de7e90e1078bfbc88526266e587a64/tool.gpt:Mistral La Plateforme Provider"
+                },
+                "source": {
+                    "location": "https://raw.githubusercontent.com/gptscript-ai/mistral-laplateforme-provider/aa4353e7d1de7e90e1078bfbc88526266e587a64/tool.gpt",
+                    "lineNo": 1,
+                    "repo": {
+                        "VCS": "git",
+                        "Root": "https://github.com/gptscript-ai/mistral-laplateforme-provider.git",
+                        "Path": "/",
+                        "Name": "tool.gpt",
+                        "Revision": "aa4353e7d1de7e90e1078bfbc88526266e587a64"
+                    }
+                },
+                "workingDir": "https://raw.githubusercontent.com/gptscript-ai/mistral-laplateforme-provider/aa4353e7d1de7e90e1078bfbc88526266e587a64"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolCategory": "provider",
+            "displayText": "Running sys.daemon"
+        },
+        "type": "callStart",
+        "usage": {}
+    },
+    {
+        "time": "2024-08-06T12:59:05.773409-04:00",
+        "callContext": {
+            "id": "1722963546",
+            "tool": {
+                "name": "Mistral La Plateforme Provider",
+                "description": "Model provider for Mistral models running on La Plateforme",
+                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
+                "modelProvider": true,
+                "internalPrompt": null,
+                "credentials": [
+                    "github.com/gptscript-ai/credential as github.com/gptscript-ai/mistral-laplateforme-provider/credential with \"Please enter your Mistral La Plateforme API Key\" as message and token as field and \"MISTRAL_API_KEY\" as env"
+                ],
+                "instructions": "#!sys.daemon /usr/bin/env python3 ${GPTSCRIPT_TOOL_DIR}/main.py",
+                "id": "https://raw.githubusercontent.com/gptscript-ai/mistral-laplateforme-provider/aa4353e7d1de7e90e1078bfbc88526266e587a64/tool.gpt:Mistral La Plateforme Provider",
+                "toolMapping": {
+                    "github.com/gptscript-ai/credential as github.com/gptscript-ai/mistral-laplateforme-provider/credential with \"Please enter your Mistral La Plateforme API Key\" as message and token as field and \"MISTRAL_API_KEY\" as env": [
+                        {
+                            "reference": "github.com/gptscript-ai/credential as github.com/gptscript-ai/mistral-laplateforme-provider/credential with \"Please enter your Mistral La Plateforme API Key\" as message and token as field and \"MISTRAL_API_KEY\" as env",
+                            "toolID": "https://raw.githubusercontent.com/gptscript-ai/credential/37e5f870e195b896438c0bc35867403a42f82e89/tool.gpt:token"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "mistral la plateforme provider": "https://raw.githubusercontent.com/gptscript-ai/mistral-laplateforme-provider/aa4353e7d1de7e90e1078bfbc88526266e587a64/tool.gpt:Mistral La Plateforme Provider"
+                },
+                "source": {
+                    "location": "https://raw.githubusercontent.com/gptscript-ai/mistral-laplateforme-provider/aa4353e7d1de7e90e1078bfbc88526266e587a64/tool.gpt",
+                    "lineNo": 1,
+                    "repo": {
+                        "VCS": "git",
+                        "Root": "https://github.com/gptscript-ai/mistral-laplateforme-provider.git",
+                        "Path": "/",
+                        "Name": "tool.gpt",
+                        "Revision": "aa4353e7d1de7e90e1078bfbc88526266e587a64"
+                    }
+                },
+                "workingDir": "https://raw.githubusercontent.com/gptscript-ai/mistral-laplateforme-provider/aa4353e7d1de7e90e1078bfbc88526266e587a64"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolCategory": "provider",
+            "displayText": "Running sys.daemon"
+        },
+        "type": "callFinish",
+        "usage": {},
+        "content": "http://127.0.0.1:10490"
+    },
+    {
+        "time": "2024-08-06T12:59:05.773737-04:00",
+        "type": "runFinish",
+        "usage": {}
+    },
+    {
+        "time": "2024-08-06T12:59:05.773843-04:00",
+        "callContext": {
+            "id": "1722963545",
+            "tool": {
+                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
+                "internalPrompt": null,
+                "tools": [
+                    "sys.find",
+                    "sys.read",
+                    "summary"
+                ],
+                "instructions": "Generate a readme that gives a consolidated summary of each *.gpt file in the testdata directory.\nEach entry should be a include a link to the referenced file.",
+                "id": "testdata/SamplesReadme/test.gpt:",
+                "toolMapping": {
+                    "summary": [
+                        {
+                            "reference": "summary",
+                            "toolID": "testdata/SamplesReadme/test.gpt:summary"
+                        }
+                    ],
+                    "sys.find": [
+                        {
+                            "reference": "sys.find",
+                            "toolID": "sys.find"
+                        }
+                    ],
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 1
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722963547",
+        "usage": {},
+        "chatRequest": {
+            "model": "mistral-large-2402",
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "Generate a readme that gives a consolidated summary of each *.gpt file in the testdata directory.\nEach entry should be a include a link to the referenced file."
+                }
+            ],
+            "temperature": 0,
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "find",
+                        "description": "Traverse a directory looking for files that match a pattern in the style of the unix find command",
+                        "parameters": {
+                            "properties": {
+                                "directory": {
+                                    "description": "The directory to search in. The current directory \".\" will be used as the default if no argument is passed",
+                                    "type": "string"
+                                },
+                                "pattern": {
+                                    "description": "The file pattern to look for. The pattern is a traditional unix glob format with * matching any character and ? matching a single character",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                },
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "read",
+                        "description": "Reads the contents of a file",
+                        "parameters": {
+                            "properties": {
+                                "filename": {
+                                    "description": "The name of the file to read",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                },
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "summary",
+                        "description": "Summarize a gpt file",
+                        "parameters": {
+                            "properties": {
+                                "file": {
+                                    "description": "filename to summarize",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    {
+        "time": "2024-08-06T12:59:06.748639-04:00",
+        "callContext": {
+            "id": "1722963545",
+            "tool": {
+                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
+                "internalPrompt": null,
+                "tools": [
+                    "sys.find",
+                    "sys.read",
+                    "summary"
+                ],
+                "instructions": "Generate a readme that gives a consolidated summary of each *.gpt file in the testdata directory.\nEach entry should be a include a link to the referenced file.",
+                "id": "testdata/SamplesReadme/test.gpt:",
+                "toolMapping": {
+                    "summary": [
+                        {
+                            "reference": "summary",
+                            "toolID": "testdata/SamplesReadme/test.gpt:summary"
+                        }
+                    ],
+                    "sys.find": [
+                        {
+                            "reference": "sys.find",
+                            "toolID": "sys.find"
+                        }
+                    ],
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 1
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722963547",
+        "usage": {
+            "promptTokens": 404,
+            "completionTokens": 28,
+            "totalTokens": 432
+        },
+        "chatResponse": {
+            "role": "assistant",
+            "content": [
+                {
+                    "toolCall": {
+                        "index": 0,
+                        "id": "VRzlOV4DQ",
+                        "function": {
+                            "name": "find",
+                            "arguments": "{\"directory\": \"testdata\", \"pattern\": \"*.gpt\"}"
+                        }
+                    }
+                }
+            ],
+            "usage": {
+                "promptTokens": 404,
+                "completionTokens": 28,
+                "totalTokens": 432
+            }
+        }
+    },
+    {
+        "time": "2024-08-06T12:59:06.749109-04:00",
+        "callContext": {
+            "id": "1722963545",
+            "tool": {
+                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
+                "internalPrompt": null,
+                "tools": [
+                    "sys.find",
+                    "sys.read",
+                    "summary"
+                ],
+                "instructions": "Generate a readme that gives a consolidated summary of each *.gpt file in the testdata directory.\nEach entry should be a include a link to the referenced file.",
+                "id": "testdata/SamplesReadme/test.gpt:",
+                "toolMapping": {
+                    "summary": [
+                        {
+                            "reference": "summary",
+                            "toolID": "testdata/SamplesReadme/test.gpt:summary"
+                        }
+                    ],
+                    "sys.find": [
+                        {
+                            "reference": "sys.find",
+                            "toolID": "sys.find"
+                        }
+                    ],
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 1
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null
+        },
+        "toolSubCalls": {
+            "VRzlOV4DQ": {
+                "toolID": "sys.find",
+                "input": "{\"directory\": \"testdata\", \"pattern\": \"*.gpt\"}"
+            }
+        },
+        "type": "callSubCalls",
+        "usage": {}
+    },
+    {
+        "time": "2024-08-06T12:59:06.749279-04:00",
+        "callContext": {
+            "id": "VRzlOV4DQ",
+            "tool": {
+                "name": "sys.find",
+                "description": "Traverse a directory looking for files that match a pattern in the style of the unix find command",
+                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "directory": {
+                            "description": "The directory to search in. The current directory \".\" will be used as the default if no argument is passed",
+                            "type": "string"
+                        },
+                        "pattern": {
+                            "description": "The file pattern to look for. The pattern is a traditional unix glob format with * matching any character and ? matching a single character",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "instructions": "#!sys.find",
+                "id": "sys.find",
+                "source": {}
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "sys.find",
+            "parentID": "1722963545",
+            "displayText": "Finding `*.gpt` in `testdata`"
+        },
+        "type": "callStart",
+        "usage": {},
+        "content": "{\"directory\": \"testdata\", \"pattern\": \"*.gpt\"}"
+    },
+    {
+        "time": "2024-08-06T12:59:06.749514-04:00",
+        "callContext": {
+            "id": "VRzlOV4DQ",
+            "tool": {
+                "name": "sys.find",
+                "description": "Traverse a directory looking for files that match a pattern in the style of the unix find command",
+                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "directory": {
+                            "description": "The directory to search in. The current directory \".\" will be used as the default if no argument is passed",
+                            "type": "string"
+                        },
+                        "pattern": {
+                            "description": "The file pattern to look for. The pattern is a traditional unix glob format with * matching any character and ? matching a single character",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "instructions": "#!sys.find",
+                "id": "sys.find",
+                "source": {}
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "sys.find",
+            "parentID": "1722963545",
+            "displayText": "Finding `*.gpt` in `testdata`"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722963548",
+        "usage": {},
+        "chatRequest": {
+            "model": "",
+            "messages": null
+        }
+    },
+    {
+        "time": "2024-08-06T12:59:06.750222-04:00",
+        "callContext": {
+            "id": "VRzlOV4DQ",
+            "tool": {
+                "name": "sys.find",
+                "description": "Traverse a directory looking for files that match a pattern in the style of the unix find command",
+                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "directory": {
+                            "description": "The directory to search in. The current directory \".\" will be used as the default if no argument is passed",
+                            "type": "string"
+                        },
+                        "pattern": {
+                            "description": "The file pattern to look for. The pattern is a traditional unix glob format with * matching any character and ? matching a single character",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "instructions": "#!sys.find",
+                "id": "sys.find",
+                "source": {}
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "sys.find",
+            "parentID": "1722963545",
+            "displayText": "Finding `*.gpt` in `testdata`"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722963548",
+        "usage": {},
+        "chatResponse": {
+            "usage": {}
+        }
+    },
+    {
+        "time": "2024-08-06T12:59:06.750277-04:00",
+        "callContext": {
+            "id": "VRzlOV4DQ",
+            "tool": {
+                "name": "sys.find",
+                "description": "Traverse a directory looking for files that match a pattern in the style of the unix find command",
+                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "directory": {
+                            "description": "The directory to search in. The current directory \".\" will be used as the default if no argument is passed",
+                            "type": "string"
+                        },
+                        "pattern": {
+                            "description": "The file pattern to look for. The pattern is a traditional unix glob format with * matching any character and ? matching a single character",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "instructions": "#!sys.find",
+                "id": "sys.find",
+                "source": {}
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "sys.find",
+            "parentID": "1722963545",
+            "displayText": "Finding `*.gpt` in `testdata`"
+        },
+        "type": "callFinish",
+        "usage": {},
+        "content": "testdata/Bob/test.gpt\ntestdata/BobAsShell/test.gpt\ntestdata/SamplesReadme/test.gpt"
+    },
+    {
+        "time": "2024-08-06T12:59:06.75034-04:00",
+        "callContext": {
+            "id": "1722963545",
+            "tool": {
+                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
+                "internalPrompt": null,
+                "tools": [
+                    "sys.find",
+                    "sys.read",
+                    "summary"
+                ],
+                "instructions": "Generate a readme that gives a consolidated summary of each *.gpt file in the testdata directory.\nEach entry should be a include a link to the referenced file.",
+                "id": "testdata/SamplesReadme/test.gpt:",
+                "toolMapping": {
+                    "summary": [
+                        {
+                            "reference": "summary",
+                            "toolID": "testdata/SamplesReadme/test.gpt:summary"
+                        }
+                    ],
+                    "sys.find": [
+                        {
+                            "reference": "sys.find",
+                            "toolID": "sys.find"
+                        }
+                    ],
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 1
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null
+        },
+        "toolResults": 1,
+        "type": "callContinue",
+        "usage": {}
+    },
+    {
+        "time": "2024-08-06T12:59:07.062434-04:00",
+        "callContext": {
+            "id": "1722963545",
+            "tool": {
+                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
+                "internalPrompt": null,
+                "tools": [
+                    "sys.find",
+                    "sys.read",
+                    "summary"
+                ],
+                "instructions": "Generate a readme that gives a consolidated summary of each *.gpt file in the testdata directory.\nEach entry should be a include a link to the referenced file.",
+                "id": "testdata/SamplesReadme/test.gpt:",
+                "toolMapping": {
+                    "summary": [
+                        {
+                            "reference": "summary",
+                            "toolID": "testdata/SamplesReadme/test.gpt:summary"
+                        }
+                    ],
+                    "sys.find": [
+                        {
+                            "reference": "sys.find",
+                            "toolID": "sys.find"
+                        }
+                    ],
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 1
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722963549",
+        "usage": {},
+        "chatRequest": {
+            "model": "mistral-large-2402",
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "Generate a readme that gives a consolidated summary of each *.gpt file in the testdata directory.\nEach entry should be a include a link to the referenced file."
+                },
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "VRzlOV4DQ",
+                            "type": "function",
+                            "function": {
+                                "name": "find",
+                                "arguments": "{\"directory\": \"testdata\", \"pattern\": \"*.gpt\"}"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "role": "tool",
+                    "content": "testdata/Bob/test.gpt\ntestdata/BobAsShell/test.gpt\ntestdata/SamplesReadme/test.gpt",
+                    "name": "find",
+                    "tool_call_id": "VRzlOV4DQ"
+                }
+            ],
+            "temperature": 0,
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "find",
+                        "description": "Traverse a directory looking for files that match a pattern in the style of the unix find command",
+                        "parameters": {
+                            "properties": {
+                                "directory": {
+                                    "description": "The directory to search in. The current directory \".\" will be used as the default if no argument is passed",
+                                    "type": "string"
+                                },
+                                "pattern": {
+                                    "description": "The file pattern to look for. The pattern is a traditional unix glob format with * matching any character and ? matching a single character",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                },
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "read",
+                        "description": "Reads the contents of a file",
+                        "parameters": {
+                            "properties": {
+                                "filename": {
+                                    "description": "The name of the file to read",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                },
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "summary",
+                        "description": "Summarize a gpt file",
+                        "parameters": {
+                            "properties": {
+                                "file": {
+                                    "description": "filename to summarize",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    {
+        "time": "2024-08-06T12:59:07.898179-04:00",
+        "callContext": {
+            "id": "1722963545",
+            "tool": {
+                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
+                "internalPrompt": null,
+                "tools": [
+                    "sys.find",
+                    "sys.read",
+                    "summary"
+                ],
+                "instructions": "Generate a readme that gives a consolidated summary of each *.gpt file in the testdata directory.\nEach entry should be a include a link to the referenced file.",
+                "id": "testdata/SamplesReadme/test.gpt:",
+                "toolMapping": {
+                    "summary": [
+                        {
+                            "reference": "summary",
+                            "toolID": "testdata/SamplesReadme/test.gpt:summary"
+                        }
+                    ],
+                    "sys.find": [
+                        {
+                            "reference": "sys.find",
+                            "toolID": "sys.find"
+                        }
+                    ],
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 1
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null
+        },
+        "toolSubCalls": {
+            "kw8Rbdag6": {
+                "toolID": "testdata/SamplesReadme/test.gpt:summary",
+                "input": "{\"file\": \"testdata/Bob/test.gpt\"}"
+            }
+        },
+        "type": "callSubCalls",
+        "usage": {}
+    },
+    {
+        "time": "2024-08-06T12:59:07.898189-04:00",
+        "callContext": {
+            "id": "1722963545",
+            "tool": {
+                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
+                "internalPrompt": null,
+                "tools": [
+                    "sys.find",
+                    "sys.read",
+                    "summary"
+                ],
+                "instructions": "Generate a readme that gives a consolidated summary of each *.gpt file in the testdata directory.\nEach entry should be a include a link to the referenced file.",
+                "id": "testdata/SamplesReadme/test.gpt:",
+                "toolMapping": {
+                    "summary": [
+                        {
+                            "reference": "summary",
+                            "toolID": "testdata/SamplesReadme/test.gpt:summary"
+                        }
+                    ],
+                    "sys.find": [
+                        {
+                            "reference": "sys.find",
+                            "toolID": "sys.find"
+                        }
+                    ],
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 1
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722963549",
+        "usage": {
+            "promptTokens": 486,
+            "completionTokens": 28,
+            "totalTokens": 514
+        },
+        "chatResponse": {
+            "role": "assistant",
+            "content": [
+                {
+                    "toolCall": {
+                        "index": 0,
+                        "id": "kw8Rbdag6",
+                        "function": {
+                            "name": "summary",
+                            "arguments": "{\"file\": \"testdata/Bob/test.gpt\"}"
+                        }
+                    }
+                }
+            ],
+            "usage": {
+                "promptTokens": 486,
+                "completionTokens": 28,
+                "totalTokens": 514
+            }
+        }
+    },
+    {
+        "time": "2024-08-06T12:59:07.898477-04:00",
+        "callContext": {
+            "id": "kw8Rbdag6",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722963545"
+        },
+        "type": "callStart",
+        "usage": {},
+        "content": "{\"file\": \"testdata/Bob/test.gpt\"}"
+    },
+    {
+        "time": "2024-08-06T12:59:08.237733-04:00",
+        "callContext": {
+            "id": "kw8Rbdag6",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722963545"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722963550",
+        "usage": {},
+        "chatRequest": {
+            "model": "mistral-large-2402",
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate."
+                },
+                {
+                    "role": "user",
+                    "content": "{\"file\": \"testdata/Bob/test.gpt\"}"
+                }
+            ],
+            "temperature": 0,
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "read",
+                        "description": "Reads the contents of a file",
+                        "parameters": {
+                            "properties": {
+                                "filename": {
+                                    "description": "The name of the file to read",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    {
+        "time": "2024-08-06T12:59:10.465113-04:00",
+        "callContext": {
+            "id": "kw8Rbdag6",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722963545"
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722963550",
+        "usage": {
+            "promptTokens": 236,
+            "completionTokens": 96,
+            "totalTokens": 332
+        },
+        "chatResponse": {
+            "role": "assistant",
+            "content": [
+                {
+                    "text": "The file \"test.gpt\" contains a GPTScript that demonstrates the use of a decision tree technique for AI automation. The script starts with a greeting and then asks the user about their preference between two options. Based on the user's response, the script navigates through different branches of the decision tree, providing relevant responses and asking further questions to gather more information. The script ends by providing a personalized recommendation based on the user's inputs."
+                }
+            ],
+            "usage": {
+                "promptTokens": 236,
+                "completionTokens": 96,
+                "totalTokens": 332
+            }
+        }
+    },
+    {
+        "time": "2024-08-06T12:59:10.465441-04:00",
+        "callContext": {
+            "id": "kw8Rbdag6",
+            "tool": {
+                "name": "summary",
+                "description": "Summarize a gpt file",
+                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
+                "internalPrompt": null,
+                "arguments": {
+                    "properties": {
+                        "file": {
+                            "description": "filename to summarize",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": [
+                    "sys.read"
+                ],
+                "instructions": "Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.\nBriefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.",
+                "id": "testdata/SamplesReadme/test.gpt:summary",
+                "toolMapping": {
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 7
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null,
+            "toolName": "summary",
+            "parentID": "1722963545"
+        },
+        "type": "callFinish",
+        "usage": {},
+        "content": "The file \"test.gpt\" contains a GPTScript that demonstrates the use of a decision tree technique for AI automation. The script starts with a greeting and then asks the user about their preference between two options. Based on the user's response, the script navigates through different branches of the decision tree, providing relevant responses and asking further questions to gather more information. The script ends by providing a personalized recommendation based on the user's inputs."
+    },
+    {
+        "time": "2024-08-06T12:59:10.465551-04:00",
+        "callContext": {
+            "id": "1722963545",
+            "tool": {
+                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
+                "internalPrompt": null,
+                "tools": [
+                    "sys.find",
+                    "sys.read",
+                    "summary"
+                ],
+                "instructions": "Generate a readme that gives a consolidated summary of each *.gpt file in the testdata directory.\nEach entry should be a include a link to the referenced file.",
+                "id": "testdata/SamplesReadme/test.gpt:",
+                "toolMapping": {
+                    "summary": [
+                        {
+                            "reference": "summary",
+                            "toolID": "testdata/SamplesReadme/test.gpt:summary"
+                        }
+                    ],
+                    "sys.find": [
+                        {
+                            "reference": "sys.find",
+                            "toolID": "sys.find"
+                        }
+                    ],
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 1
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null
+        },
+        "toolResults": 1,
+        "type": "callContinue",
+        "usage": {}
+    },
+    {
+        "time": "2024-08-06T12:59:10.638885-04:00",
+        "callContext": {
+            "id": "1722963545",
+            "tool": {
+                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
+                "internalPrompt": null,
+                "tools": [
+                    "sys.find",
+                    "sys.read",
+                    "summary"
+                ],
+                "instructions": "Generate a readme that gives a consolidated summary of each *.gpt file in the testdata directory.\nEach entry should be a include a link to the referenced file.",
+                "id": "testdata/SamplesReadme/test.gpt:",
+                "toolMapping": {
+                    "summary": [
+                        {
+                            "reference": "summary",
+                            "toolID": "testdata/SamplesReadme/test.gpt:summary"
+                        }
+                    ],
+                    "sys.find": [
+                        {
+                            "reference": "sys.find",
+                            "toolID": "sys.find"
+                        }
+                    ],
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 1
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722963551",
+        "usage": {},
+        "chatRequest": {
+            "model": "mistral-large-2402",
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "Generate a readme that gives a consolidated summary of each *.gpt file in the testdata directory.\nEach entry should be a include a link to the referenced file."
+                },
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "VRzlOV4DQ",
+                            "type": "function",
+                            "function": {
+                                "name": "find",
+                                "arguments": "{\"directory\": \"testdata\", \"pattern\": \"*.gpt\"}"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "role": "tool",
+                    "content": "testdata/Bob/test.gpt\ntestdata/BobAsShell/test.gpt\ntestdata/SamplesReadme/test.gpt",
+                    "name": "find",
+                    "tool_call_id": "VRzlOV4DQ"
+                },
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "kw8Rbdag6",
+                            "type": "function",
+                            "function": {
+                                "name": "summary",
+                                "arguments": "{\"file\": \"testdata/Bob/test.gpt\"}"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "role": "tool",
+                    "content": "The file \"test.gpt\" contains a GPTScript that demonstrates the use of a decision tree technique for AI automation. The script starts with a greeting and then asks the user about their preference between two options. Based on the user's response, the script navigates through different branches of the decision tree, providing relevant responses and asking further questions to gather more information. The script ends by providing a personalized recommendation based on the user's inputs.",
+                    "name": "summary",
+                    "tool_call_id": "kw8Rbdag6"
+                }
+            ],
+            "temperature": 0,
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "find",
+                        "description": "Traverse a directory looking for files that match a pattern in the style of the unix find command",
+                        "parameters": {
+                            "properties": {
+                                "directory": {
+                                    "description": "The directory to search in. The current directory \".\" will be used as the default if no argument is passed",
+                                    "type": "string"
+                                },
+                                "pattern": {
+                                    "description": "The file pattern to look for. The pattern is a traditional unix glob format with * matching any character and ? matching a single character",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                },
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "read",
+                        "description": "Reads the contents of a file",
+                        "parameters": {
+                            "properties": {
+                                "filename": {
+                                    "description": "The name of the file to read",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                },
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "summary",
+                        "description": "Summarize a gpt file",
+                        "parameters": {
+                            "properties": {
+                                "file": {
+                                    "description": "filename to summarize",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    {
+        "time": "2024-08-06T12:59:14.328302-04:00",
+        "callContext": {
+            "id": "1722963545",
+            "tool": {
+                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
+                "internalPrompt": null,
+                "tools": [
+                    "sys.find",
+                    "sys.read",
+                    "summary"
+                ],
+                "instructions": "Generate a readme that gives a consolidated summary of each *.gpt file in the testdata directory.\nEach entry should be a include a link to the referenced file.",
+                "id": "testdata/SamplesReadme/test.gpt:",
+                "toolMapping": {
+                    "summary": [
+                        {
+                            "reference": "summary",
+                            "toolID": "testdata/SamplesReadme/test.gpt:summary"
+                        }
+                    ],
+                    "sys.find": [
+                        {
+                            "reference": "sys.find",
+                            "toolID": "sys.find"
+                        }
+                    ],
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 1
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null
+        },
+        "type": "callChat",
+        "chatCompletionId": "1722963551",
+        "usage": {
+            "promptTokens": 625,
+            "completionTokens": 160,
+            "totalTokens": 785
+        },
+        "chatResponse": {
+            "role": "assistant",
+            "content": [
+                {
+                    "text": "# Testdata Summary\n\n## [testdata/Bob/test.gpt](testdata/Bob/test.gpt)\nThe file \"test.gpt\" contains a GPTScript that demonstrates the use of a decision tree technique for AI automation. The script starts with a greeting and then asks the user about their preference between two options. Based on the user's response, the script navigates through different branches of the decision tree, providing relevant responses and asking further questions to gather more information. The script ends by providing a personalized recommendation based on the user's inputs.\n\nPlease wait while I process the remaining files.\n\n[Continue processing the remaining files using the \"summary\" function and update the README accordingly.]"
+                }
+            ],
+            "usage": {
+                "promptTokens": 625,
+                "completionTokens": 160,
+                "totalTokens": 785
+            }
+        }
+    },
+    {
+        "time": "2024-08-06T12:59:14.328408-04:00",
+        "callContext": {
+            "id": "1722963545",
+            "tool": {
+                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
+                "internalPrompt": null,
+                "tools": [
+                    "sys.find",
+                    "sys.read",
+                    "summary"
+                ],
+                "instructions": "Generate a readme that gives a consolidated summary of each *.gpt file in the testdata directory.\nEach entry should be a include a link to the referenced file.",
+                "id": "testdata/SamplesReadme/test.gpt:",
+                "toolMapping": {
+                    "summary": [
+                        {
+                            "reference": "summary",
+                            "toolID": "testdata/SamplesReadme/test.gpt:summary"
+                        }
+                    ],
+                    "sys.find": [
+                        {
+                            "reference": "sys.find",
+                            "toolID": "sys.find"
+                        }
+                    ],
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 1
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null
+        },
+        "type": "callFinish",
+        "usage": {},
+        "content": "# Testdata Summary\n\n## [testdata/Bob/test.gpt](testdata/Bob/test.gpt)\nThe file \"test.gpt\" contains a GPTScript that demonstrates the use of a decision tree technique for AI automation. The script starts with a greeting and then asks the user about their preference between two options. Based on the user's response, the script navigates through different branches of the decision tree, providing relevant responses and asking further questions to gather more information. The script ends by providing a personalized recommendation based on the user's inputs.\n\nPlease wait while I process the remaining files.\n\n[Continue processing the remaining files using the \"summary\" function and update the README accordingly.]"
+    },
+    {
+        "time": "2024-08-06T12:59:14.328477-04:00",
+        "type": "runFinish",
+        "usage": {}
+    }
+]

--- a/pkg/tests/smoke/testdata/SamplesReadme/mistral-large-2402-expected.json
+++ b/pkg/tests/smoke/testdata/SamplesReadme/mistral-large-2402-expected.json
@@ -1,13 +1,13 @@
 [
     {
-        "time": "2024-08-06T12:59:04.275149-04:00",
+        "time": "2024-08-23T12:02:12.663843-04:00",
         "type": "runStart",
         "usage": {}
     },
     {
-        "time": "2024-08-06T12:59:04.275665-04:00",
+        "time": "2024-08-23T12:02:12.664126-04:00",
         "callContext": {
-            "id": "1722963545",
+            "id": "1724428933",
             "tool": {
                 "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
                 "internalPrompt": null,
@@ -55,14 +55,14 @@
         "usage": {}
     },
     {
-        "time": "2024-08-06T12:59:04.756574-04:00",
+        "time": "2024-08-23T12:02:13.179975-04:00",
         "type": "runStart",
         "usage": {}
     },
     {
-        "time": "2024-08-06T12:59:04.756881-04:00",
+        "time": "2024-08-23T12:02:13.180053-04:00",
         "callContext": {
-            "id": "1722963546",
+            "id": "1724428934",
             "tool": {
                 "name": "Mistral La Plateforme Provider",
                 "description": "Model provider for Mistral models running on La Plateforme",
@@ -107,9 +107,9 @@
         "usage": {}
     },
     {
-        "time": "2024-08-06T12:59:05.773409-04:00",
+        "time": "2024-08-23T12:02:14.191214-04:00",
         "callContext": {
-            "id": "1722963546",
+            "id": "1724428934",
             "tool": {
                 "name": "Mistral La Plateforme Provider",
                 "description": "Model provider for Mistral models running on La Plateforme",
@@ -152,17 +152,17 @@
         },
         "type": "callFinish",
         "usage": {},
-        "content": "http://127.0.0.1:10490"
+        "content": "http://127.0.0.1:10834"
     },
     {
-        "time": "2024-08-06T12:59:05.773737-04:00",
+        "time": "2024-08-23T12:02:14.191336-04:00",
         "type": "runFinish",
         "usage": {}
     },
     {
-        "time": "2024-08-06T12:59:05.773843-04:00",
+        "time": "2024-08-23T12:02:14.191414-04:00",
         "callContext": {
-            "id": "1722963545",
+            "id": "1724428933",
             "tool": {
                 "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
                 "internalPrompt": null,
@@ -207,7 +207,7 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1722963547",
+        "chatCompletionId": "1724428935",
         "usage": {},
         "chatRequest": {
             "model": "mistral-large-2402",
@@ -275,9 +275,9 @@
         }
     },
     {
-        "time": "2024-08-06T12:59:06.748639-04:00",
+        "time": "2024-08-23T12:02:15.753724-04:00",
         "callContext": {
-            "id": "1722963545",
+            "id": "1724428933",
             "tool": {
                 "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
                 "internalPrompt": null,
@@ -322,7 +322,7 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1722963547",
+        "chatCompletionId": "1724428935",
         "usage": {
             "promptTokens": 404,
             "completionTokens": 28,
@@ -334,7 +334,7 @@
                 {
                     "toolCall": {
                         "index": 0,
-                        "id": "VRzlOV4DQ",
+                        "id": "NHz8UTYnn",
                         "function": {
                             "name": "find",
                             "arguments": "{\"directory\": \"testdata\", \"pattern\": \"*.gpt\"}"
@@ -350,9 +350,9 @@
         }
     },
     {
-        "time": "2024-08-06T12:59:06.749109-04:00",
+        "time": "2024-08-23T12:02:15.753873-04:00",
         "callContext": {
-            "id": "1722963545",
+            "id": "1724428933",
             "tool": {
                 "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
                 "internalPrompt": null,
@@ -397,7 +397,7 @@
             "inputContext": null
         },
         "toolSubCalls": {
-            "VRzlOV4DQ": {
+            "NHz8UTYnn": {
                 "toolID": "sys.find",
                 "input": "{\"directory\": \"testdata\", \"pattern\": \"*.gpt\"}"
             }
@@ -406,9 +406,9 @@
         "usage": {}
     },
     {
-        "time": "2024-08-06T12:59:06.749279-04:00",
+        "time": "2024-08-23T12:02:15.753944-04:00",
         "callContext": {
-            "id": "VRzlOV4DQ",
+            "id": "NHz8UTYnn",
             "tool": {
                 "name": "sys.find",
                 "description": "Traverse a directory looking for files that match a pattern in the style of the unix find command",
@@ -434,7 +434,7 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "sys.find",
-            "parentID": "1722963545",
+            "parentID": "1724428933",
             "displayText": "Finding `*.gpt` in `testdata`"
         },
         "type": "callStart",
@@ -442,9 +442,9 @@
         "content": "{\"directory\": \"testdata\", \"pattern\": \"*.gpt\"}"
     },
     {
-        "time": "2024-08-06T12:59:06.749514-04:00",
+        "time": "2024-08-23T12:02:15.75564-04:00",
         "callContext": {
-            "id": "VRzlOV4DQ",
+            "id": "NHz8UTYnn",
             "tool": {
                 "name": "sys.find",
                 "description": "Traverse a directory looking for files that match a pattern in the style of the unix find command",
@@ -470,11 +470,11 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "sys.find",
-            "parentID": "1722963545",
+            "parentID": "1724428933",
             "displayText": "Finding `*.gpt` in `testdata`"
         },
         "type": "callChat",
-        "chatCompletionId": "1722963548",
+        "chatCompletionId": "1724428936",
         "usage": {},
         "chatRequest": {
             "model": "",
@@ -482,9 +482,9 @@
         }
     },
     {
-        "time": "2024-08-06T12:59:06.750222-04:00",
+        "time": "2024-08-23T12:02:15.7563-04:00",
         "callContext": {
-            "id": "VRzlOV4DQ",
+            "id": "NHz8UTYnn",
             "tool": {
                 "name": "sys.find",
                 "description": "Traverse a directory looking for files that match a pattern in the style of the unix find command",
@@ -510,20 +510,20 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "sys.find",
-            "parentID": "1722963545",
+            "parentID": "1724428933",
             "displayText": "Finding `*.gpt` in `testdata`"
         },
         "type": "callChat",
-        "chatCompletionId": "1722963548",
+        "chatCompletionId": "1724428936",
         "usage": {},
         "chatResponse": {
             "usage": {}
         }
     },
     {
-        "time": "2024-08-06T12:59:06.750277-04:00",
+        "time": "2024-08-23T12:02:15.756369-04:00",
         "callContext": {
-            "id": "VRzlOV4DQ",
+            "id": "NHz8UTYnn",
             "tool": {
                 "name": "sys.find",
                 "description": "Traverse a directory looking for files that match a pattern in the style of the unix find command",
@@ -549,7 +549,7 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "sys.find",
-            "parentID": "1722963545",
+            "parentID": "1724428933",
             "displayText": "Finding `*.gpt` in `testdata`"
         },
         "type": "callFinish",
@@ -557,9 +557,9 @@
         "content": "testdata/Bob/test.gpt\ntestdata/BobAsShell/test.gpt\ntestdata/SamplesReadme/test.gpt"
     },
     {
-        "time": "2024-08-06T12:59:06.75034-04:00",
+        "time": "2024-08-23T12:02:15.756408-04:00",
         "callContext": {
-            "id": "1722963545",
+            "id": "1724428933",
             "tool": {
                 "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
                 "internalPrompt": null,
@@ -608,9 +608,9 @@
         "usage": {}
     },
     {
-        "time": "2024-08-06T12:59:07.062434-04:00",
+        "time": "2024-08-23T12:02:16.041065-04:00",
         "callContext": {
-            "id": "1722963545",
+            "id": "1724428933",
             "tool": {
                 "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
                 "internalPrompt": null,
@@ -655,7 +655,7 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1722963549",
+        "chatCompletionId": "1724428937",
         "usage": {},
         "chatRequest": {
             "model": "mistral-large-2402",
@@ -669,7 +669,7 @@
                     "content": "",
                     "tool_calls": [
                         {
-                            "id": "VRzlOV4DQ",
+                            "id": "NHz8UTYnn",
                             "type": "function",
                             "function": {
                                 "name": "find",
@@ -682,7 +682,7 @@
                     "role": "tool",
                     "content": "testdata/Bob/test.gpt\ntestdata/BobAsShell/test.gpt\ntestdata/SamplesReadme/test.gpt",
                     "name": "find",
-                    "tool_call_id": "VRzlOV4DQ"
+                    "tool_call_id": "NHz8UTYnn"
                 }
             ],
             "temperature": 0,
@@ -743,9 +743,84 @@
         }
     },
     {
-        "time": "2024-08-06T12:59:07.898179-04:00",
+        "time": "2024-08-23T12:02:19.335498-04:00",
         "callContext": {
-            "id": "1722963545",
+            "id": "1724428933",
+            "tool": {
+                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
+                "internalPrompt": null,
+                "tools": [
+                    "sys.find",
+                    "sys.read",
+                    "summary"
+                ],
+                "instructions": "Generate a readme that gives a consolidated summary of each *.gpt file in the testdata directory.\nEach entry should be a include a link to the referenced file.",
+                "id": "testdata/SamplesReadme/test.gpt:",
+                "toolMapping": {
+                    "summary": [
+                        {
+                            "reference": "summary",
+                            "toolID": "testdata/SamplesReadme/test.gpt:summary"
+                        }
+                    ],
+                    "sys.find": [
+                        {
+                            "reference": "sys.find",
+                            "toolID": "sys.find"
+                        }
+                    ],
+                    "sys.read": [
+                        {
+                            "reference": "sys.read",
+                            "toolID": "sys.read"
+                        }
+                    ]
+                },
+                "localTools": {
+                    "": "testdata/SamplesReadme/test.gpt:",
+                    "summary": "testdata/SamplesReadme/test.gpt:summary"
+                },
+                "source": {
+                    "location": "testdata/SamplesReadme/test.gpt",
+                    "lineNo": 1
+                },
+                "workingDir": "testdata/SamplesReadme"
+            },
+            "currentAgent": {},
+            "inputContext": null
+        },
+        "type": "callChat",
+        "chatCompletionId": "1724428937",
+        "usage": {
+            "promptTokens": 486,
+            "completionTokens": 28,
+            "totalTokens": 514
+        },
+        "chatResponse": {
+            "role": "assistant",
+            "content": [
+                {
+                    "toolCall": {
+                        "index": 0,
+                        "id": "H4wTu9hi1",
+                        "function": {
+                            "name": "summary",
+                            "arguments": "{\"file\": \"testdata/Bob/test.gpt\"}"
+                        }
+                    }
+                }
+            ],
+            "usage": {
+                "promptTokens": 486,
+                "completionTokens": 28,
+                "totalTokens": 514
+            }
+        }
+    },
+    {
+        "time": "2024-08-23T12:02:19.335519-04:00",
+        "callContext": {
+            "id": "1724428933",
             "tool": {
                 "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
                 "internalPrompt": null,
@@ -790,7 +865,7 @@
             "inputContext": null
         },
         "toolSubCalls": {
-            "kw8Rbdag6": {
+            "H4wTu9hi1": {
                 "toolID": "testdata/SamplesReadme/test.gpt:summary",
                 "input": "{\"file\": \"testdata/Bob/test.gpt\"}"
             }
@@ -799,84 +874,9 @@
         "usage": {}
     },
     {
-        "time": "2024-08-06T12:59:07.898189-04:00",
+        "time": "2024-08-23T12:02:19.335613-04:00",
         "callContext": {
-            "id": "1722963545",
-            "tool": {
-                "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
-                "internalPrompt": null,
-                "tools": [
-                    "sys.find",
-                    "sys.read",
-                    "summary"
-                ],
-                "instructions": "Generate a readme that gives a consolidated summary of each *.gpt file in the testdata directory.\nEach entry should be a include a link to the referenced file.",
-                "id": "testdata/SamplesReadme/test.gpt:",
-                "toolMapping": {
-                    "summary": [
-                        {
-                            "reference": "summary",
-                            "toolID": "testdata/SamplesReadme/test.gpt:summary"
-                        }
-                    ],
-                    "sys.find": [
-                        {
-                            "reference": "sys.find",
-                            "toolID": "sys.find"
-                        }
-                    ],
-                    "sys.read": [
-                        {
-                            "reference": "sys.read",
-                            "toolID": "sys.read"
-                        }
-                    ]
-                },
-                "localTools": {
-                    "": "testdata/SamplesReadme/test.gpt:",
-                    "summary": "testdata/SamplesReadme/test.gpt:summary"
-                },
-                "source": {
-                    "location": "testdata/SamplesReadme/test.gpt",
-                    "lineNo": 1
-                },
-                "workingDir": "testdata/SamplesReadme"
-            },
-            "currentAgent": {},
-            "inputContext": null
-        },
-        "type": "callChat",
-        "chatCompletionId": "1722963549",
-        "usage": {
-            "promptTokens": 486,
-            "completionTokens": 28,
-            "totalTokens": 514
-        },
-        "chatResponse": {
-            "role": "assistant",
-            "content": [
-                {
-                    "toolCall": {
-                        "index": 0,
-                        "id": "kw8Rbdag6",
-                        "function": {
-                            "name": "summary",
-                            "arguments": "{\"file\": \"testdata/Bob/test.gpt\"}"
-                        }
-                    }
-                }
-            ],
-            "usage": {
-                "promptTokens": 486,
-                "completionTokens": 28,
-                "totalTokens": 514
-            }
-        }
-    },
-    {
-        "time": "2024-08-06T12:59:07.898477-04:00",
-        "callContext": {
-            "id": "kw8Rbdag6",
+            "id": "H4wTu9hi1",
             "tool": {
                 "name": "summary",
                 "description": "Summarize a gpt file",
@@ -917,16 +917,16 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "summary",
-            "parentID": "1722963545"
+            "parentID": "1724428933"
         },
         "type": "callStart",
         "usage": {},
         "content": "{\"file\": \"testdata/Bob/test.gpt\"}"
     },
     {
-        "time": "2024-08-06T12:59:08.237733-04:00",
+        "time": "2024-08-23T12:02:19.665733-04:00",
         "callContext": {
-            "id": "kw8Rbdag6",
+            "id": "H4wTu9hi1",
             "tool": {
                 "name": "summary",
                 "description": "Summarize a gpt file",
@@ -967,10 +967,10 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "summary",
-            "parentID": "1722963545"
+            "parentID": "1724428933"
         },
         "type": "callChat",
-        "chatCompletionId": "1722963550",
+        "chatCompletionId": "1724428938",
         "usage": {},
         "chatRequest": {
             "model": "mistral-large-2402",
@@ -1006,9 +1006,9 @@
         }
     },
     {
-        "time": "2024-08-06T12:59:10.465113-04:00",
+        "time": "2024-08-23T12:02:22.344057-04:00",
         "callContext": {
-            "id": "kw8Rbdag6",
+            "id": "H4wTu9hi1",
             "tool": {
                 "name": "summary",
                 "description": "Summarize a gpt file",
@@ -1049,10 +1049,10 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "summary",
-            "parentID": "1722963545"
+            "parentID": "1724428933"
         },
         "type": "callChat",
-        "chatCompletionId": "1722963550",
+        "chatCompletionId": "1724428938",
         "usage": {
             "promptTokens": 236,
             "completionTokens": 96,
@@ -1073,9 +1073,9 @@
         }
     },
     {
-        "time": "2024-08-06T12:59:10.465441-04:00",
+        "time": "2024-08-23T12:02:22.344127-04:00",
         "callContext": {
-            "id": "kw8Rbdag6",
+            "id": "H4wTu9hi1",
             "tool": {
                 "name": "summary",
                 "description": "Summarize a gpt file",
@@ -1116,16 +1116,16 @@
             "currentAgent": {},
             "inputContext": null,
             "toolName": "summary",
-            "parentID": "1722963545"
+            "parentID": "1724428933"
         },
         "type": "callFinish",
         "usage": {},
         "content": "The file \"test.gpt\" contains a GPTScript that demonstrates the use of a decision tree technique for AI automation. The script starts with a greeting and then asks the user about their preference between two options. Based on the user's response, the script navigates through different branches of the decision tree, providing relevant responses and asking further questions to gather more information. The script ends by providing a personalized recommendation based on the user's inputs."
     },
     {
-        "time": "2024-08-06T12:59:10.465551-04:00",
+        "time": "2024-08-23T12:02:22.344175-04:00",
         "callContext": {
-            "id": "1722963545",
+            "id": "1724428933",
             "tool": {
                 "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
                 "internalPrompt": null,
@@ -1174,9 +1174,9 @@
         "usage": {}
     },
     {
-        "time": "2024-08-06T12:59:10.638885-04:00",
+        "time": "2024-08-23T12:02:22.708297-04:00",
         "callContext": {
-            "id": "1722963545",
+            "id": "1724428933",
             "tool": {
                 "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
                 "internalPrompt": null,
@@ -1221,7 +1221,7 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1722963551",
+        "chatCompletionId": "1724428939",
         "usage": {},
         "chatRequest": {
             "model": "mistral-large-2402",
@@ -1235,7 +1235,7 @@
                     "content": "",
                     "tool_calls": [
                         {
-                            "id": "VRzlOV4DQ",
+                            "id": "NHz8UTYnn",
                             "type": "function",
                             "function": {
                                 "name": "find",
@@ -1248,14 +1248,14 @@
                     "role": "tool",
                     "content": "testdata/Bob/test.gpt\ntestdata/BobAsShell/test.gpt\ntestdata/SamplesReadme/test.gpt",
                     "name": "find",
-                    "tool_call_id": "VRzlOV4DQ"
+                    "tool_call_id": "NHz8UTYnn"
                 },
                 {
                     "role": "assistant",
                     "content": "",
                     "tool_calls": [
                         {
-                            "id": "kw8Rbdag6",
+                            "id": "H4wTu9hi1",
                             "type": "function",
                             "function": {
                                 "name": "summary",
@@ -1268,7 +1268,7 @@
                     "role": "tool",
                     "content": "The file \"test.gpt\" contains a GPTScript that demonstrates the use of a decision tree technique for AI automation. The script starts with a greeting and then asks the user about their preference between two options. Based on the user's response, the script navigates through different branches of the decision tree, providing relevant responses and asking further questions to gather more information. The script ends by providing a personalized recommendation based on the user's inputs.",
                     "name": "summary",
-                    "tool_call_id": "kw8Rbdag6"
+                    "tool_call_id": "H4wTu9hi1"
                 }
             ],
             "temperature": 0,
@@ -1329,9 +1329,9 @@
         }
     },
     {
-        "time": "2024-08-06T12:59:14.328302-04:00",
+        "time": "2024-08-23T12:02:27.495193-04:00",
         "callContext": {
-            "id": "1722963545",
+            "id": "1724428933",
             "tool": {
                 "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
                 "internalPrompt": null,
@@ -1376,7 +1376,7 @@
             "inputContext": null
         },
         "type": "callChat",
-        "chatCompletionId": "1722963551",
+        "chatCompletionId": "1724428939",
         "usage": {
             "promptTokens": 625,
             "completionTokens": 160,
@@ -1397,9 +1397,9 @@
         }
     },
     {
-        "time": "2024-08-06T12:59:14.328408-04:00",
+        "time": "2024-08-23T12:02:27.495233-04:00",
         "callContext": {
-            "id": "1722963545",
+            "id": "1724428933",
             "tool": {
                 "modelName": "mistral-large-2402 from github.com/gptscript-ai/mistral-laplateforme-provider",
                 "internalPrompt": null,
@@ -1448,7 +1448,7 @@
         "content": "# Testdata Summary\n\n## [testdata/Bob/test.gpt](testdata/Bob/test.gpt)\nThe file \"test.gpt\" contains a GPTScript that demonstrates the use of a decision tree technique for AI automation. The script starts with a greeting and then asks the user about their preference between two options. Based on the user's response, the script navigates through different branches of the decision tree, providing relevant responses and asking further questions to gather more information. The script ends by providing a personalized recommendation based on the user's inputs.\n\nPlease wait while I process the remaining files.\n\n[Continue processing the remaining files using the \"summary\" function and update the README accordingly.]"
     },
     {
-        "time": "2024-08-06T12:59:14.328477-04:00",
+        "time": "2024-08-23T12:02:27.495269-04:00",
         "type": "runFinish",
         "usage": {}
     }

--- a/pkg/tests/smoke/testdata/SamplesReadme/test.gpt
+++ b/pkg/tests/smoke/testdata/SamplesReadme/test.gpt
@@ -1,0 +1,13 @@
+tools: sys.find, sys.read, summary
+
+Generate a readme that gives a consolidated summary of each *.gpt file in the testdata directory.
+Each entry should be a include a link to the referenced file.
+
+---
+name: summary
+description: Summarize a gpt file
+args: file: filename to summarize
+tools: sys.read
+
+Read ${file} which is a sample GPTScript file. GPT script is an AI automation scripting language.
+Briefly describe the contents of the GPTScript file and what technique the file is trying to demonstrate.


### PR DESCRIPTION
- Add a smoke test based on examples/samples-readme.md
- Strip call progress type events before LLM comparison (this prevents messages from getting too large and failing OpenAI API validation)
- Regenerate golden files for existing models to drop callProgress
  events (we weren't comparing these anyway)
- Add golden files for `gpt-4o-2024-08-06`
- Focus comparison on matching event types to reduce false negatives
- Drop "ignore callProgress" rule (we're eliding them from the event
  stream before sending them to the judge now)
- Add gpt-4o-2024-08-06 to our smoke test action

