### PR TITLE
fix: make vars capital in smoke tests

### DIFF
--- a/pkg/tests/smoke/testdata/Bob/test.gpt
+++ b/pkg/tests/smoke/testdata/Bob/test.gpt
@@ -7,4 +7,4 @@ name: bob
 description: I'm Bob, a friendly guy.
 args: question: The question to ask Bob.
 
-When asked how I am doing, respond with exactly "Thanks for asking "${question}", I'm doing great fellow friendly AI tool!"
+When asked how I am doing, respond with exactly "Thanks for asking "${QUESTION}", I'm doing great fellow friendly AI tool!"

--- a/pkg/tests/smoke/testdata/BobAsShell/test.gpt
+++ b/pkg/tests/smoke/testdata/BobAsShell/test.gpt
@@ -10,4 +10,4 @@ args: question: The question to ask Bob.
 
 #!/bin/bash
 
-echo "Thanks for asking ${question}, I'm doing great fellow friendly AI tool!"
+echo "Thanks for asking ${QUESTION}, I'm doing great fellow friendly AI tool!"


### PR DESCRIPTION
A recent change in gptscript got rid of the lowercase env vars because they don't work on Windows. This change updates the smoke tests.