### PR TITLE
fix: use shellwords instead of shlex

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,12 +7,12 @@ require (
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/BurntSushi/locker v0.0.0-20171006230638-a6e239ea1c69
 	github.com/adrg/xdg v0.4.0
+	github.com/buildkite/shellwords v0.0.0-20180315110454-59467a9b8e10
 	github.com/chzyer/readline v1.5.1
 	github.com/docker/cli v26.0.0+incompatible
 	github.com/docker/docker-credential-helpers v0.8.1
 	github.com/fatih/color v1.17.0
 	github.com/getkin/kin-openapi v0.124.0
-	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/google/uuid v1.6.0
 	github.com/gptscript-ai/broadcaster v0.0.0-20240625175512-c43682019b86
 	github.com/gptscript-ai/chat-completion-client v0.0.0-20240531200700-af8e7ecf0379

--- a/go.sum
+++ b/go.sum
@@ -61,6 +61,8 @@ github.com/bodgit/sevenzip v1.3.0 h1:1ljgELgtHqvgIp8W8kgeEGHIWP4ch3xGI8uOBZgLVKY
 github.com/bodgit/sevenzip v1.3.0/go.mod h1:omwNcgZTEooWM8gA/IJ2Nk/+ZQ94+GsytRzOJJ8FBlM=
 github.com/bodgit/windows v1.0.0 h1:rLQ/XjsleZvx4fR1tB/UxQrK+SJ2OFHzfPjLWWOhDIA=
 github.com/bodgit/windows v1.0.0/go.mod h1:a6JLwrB4KrTR5hBpp8FI9/9W9jJfeQ2h4XDXU74ZCdM=
+github.com/buildkite/shellwords v0.0.0-20180315110454-59467a9b8e10 h1:XwHQ5xDtYPdtBbVPyRO6UZoWZe8/mbKUb076f8x7RvI=
+github.com/buildkite/shellwords v0.0.0-20180315110454-59467a9b8e10/go.mod h1:gv0DYOzHEsKgo31lTCDGauIg4DTTGn41Bzp+t3wSOlk=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/charmbracelet/glamour v0.7.0 h1:2BtKGZ4iVJCDfMF229EzbeR1QRKLWztO9dMtjmqZSng=
 github.com/charmbracelet/glamour v0.7.0/go.mod h1:jUMh5MeihljJPQbJ/wf4ldw2+yBP59+ctV36jASy7ps=
@@ -153,8 +155,6 @@ github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OI
 github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20200212024743-f11f1df84d12/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
-github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
-github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=

--- a/pkg/engine/cmd.go
+++ b/pkg/engine/cmd.go
@@ -17,7 +17,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/google/shlex"
+	"github.com/buildkite/shellwords"
 	"github.com/gptscript-ai/gptscript/pkg/counter"
 	"github.com/gptscript-ai/gptscript/pkg/env"
 	"github.com/gptscript-ai/gptscript/pkg/types"
@@ -118,7 +118,7 @@ func (e *Engine) runCommand(ctx Context, tool types.Tool, input string, toolCate
 		instructions = append(instructions, inputContext.Content)
 	}
 
-	var extraEnv = []string{
+	extraEnv := []string{
 		strings.TrimSpace("GPTSCRIPT_CONTEXT=" + strings.Join(instructions, "\n")),
 	}
 	cmd, stop, err := e.newCommand(ctx.Ctx, extraEnv, tool, input)
@@ -254,7 +254,7 @@ func (e *Engine) newCommand(ctx context.Context, extraEnv []string, tool types.T
 	interpreter, rest, _ := strings.Cut(tool.Instructions, "\n")
 	interpreter = strings.TrimSpace(interpreter)[2:]
 
-	args, err := shlex.Split(interpreter)
+	args, err := shellwords.Split(interpreter)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -332,7 +332,7 @@ func replaceVariablesForInterpreter(interpreter string, envMap map[string]string
 				return envMap[s]
 			})
 			// We protect newly resolved env vars from getting replaced when we do the second Expand
-			// after shlex. Yeah, crazy. I'm guessing this isn't secure, but just trying to avoid a foot gun.
+			// after shellwords. Yeah, crazy. I'm guessing this isn't secure, but just trying to avoid a foot gun.
 			part = os.Expand(part, func(s string) string {
 				return "${__" + s + "}"
 			})
@@ -340,7 +340,7 @@ func replaceVariablesForInterpreter(interpreter string, envMap map[string]string
 		parts = append(parts, part)
 	}
 
-	parts, err := shlex.Split(strings.Join(parts, ""))
+	parts, err := shellwords.Split(strings.Join(parts, ""))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/types/tool.go
+++ b/pkg/types/tool.go
@@ -9,8 +9,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/buildkite/shellwords"
 	"github.com/getkin/kin-openapi/openapi3"
-	"github.com/google/shlex"
 	"github.com/gptscript-ai/gptscript/pkg/system"
 	"golang.org/x/exp/maps"
 )
@@ -22,9 +22,7 @@ const (
 	CommandPrefix = "#!"
 )
 
-var (
-	DefaultFiles = []string{"agent.gpt", "tool.gpt"}
-)
+var DefaultFiles = []string{"agent.gpt", "tool.gpt"}
 
 type ToolType string
 
@@ -257,7 +255,7 @@ func ParseCredentialArgs(toolName string, input string) (string, string, map[str
 		_ = json.Unmarshal([]byte(input), &inputMap)
 	}
 
-	fields, err := shlex.Split(toolName)
+	fields, err := shellwords.Split(toolName)
 	if err != nil {
 		return "", "", nil, err
 	}


### PR DESCRIPTION
The shlex splitting was ruining Windows paths. The shellwords is nicer to Windows.

