### PR TITLE
fix: support share credentials in context tools

### DIFF
--- a/pkg/types/tool.go
+++ b/pkg/types/tool.go
@@ -752,6 +752,16 @@ func (t Tool) GetCredentialTools(prg Program, agentGroup []ToolReference) ([]Too
 		result.AddAll(referencedTool.GetToolRefsFromNames(referencedTool.ExportCredentials))
 	}
 
+	contextToolRefs, err := t.getDirectContextToolRefs(prg)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, contextToolRef := range contextToolRefs {
+		contextTool := prg.ToolSet[contextToolRef.ToolID]
+		result.AddAll(contextTool.GetToolRefsFromNames(contextTool.ExportCredentials))
+	}
+
 	return result.List()
 }
 


### PR DESCRIPTION
Previously, we simply did not check for or handle this use case, but it is now something we need to support.