### PR TITLE
fix: share credentials in context tools

### DIFF
--- a/pkg/types/tool.go
+++ b/pkg/types/tool.go
@@ -752,7 +752,7 @@ func (t Tool) GetCredentialTools(prg Program, agentGroup []ToolReference) ([]Too
 		result.AddAll(referencedTool.GetToolRefsFromNames(referencedTool.ExportCredentials))
 	}
 
-	contextToolRefs, err := t.getDirectContextToolRefs(prg)
+	contextToolRefs, err := t.GetContextTools(prg)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Looks like I was calling the wrong function before.