### PR TITLE
fix: address panic when listing models with default model provider

### DIFF
--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -189,7 +189,7 @@ func (c *Client) load(ctx context.Context, toolName string) (*openai.Client, err
 		client: oClient,
 		url:    url,
 	}
-	return client.client, nil
+	return oClient, nil
 }
 
 func (c *Client) retrieveAPIKey(ctx context.Context, env, url string) (string, error) {


### PR DESCRIPTION
Apparently, this code path is exercised by listing models and not by using the provider with LLM calls.