### PR TITLE
fix(openapi): don't panic on requestBody content mime without schema

### DIFF
--- a/pkg/loader/openapi.go
+++ b/pkg/loader/openapi.go
@@ -209,6 +209,11 @@ func getOpenAPITools(t *openapi3.T, defaultHost, source, targetToolName string) 
 					}
 					bodyMIME = mime
 
+					// requestBody content mime without schema
+					if content == nil || content.Schema == nil {
+						continue
+					}
+
 					arg := content.Schema.Value
 					if arg.Description == "" {
 						arg.Description = content.Schema.Value.Description


### PR DESCRIPTION
Panics in cases like:
```yml
      requestBody:
        required: true
        content:
          application/json: {}
``` 

- `gptscript --list-tools https://raw.githubusercontent.com/cloudflare/api-schemas/main/openapi.yaml`
```sh
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x9d209e]

goroutine 1 [running]:
github.com/gptscript-ai/gptscript/pkg/loader.getOpenAPITools(0xc0000e1ef0, {0xc0001900a0, 0x4a}, {0xc0001900a0, 0x4a}, {0x0, 0x0})
	github.com/gptscript-ai/gptscript/pkg/loader/openapi.go:212 +0x2b7e
...
```