### PR TITLE
fix: openapi: return validation errors to the LLM; improve confirmation prompt

### DIFF
--- a/pkg/openapi/run.go
+++ b/pkg/openapi/run.go
@@ -42,7 +42,8 @@ func Run(operationID, defaultHost, args string, t *openapi3.T, envs []string) (s
 	}
 
 	if !validationResult.Valid() {
-		return "", false, fmt.Errorf("invalid arguments for operation %s: %s", operationID, validationResult.Errors())
+		// We don't return an error here because we want the LLM to be able to maintain control and try again.
+		return fmt.Sprintf("invalid arguments for operation %s: %s", operationID, validationResult.Errors()), true, nil
 	}
 
 	// Construct and execute the HTTP request.

--- a/pkg/types/toolstring.go
+++ b/pkg/types/toolstring.go
@@ -3,6 +3,7 @@ package types
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 )
@@ -76,6 +77,11 @@ func ToSysDisplayString(id string, args map[string]string) (string, error) {
 		return fmt.Sprintf("Writing `%s`", args["filename"]), nil
 	case "sys.context", "sys.stat", "sys.getenv", "sys.abort", "sys.chat.current", "sys.chat.finish", "sys.chat.history", "sys.echo", "sys.prompt", "sys.time.now", "sys.model.provider.credential":
 		return "", nil
+	case "sys.openapi":
+		if os.Getenv("GPTSCRIPT_OPENAPI_REVAMP") == "true" && args["operation"] != "" {
+			return fmt.Sprintf("Running API operation `%s` with arguments %s", args["operation"], args["args"]), nil
+		}
+		fallthrough
 	default:
 		return "", fmt.Errorf("unknown tool for display string: %s", id)
 	}


### PR DESCRIPTION
This PR does two things in the OpenAPI revamp:
- When the LLM provides arguments that do not match the JSONSchema, rather than exiting with an error, the validation errors are returned as a normal message to the LLM so that it can respond by trying again.
- The confirmation prompt shown to the user when running an OpenAPI operation under the OpenAPI revamp is improved to provide details about the specific operation and arguments.