### PR TITLE
chore: add content length when handling json request bodies.

### DIFF
--- a/pkg/openapi/run.go
+++ b/pkg/openapi/run.go
@@ -107,6 +107,7 @@ func Run(operationID, defaultHost, args string, t *openapi3.T, envs []string) (s
 				return "", false, fmt.Errorf("failed to encode JSON: %w", err)
 			}
 			req.Header.Set("Content-Type", "application/json")
+			req.ContentLength = int64(body.Len())
 
 		case "text/plain":
 			reqBody := ""


### PR DESCRIPTION
Explicitly setting the content length instead of allowing the Go default of transfer encoding chunked.
This change only applies to the application/json request body objects using openapi.