### PR TITLE
Fix: Do not return full env map after downloading releases

### DIFF
--- a/pkg/repos/runtimes/golang/golang.go
+++ b/pkg/repos/runtimes/golang/golang.go
@@ -244,7 +244,7 @@ func getChecksum(ctx context.Context, rel *release, artifactName string) string 
 	return ""
 }
 
-func (r *Runtime) Binary(ctx context.Context, tool types.Tool, _, toolSource string, env []string) (bool, []string, error) {
+func (r *Runtime) Binary(ctx context.Context, tool types.Tool, _, toolSource string, _ []string) (bool, []string, error) {
 	if !tool.Source.IsGit() {
 		return false, nil, nil
 	}
@@ -264,7 +264,7 @@ func (r *Runtime) Binary(ctx context.Context, tool types.Tool, _, toolSource str
 		return false, nil, nil
 	}
 
-	return true, env, nil
+	return true, nil, nil
 }
 
 func (r *Runtime) Setup(ctx context.Context, _ types.Tool, dataRoot, toolSource string, env []string) ([]string, error) {


### PR DESCRIPTION
After downloading gptscript release, we return a full map of current environment variables and this will eventuall get saved in to done.file, which will be picked up and saved as environment variable on the next run. This is causing weird issues like https://github.com/gptscript-ai/desktop/issues/253. The original purpose of adding env variable to done.file is probably related to only append PATH, as we can see the logic here: https://github.com/gptscript-ai/gptscript/blob/56b286bd2b01fb1dd5b562f3d4c98d55147c4a20/pkg/repos/runtimes/golang/golang.go#L276. But this is not needed when downloading releases because it is always downloaded in known location.