### PR TITLE
interp/embedded(expr): init embedded expr-lang.org

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/chzyer/readline v1.5.1
 	github.com/docker/cli v26.0.0+incompatible
 	github.com/docker/docker-credential-helpers v0.8.1
+	github.com/expr-lang/expr v1.16.10-0.20240715091933-5e660e753e47
 	github.com/fatih/color v1.17.0
 	github.com/getkin/kin-openapi v0.124.0
 	github.com/go-git/go-git/v5 v5.12.0

--- a/go.sum
+++ b/go.sum
@@ -123,6 +123,8 @@ github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/expr-lang/expr v1.16.10-0.20240715091933-5e660e753e47 h1:CIkFTe0UsAnBSTFKSqBtvqD7qyJbxhCTHGHYnJSSkds=
+github.com/expr-lang/expr v1.16.10-0.20240715091933-5e660e753e47/go.mod h1:8/vRC7+7HBzESEqt5kKpYXxrxkr31SaO8r40VO/1IT4=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/fatih/color v1.15.0/go.mod h1:0h5ZqXfHYED7Bhv2ZJamyIOUej9KtShiJESRwBDUSsw=
 github.com/fatih/color v1.17.0 h1:GlRw1BRJxkpqUCBKzKOw098ed57fEsKeNjpTe3cSjK4=

--- a/pkg/builtin/builtin.go
+++ b/pkg/builtin/builtin.go
@@ -35,6 +35,7 @@ var SafeTools = map[string]struct{}{
 	"sys.time.now":                  {},
 	"sys.context":                   {},
 	"sys.model.provider.credential": {},
+	"sys.interp.expr":               {},
 }
 
 var tools = map[string]types.Tool{

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -299,7 +299,10 @@ func (e *Engine) Start(ctx Context, input string) (ret *Return, _ error) {
 			return e.runOpenAPI(tool, input)
 		} else if tool.IsEcho() {
 			return e.runEcho(tool)
+		} else if tool.IsInterpExpr() {
+			return e.runInterpExpr(ctx, input)
 		}
+
 		s, err := e.runCommand(ctx, tool, input, ctx.ToolCategory)
 		if err != nil {
 			return nil, err

--- a/pkg/engine/interpreter_expr.go
+++ b/pkg/engine/interpreter_expr.go
@@ -1,0 +1,67 @@
+package engine
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/expr-lang/expr"
+
+	"github.com/gptscript-ai/gptscript/pkg/counter"
+	"github.com/gptscript-ai/gptscript/pkg/types"
+)
+
+func (e *Engine) runInterpExpr(ctx Context, input string) (*Return, error) {
+	// get code to eval
+	_, script, _ := strings.Cut(ctx.Tool.Instructions, "\n")
+	if script == "" {
+		return nil, nil
+	}
+
+	// setup environment for the interpreter
+	envExpr, err := prepareExprEnv(ctx, input)
+	if err != nil {
+		return nil, err
+	}
+
+	// eval code
+	outAny, err := expr.Eval(script, envExpr)
+	if err != nil {
+		return nil, err
+	}
+	out := fmt.Sprint(outAny)
+
+	e.Progress <- types.CompletionStatus{
+		CompletionID: counter.Next(),
+		Response: map[string]any{
+			"output": outAny,
+			"err":    nil,
+		},
+	}
+
+	return &Return{
+		Result: &out,
+	}, nil
+}
+
+func prepareExprEnv(engineContext Context, input string) (any, error) {
+	// get input
+	IN := map[string]any{
+		"input": "",
+	}
+	if input != "" {
+		err := json.Unmarshal([]byte(input), &IN)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// names kept uppercase just for testing to match (kind of) env variables
+	return map[string]any{
+		"INPUT":             IN["input"],
+		"GPTSCRIPT_INPUT":   input,
+		"GPTSCRIPT_CONTEXT": &engineContext, // full engine context just to test atm
+		// useful stuff from stdlib
+		"fmtSprintf": fmt.Sprintf,
+	}, nil
+}

--- a/pkg/types/tool.go
+++ b/pkg/types/tool.go
@@ -16,10 +16,11 @@ import (
 )
 
 const (
-	DaemonPrefix  = "#!sys.daemon"
-	OpenAPIPrefix = "#!sys.openapi"
-	EchoPrefix    = "#!sys.echo"
-	CommandPrefix = "#!"
+	InterpExprPrefix = "#!sys.interp.expr"
+	DaemonPrefix     = "#!sys.daemon"
+	OpenAPIPrefix    = "#!sys.openapi"
+	EchoPrefix       = "#!sys.echo"
+	CommandPrefix    = "#!"
 )
 
 var (
@@ -896,6 +897,10 @@ func (t Tool) IsEcho() bool {
 func (t Tool) IsHTTP() bool {
 	return strings.HasPrefix(t.Instructions, "#!http://") ||
 		strings.HasPrefix(t.Instructions, "#!https://")
+}
+
+func (t Tool) IsInterpExpr() bool {
+	return strings.HasPrefix(t.Instructions, InterpExprPrefix)
 }
 
 func FirstSet[T comparable](in ...T) (result T) {


### PR DESCRIPTION
Experimenting with https://expr-lang.org/. Just a draft implementation to start a feasibility discussion and mostly to check where and how might be useful in practice. 

Right now I just converted some stuff from https://github.com/gptscript-ai/context :

**Note**: For testing, I'm using only builtin stuff [language-definition](https://github.com/expr-lang/expr/blob/master/docs/language-definition.md). Things can be improved by exposing additional custom data/functions/types.

- https://github.com/gptscript-ai/context/tree/main/at-syntax
```go
Name: At syntax
Description: Add the ability for users to use at (@) to direct message an agent
Type: context

Share Input Filter: At syntax filter

---
Name: At syntax filter
Description: Translates @name command into "Call tool name with command"

#!sys.interp.expr
// INPUT - variant
let input = INPUT == nil || len(INPUT) == 0 ? "" : trim(INPUT);
!(input startsWith '@') || len(input) < 2 ? input :
  let parts = split(input[1:], " ") | map(trim(#)) | filter(len(#) > 0);
  len(parts) == 1
    ? "Call the tool \"" + parts[0] + "\" with defaultPromptParameter as empty"
    : "Call the tool \"" + parts[0] + "\" with defaultPromptParameter as exactly \"" + join(parts[1:], " ") + "\""
```

- https://github.com/gptscript-ai/context/tree/main/available-agents

```go
Name: Available Agents
Description: List the agents that are available in the current context
Context: sys.context
Type: context

#!sys.interp.expr
// GPTSCRIPT_CONTEXT
let agents = GPTSCRIPT_CONTEXT.AgentGroup | filter(.ToolID != GPTSCRIPT_CONTEXT.CurrentAgent().ToolID) | map({"\t" + .Named + " " + GPTSCRIPT_CONTEXT.Program.ToolSet[.ToolID].Description});
len(agents) == 0 ? "" : "You have the following (" + string(len(agents)) + ") agent(s) available to you:\n" + join(agents, "\n")
```
I plan to check and try to convert more scripts and tools to get a better understanding, but please feel free to propose stuff that you would like me to check. 