### PR TITLE
enhance: avoid context limit

### DIFF
--- a/pkg/openai/client.go
+++ b/pkg/openai/client.go
@@ -453,7 +453,7 @@ func (c *Client) contextLimitRetryLoop(ctx context.Context, request openai.ChatC
 		request.Messages = dropMessagesOverCount(maxTokens, request.Messages)
 		response, err = c.call(ctx, request, id, status)
 		if err == nil {
-			break
+			return response, nil
 		}
 
 		var apiError *openai.APIError
@@ -465,7 +465,7 @@ func (c *Client) contextLimitRetryLoop(ctx context.Context, request openai.ChatC
 		return nil, err
 	}
 
-	return response, nil
+	return nil, err
 }
 
 func appendMessage(msg types.CompletionMessage, response openai.ChatCompletionStreamResponse) types.CompletionMessage {

--- a/pkg/openai/count.go
+++ b/pkg/openai/count.go
@@ -53,7 +53,7 @@ func dropMessagesOverCount(maxTokens int, msgs []openai.ChatCompletionMessage) (
 		withinBudget++
 	}
 
-	if withinBudget >= len(msgs)-1 {
+	if withinBudget == len(msgs)-1 {
 		// We are going to drop all non system messages, which seems useless, so just return them
 		// all and let it fail
 		return msgs

--- a/pkg/openai/count.go
+++ b/pkg/openai/count.go
@@ -1,8 +1,6 @@
 package openai
 
 import (
-	"math"
-
 	openai "github.com/gptscript-ai/chat-completion-client"
 )
 
@@ -10,7 +8,7 @@ const DefaultMaxTokens = 128_000
 
 func decreaseTenPercent(maxTokens int) int {
 	maxTokens = getBudget(maxTokens)
-	return int(math.Round(float64(maxTokens) * 0.9))
+	return int(float64(maxTokens) * 0.9)
 }
 
 func getBudget(maxTokens int) int {


### PR DESCRIPTION
for gptscript-ai/desktop#283

This PR introduces three new measures to try to help the user avoid hitting the context length error:

1. Garbage collection works now. Previously, the token threshold was set too high, so we would run out of context before garbage collection would ever hit. Now, older messages will get deleted from the chat (on the LLM's side only; users can still see them) once it is needed in order to stay under the context limit.
2. If the output of a single tool output surpasses approximately 80% of the total context window, the tool output is considered too long and an error message is given to the LLM. We will design tools with the context limits in mind, but this is a safeguard to prevent just crashing and to allow the user to continue chatting with the LLM, and to allow the LLM to adjust its tool arguments and possibly remain under the output limit.
3. If, despite the previous measures, we do somehow hit the context length limit error, we catch that error and try to garbage collect more aggressively, and then retry the call up to ten times, doing more aggressive garbage collection each time.

With these three measures, I am fairly confident that users will no longer encounter the error.