### PR TITLE
feat: add standalone mode to SDKServer and server options

### DIFF
--- a/pkg/cli/sdk_server.go
+++ b/pkg/cli/sdk_server.go
@@ -11,6 +11,7 @@ import (
 
 type SDKServer struct {
 	*GPTScript
+	Standalone bool `usage:"Standalone mode" local:"true"`
 }
 
 func (c *SDKServer) Customize(cmd *cobra.Command) {
@@ -37,5 +38,6 @@ func (c *SDKServer) Run(cmd *cobra.Command, _ []string) error {
 		Options:       opts,
 		ListenAddress: c.ListenAddress,
 		Debug:         c.Debug,
+		Standalone:    c.Standalone,
 	})
 }


### PR DESCRIPTION
Added a new `Standalone` boolean field to the `SDKServer` and `Options` structs to support running the server in standalone mode. Updated the server run logic to conditionally skip the stdin read hack when in standalone mode.

**Why**:  because I need to run a single instance of the server on my own, but the hack prevents the server to start in environments where stdin is 'closed' (reading returns EOF immediately), ie:

```log
$ gptscript sys.sdkserver --listen-address=0.0.0.0:9090  < /dev/null
[::]:9090
08:23:24 Shutting down server
08:23:24 Server stopped
```