### PR TITLE
fix: sys.read: never read files that contain a null byte

### DIFF
--- a/pkg/builtin/builtin.go
+++ b/pkg/builtin/builtin.go
@@ -489,6 +489,12 @@ func SysRead(_ context.Context, _ []string, input string, _ chan<- string) (stri
 	if len(data) == 0 {
 		return fmt.Sprintf("The file %s has no contents", params.Filename), nil
 	}
+
+	// Assume the file is not text if it contains a null byte
+	if bytes.Contains(data, []byte{0}) {
+		return fmt.Sprintf("The file %s cannot be read because it is not a plaintext file", params.Filename), nil
+	}
+
 	return string(data), nil
 }
 

--- a/pkg/builtin/builtin.go
+++ b/pkg/builtin/builtin.go
@@ -491,7 +491,7 @@ func SysRead(_ context.Context, _ []string, input string, _ chan<- string) (stri
 	}
 
 	// Assume the file is not text if it contains a null byte
-	if bytes.Contains(data, []byte{0}) {
+	if bytes.IndexByte(data, 0) != -1 {
 		return fmt.Sprintf("The file %s cannot be read because it is not a plaintext file", params.Filename), nil
 	}
 


### PR DESCRIPTION
for gptscript-ai/desktop#263