### PR TITLE
fix: sdkserver: credentials: ensure credential helpers exist

### DIFF
--- a/pkg/sdkserver/credentials.go
+++ b/pkg/sdkserver/credentials.go
@@ -9,7 +9,6 @@ import (
 	"github.com/gptscript-ai/gptscript/pkg/config"
 	gcontext "github.com/gptscript-ai/gptscript/pkg/context"
 	"github.com/gptscript-ai/gptscript/pkg/credentials"
-	"github.com/gptscript-ai/gptscript/pkg/repos/runtimes"
 )
 
 func (s *server) initializeCredentialStore(ctx context.Context, credCtx string) (credentials.CredentialStore, error) {
@@ -18,16 +17,14 @@ func (s *server) initializeCredentialStore(ctx context.Context, credCtx string) 
 		return nil, fmt.Errorf("failed to read CLI config: %w", err)
 	}
 
-	// TODO - are we sure we want to always use runtimes.Default here?
-	runtimeManager := runtimes.Default(s.gptscriptOpts.Cache.CacheDir)
-	if err := runtimeManager.SetUpCredentialHelpers(ctx, cfg); err != nil {
+	if err := s.runtimeManager.SetUpCredentialHelpers(ctx, cfg); err != nil {
 		return nil, fmt.Errorf("failed to set up credential helpers: %w", err)
 	}
-	if err := runtimeManager.EnsureCredentialHelpers(ctx); err != nil {
+	if err := s.runtimeManager.EnsureCredentialHelpers(ctx); err != nil {
 		return nil, fmt.Errorf("failed to ensure credential helpers: %w", err)
 	}
 
-	store, err := credentials.NewStore(cfg, runtimeManager, credCtx, s.gptscriptOpts.Cache.CacheDir)
+	store, err := credentials.NewStore(cfg, s.runtimeManager, credCtx, s.gptscriptOpts.Cache.CacheDir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize credential store: %w", err)
 	}

--- a/pkg/sdkserver/routes.go
+++ b/pkg/sdkserver/routes.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gptscript-ai/broadcaster"
 	"github.com/gptscript-ai/gptscript/pkg/cache"
 	gcontext "github.com/gptscript-ai/gptscript/pkg/context"
+	"github.com/gptscript-ai/gptscript/pkg/engine"
 	"github.com/gptscript-ai/gptscript/pkg/gptscript"
 	"github.com/gptscript-ai/gptscript/pkg/input"
 	"github.com/gptscript-ai/gptscript/pkg/loader"
@@ -29,6 +30,8 @@ type server struct {
 	address, token string
 	client         *gptscript.GPTScript
 	events         *broadcaster.Broadcaster[event]
+
+	runtimeManager engine.RuntimeManager
 
 	lock             sync.RWMutex
 	waitingToConfirm map[string]chan runner.AuthorizerResponse

--- a/pkg/sdkserver/server.go
+++ b/pkg/sdkserver/server.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gptscript-ai/broadcaster"
 	"github.com/gptscript-ai/gptscript/pkg/gptscript"
 	"github.com/gptscript-ai/gptscript/pkg/mvl"
+	"github.com/gptscript-ai/gptscript/pkg/repos/runtimes"
 	"github.com/gptscript-ai/gptscript/pkg/runner"
 	"github.com/gptscript-ai/gptscript/pkg/types"
 	"github.com/rs/cors"
@@ -108,6 +109,7 @@ func run(ctx context.Context, listener net.Listener, opts Options) error {
 		token:            token,
 		client:           g,
 		events:           events,
+		runtimeManager:   runtimes.Default(opts.Options.Cache.CacheDir), // TODO - do we always want to use runtimes.Default here?
 		waitingToConfirm: make(map[string]chan runner.AuthorizerResponse),
 		waitingToPrompt:  make(map[string]chan map[string]string),
 	}


### PR DESCRIPTION
The SDKServer was assuming that credential helpers were already present, which causes problems when they aren't there.