### PR TITLE
fix: sdkserver: rename credentialContext to credentialContexts

### DIFF
--- a/pkg/sdkserver/routes.go
+++ b/pkg/sdkserver/routes.go
@@ -188,7 +188,7 @@ func (s *server) execHandler(w http.ResponseWriter, r *http.Request) {
 		OpenAI:             openai.Options(reqObject.openAIOptions),
 		Env:                reqObject.Env,
 		Workspace:          reqObject.Workspace,
-		CredentialContexts: reqObject.CredentialContext,
+		CredentialContexts: reqObject.CredentialContexts,
 		Runner: runner.Options{
 			// Set the monitor factory so that we can get events from the server.
 			MonitorFactory:      NewSessionFactory(s.events),

--- a/pkg/sdkserver/types.go
+++ b/pkg/sdkserver/types.go
@@ -58,7 +58,7 @@ type toolOrFileRequest struct {
 	ChatState            string   `json:"chatState"`
 	Workspace            string   `json:"workspace"`
 	Env                  []string `json:"env"`
-	CredentialContext    []string `json:"credentialContext"`
+	CredentialContexts   []string `json:"credentialContexts"`
 	CredentialOverrides  []string `json:"credentialOverrides"`
 	Confirm              bool     `json:"confirm"`
 	Location             string   `json:"location,omitempty"`


### PR DESCRIPTION
This is to help undo some of the damage from the breaking change.