### PR TITLE
fix: modify credential refresh to support stacked contexts

### DIFF
--- a/pkg/credentials/noop.go
+++ b/pkg/credentials/noop.go
@@ -12,7 +12,7 @@ func (s NoopStore) Add(context.Context, Credential) error {
 	return nil
 }
 
-func (s NoopStore) Refresh(context.Context, Credential, string) error {
+func (s NoopStore) Refresh(context.Context, Credential) error {
 	return nil
 }
 

--- a/pkg/credentials/noop.go
+++ b/pkg/credentials/noop.go
@@ -12,6 +12,10 @@ func (s NoopStore) Add(context.Context, Credential) error {
 	return nil
 }
 
+func (s NoopStore) Refresh(context.Context, Credential, string) error {
+	return nil
+}
+
 func (s NoopStore) Remove(context.Context, string) error {
 	return nil
 }

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -962,7 +962,7 @@ func (r *Runner) handleCredentials(callCtx engine.Context, monitor Monitor, env 
 			}
 		}
 
-		if resultCredential.ExpiresAt != nil && (nearestExpiration == nil || nearestExpiration.After(*c.ExpiresAt)) {
+		if resultCredential.ExpiresAt != nil && (nearestExpiration == nil || nearestExpiration.After(*resultCredential.ExpiresAt)) {
 			nearestExpiration = resultCredential.ExpiresAt
 		}
 

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -960,6 +960,8 @@ func (r *Runner) handleCredentials(callCtx engine.Context, monitor Monitor, env 
 					log.Warnf("Not saving credential for tool %s - credentials will only be saved for tools from GitHub, or tools that use aliases.", toolName)
 				}
 			}
+		} else {
+			resultCredential = *c
 		}
 
 		if resultCredential.ExpiresAt != nil && (nearestExpiration == nil || nearestExpiration.After(*resultCredential.ExpiresAt)) {

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -854,8 +854,10 @@ func (r *Runner) handleCredentials(callCtx engine.Context, monitor Monitor, env 
 		}
 
 		var (
-			c      *credentials.Credential
-			exists bool
+			c                *credentials.Credential
+			resultCredential credentials.Credential
+			exists           bool
+			refresh          bool
 		)
 
 		rm := runtimeWithLogger(callCtx, monitor, r.runtimeManager)
@@ -886,6 +888,7 @@ func (r *Runner) handleCredentials(callCtx engine.Context, monitor Monitor, env 
 		if !exists || c.IsExpired() {
 			// If the existing credential is expired, we need to provide it to the cred tool through the environment.
 			if exists && c.IsExpired() {
+				refresh = true
 				credJSON, err := json.Marshal(c)
 				if err != nil {
 					return nil, fmt.Errorf("failed to marshal credential: %w", err)
@@ -916,27 +919,42 @@ func (r *Runner) handleCredentials(callCtx engine.Context, monitor Monitor, env 
 				continue
 			}
 
-			if err := json.Unmarshal([]byte(*res.Result), &c); err != nil {
+			if err := json.Unmarshal([]byte(*res.Result), &resultCredential); err != nil {
 				return nil, fmt.Errorf("failed to unmarshal credential tool %s response: %w", ref.Reference, err)
 			}
-			c.ToolName = credName
-			c.Type = credentials.CredentialTypeTool
+			resultCredential.ToolName = credName
+			resultCredential.Type = credentials.CredentialTypeTool
+
+			if refresh {
+				// If this is a credential refresh, we need to make sure we use the same context.
+				resultCredential.Context = c.Context
+			} else {
+				// If it is a new credential, let the credential store determine the context.
+				resultCredential.Context = ""
+			}
 
 			isEmpty := true
-			for _, v := range c.Env {
+			for _, v := range resultCredential.Env {
 				if v != "" {
 					isEmpty = false
 					break
 				}
 			}
 
-			if !c.Ephemeral {
+			if !resultCredential.Ephemeral {
 				// Only store the credential if the tool is on GitHub or has an alias, and the credential is non-empty.
 				if (isGitHubTool(toolName) && callCtx.Program.ToolSet[ref.ToolID].Source.Repo != nil) || credentialAlias != "" {
 					if isEmpty {
 						log.Warnf("Not saving empty credential for tool %s", toolName)
-					} else if err := r.credStore.Add(callCtx.Ctx, *c); err != nil {
-						return nil, fmt.Errorf("failed to add credential for tool %s: %w", toolName, err)
+					} else {
+						if refresh {
+							err = r.credStore.Refresh(callCtx.Ctx, resultCredential)
+						} else {
+							err = r.credStore.Add(callCtx.Ctx, resultCredential)
+						}
+						if err != nil {
+							return nil, fmt.Errorf("failed to save credential for tool %s: %w", toolName, err)
+						}
 					}
 				} else {
 					log.Warnf("Not saving credential for tool %s - credentials will only be saved for tools from GitHub, or tools that use aliases.", toolName)
@@ -944,11 +962,11 @@ func (r *Runner) handleCredentials(callCtx engine.Context, monitor Monitor, env 
 			}
 		}
 
-		if c.ExpiresAt != nil && (nearestExpiration == nil || nearestExpiration.After(*c.ExpiresAt)) {
-			nearestExpiration = c.ExpiresAt
+		if resultCredential.ExpiresAt != nil && (nearestExpiration == nil || nearestExpiration.After(*c.ExpiresAt)) {
+			nearestExpiration = resultCredential.ExpiresAt
 		}
 
-		for k, v := range c.Env {
+		for k, v := range resultCredential.Env {
 			env = append(env, fmt.Sprintf("%s=%s", k, v))
 		}
 	}


### PR DESCRIPTION
The stacked credentials feature was not working with credential refresh until this PR. The refreshed credential used to be stored into the highest priority context, even if it previously existed in a different context.

For example, say I had credential `cred` in context `one`, and then I do `gptscript --credential-context two,one <script>`. The script uses the `cred` credential, so it gets refreshed. GPTScript was storing the new refreshed credential in the context `two`, even though it previously existed in `one`.

This PR changes it so that refreshed credentials are always stored in the context from which they came.