### PR TITLE
fix: credentials: check for not found errors properly

### DIFF
--- a/pkg/credentials/error.go
+++ b/pkg/credentials/error.go
@@ -1,0 +1,12 @@
+package credentials
+
+import (
+	"strings"
+)
+
+func IsCredentialsNotFoundError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "credentials not found in native keychain")
+}

--- a/pkg/credentials/store.go
+++ b/pkg/credentials/store.go
@@ -9,7 +9,6 @@ import (
 	"github.com/docker/cli/cli/config/credentials"
 	"github.com/docker/cli/cli/config/types"
 	"github.com/docker/docker-credential-helpers/client"
-	credentials2 "github.com/docker/docker-credential-helpers/credentials"
 	"github.com/gptscript-ai/gptscript/pkg/config"
 	"golang.org/x/exp/maps"
 )
@@ -50,7 +49,7 @@ func (s Store) Get(_ context.Context, toolName string) (*Credential, bool, error
 	for _, c := range s.credCtxs {
 		auth, err := store.Get(toolNameWithCtx(toolName, c))
 		if err != nil {
-			if credentials2.IsErrCredentialsNotFound(err) {
+			if IsCredentialsNotFoundError(err) {
 				continue
 			}
 			return nil, false, err

--- a/pkg/credentials/toolstore.go
+++ b/pkg/credentials/toolstore.go
@@ -30,7 +30,7 @@ func (h *toolCredentialStore) Erase(serverAddress string) error {
 
 func (h *toolCredentialStore) Get(serverAddress string) (types.AuthConfig, error) {
 	creds, err := client.Get(h.program, serverAddress)
-	if credentials2.IsErrCredentialsNotFound(err) {
+	if IsCredentialsNotFoundError(err) {
 		return h.file.Get(serverAddress)
 	} else if err != nil {
 		return types.AuthConfig{}, err

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -872,7 +872,7 @@ func (r *Runner) handleCredentials(callCtx engine.Context, monitor Monitor, env 
 		} else if credentialAlias != "" {
 			c, exists, err = r.credStore.Get(callCtx.Ctx, credentialAlias)
 			if err != nil {
-				return nil, fmt.Errorf("failed to get credentials for tool %s: %w", credentialAlias, err)
+				return nil, fmt.Errorf("failed to get credential %s: %w", credentialAlias, err)
 			}
 		}
 


### PR DESCRIPTION
The recent refactoring of credential helpers to be run as tools resulted in a bug where the output of the credential tool (which would become part of the error message) would have things appended to it like `:\n exit status 1`, which was messing up the detection of Not Found errors. I fixed this in this PR by implementing our own function to examine the error message. I wish I could have used the defined `const` for this from the Docker package that we depend on, but it is unexported.