### PR TITLE
chore: Add GPTSCRIPT_HTTP_ENV_PREFIX to specify http env vars to send

### DIFF
--- a/pkg/credentials/store.go
+++ b/pkg/credentials/store.go
@@ -195,7 +195,7 @@ func validateCredentialCtx(ctxs []string) error {
 	}
 
 	// check alphanumeric
-	r := regexp.MustCompile("^[-a-zA-Z0-9]+$")
+	r := regexp.MustCompile("^[-a-zA-Z0-9.]+$")
 	for _, c := range ctxs {
 		if !r.MatchString(c) {
 			return fmt.Errorf("credential contexts must be alphanumeric")

--- a/pkg/engine/http.go
+++ b/pkg/engine/http.go
@@ -82,6 +82,16 @@ func (e *Engine) runHTTP(ctx context.Context, prg *types.Program, tool types.Too
 			req.Header.Add("X-GPTScript-Env", k+"="+envMap[k])
 		}
 	}
+	for _, prefix := range strings.Split(os.Getenv("GPTSCRIPT_HTTP_ENV_PREFIX"), ",") {
+		if prefix == "" {
+			continue
+		}
+		for _, k := range slices.Sorted(maps.Keys(envMap)) {
+			if strings.HasPrefix(k, prefix) {
+				req.Header.Add("X-GPTScript-Env", k+"="+envMap[k])
+			}
+		}
+	}
 
 	req.Header.Set("X-GPTScript-Tool-Name", tool.Parameters.Name)
 


### PR DESCRIPTION
- **chore: allow dot in credential context**
- **chore: Add GPTSCRIPT_HTTP_ENV_PREFIX to specify http env vars to send**
