### PR TITLE
chore: change the dataset tool to the gptscript-ai org

### DIFF
--- a/pkg/sdkserver/server.go
+++ b/pkg/sdkserver/server.go
@@ -174,7 +174,7 @@ func complete(opts ...Options) Options {
 		result.WorkspaceTool = "github.com/gptscript-ai/workspace-provider"
 	}
 	if result.DatasetTool == "" {
-		result.DatasetTool = "github.com/otto8-ai/datasets"
+		result.DatasetTool = "github.com/gptscript-ai/datasets"
 	}
 
 	return result


### PR DESCRIPTION
This tool was moved back to the gptscript-ai org.