### PR TITLE
Fix server creds

### DIFF
--- a/pkg/cli/credential.go
+++ b/pkg/cli/credential.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	cmd2 "github.com/gptscript-ai/cmd"
+	"github.com/gptscript-ai/gptscript/pkg/credentials"
 	"github.com/gptscript-ai/gptscript/pkg/gptscript"
 	"github.com/spf13/cobra"
 )
@@ -44,7 +45,12 @@ func (c *Credential) Run(cmd *cobra.Command, _ []string) error {
 	}
 	defer gptScript.Close(true)
 
-	store, err := gptScript.CredentialStoreFactory.NewStore(gptScript.DefaultCredentialContexts)
+	credCtxs := gptScript.DefaultCredentialContexts
+	if c.AllContexts {
+		credCtxs = []string{credentials.AllCredentialContexts}
+	}
+
+	store, err := gptScript.CredentialStoreFactory.NewStore(credCtxs)
 	if err != nil {
 		return err
 	}

--- a/pkg/credentials/store.go
+++ b/pkg/credentials/store.go
@@ -140,7 +140,7 @@ func (s Store) List(_ context.Context) ([]Credential, error) {
 	}
 
 	if len(s.credCtxs) > 0 && s.credCtxs[0] == AllCredentialContexts {
-		allCreds := make([]Credential, len(list))
+		allCreds := make([]Credential, 0, len(list))
 		for serverAddress := range list {
 			ac, err := store.Get(serverAddress)
 			if err != nil {


### PR DESCRIPTION
This change does two related things:
1. Allow listing of credentials in all contexts
2. When running in SDK server mode and using the file cred store, we must 
reload the credentials in the file each time. Typically, these 
credentials will be added via a tool call, which would invalidate the 
credentials held in memory.