### PR TITLE
enhance: clear cache on load with disabled cache

### DIFF
--- a/pkg/loader/url.go
+++ b/pkg/loader/url.go
@@ -63,6 +63,9 @@ func loadURL(ctx context.Context, cache *cache.Client, base *source, name string
 			}
 		}
 	}
+	if cachedKey.Path == "" {
+		cachedKey.Path = "."
+	}
 
 	if ok, err := cache.Get(ctx, cachedKey, &cachedValue); err != nil {
 		return nil, false, err

--- a/pkg/sdkserver/routes.go
+++ b/pkg/sdkserver/routes.go
@@ -232,21 +232,22 @@ func (s *server) load(w http.ResponseWriter, r *http.Request) {
 	logger.Debugf("parsing file: file=%s, content=%s", reqObject.File, reqObject.Content)
 
 	var (
-		prg   types.Program
-		err   error
-		cache = s.client.Cache
+		prg types.Program
+		err error
+
+		ctx = r.Context()
 	)
 
 	if reqObject.DisableCache {
-		cache = nil
+		ctx = cache.WithNoCache(ctx)
 	}
 
 	if reqObject.Content != "" {
-		prg, err = loader.ProgramFromSource(r.Context(), reqObject.Content, reqObject.SubTool, loader.Options{Cache: cache})
+		prg, err = loader.ProgramFromSource(ctx, reqObject.Content, reqObject.SubTool, loader.Options{Cache: s.client.Cache})
 	} else if reqObject.File != "" {
-		prg, err = loader.Program(r.Context(), reqObject.File, reqObject.SubTool, loader.Options{Cache: cache})
+		prg, err = loader.Program(ctx, reqObject.File, reqObject.SubTool, loader.Options{Cache: s.client.Cache})
 	} else {
-		prg, err = loader.ProgramFromSource(r.Context(), reqObject.ToolDefs.String(), reqObject.SubTool, loader.Options{Cache: cache})
+		prg, err = loader.ProgramFromSource(ctx, reqObject.ToolDefs.String(), reqObject.SubTool, loader.Options{Cache: s.client.Cache})
 	}
 	if err != nil {
 		writeError(logger, w, http.StatusInternalServerError, fmt.Errorf("failed to load program: %w", err))


### PR DESCRIPTION
A change was made such that the cache key was removed when a tool was run with cache disabled. This change connects the cache disabled feature when running tools with the cache disabled when loading tools. That way, if a tool is loaded with cache disabled, then this newer version is used when running the tool the next time.

Related issue: https://github.com/obot-platform/obot/issues/735