### PR TITLE
fix: count tokens from tool definitions when adjusting for context window

### DIFF
--- a/pkg/openai/client.go
+++ b/pkg/openai/client.go
@@ -413,7 +413,7 @@ func (c *Client) Call(ctx context.Context, messageRequest types.CompletionReques
 
 		// If we got back a context length exceeded error, keep retrying and shrinking the message history until we pass.
 		var apiError *openai.APIError
-		if errors.As(err, &apiError) && apiError.Code == "context_length_exceeded" && messageRequest.Chat {
+		if err != nil && ((errors.As(err, &apiError) && apiError.Code == "context_length_exceeded") || strings.Contains(err.Error(), "maximum context length is")) && messageRequest.Chat {
 			// Decrease maxTokens by 10% to make garbage collection more aggressive.
 			// The retry loop will further decrease maxTokens if needed.
 			maxTokens := decreaseTenPercent(messageRequest.MaxTokens)
@@ -467,7 +467,7 @@ func (c *Client) contextLimitRetryLoop(ctx context.Context, request openai.ChatC
 		}
 
 		var apiError *openai.APIError
-		if errors.As(err, &apiError) && apiError.Code == "context_length_exceeded" {
+		if (errors.As(err, &apiError) && apiError.Code == "context_length_exceeded") || strings.Contains(err.Error(), "maximum context length is") {
 			// Decrease maxTokens and try again
 			maxTokens = decreaseTenPercent(maxTokens)
 			continue

--- a/pkg/openai/count.go
+++ b/pkg/openai/count.go
@@ -15,8 +15,17 @@ func decreaseTenPercent(maxTokens int) int {
 }
 
 func getBudget(maxTokens int) int {
-	if maxTokens <= 0 {
+	if maxTokens == 0 {
 		return DefaultMaxTokens
+	} else if maxTokens <= 0 {
+		// maxTokens was 0 (or some very small number), the tool count pushed it negative
+		// so we can just add that negative number to the default max tokens, to get something lower
+		if DefaultMaxTokens+maxTokens >= 0 {
+			return DefaultMaxTokens + maxTokens
+		}
+
+		// If max tokens was so negative that it was below 128k, then we just return 0 I guess
+		return 0
 	}
 	return maxTokens
 }

--- a/pkg/openai/count.go
+++ b/pkg/openai/count.go
@@ -15,7 +15,7 @@ func decreaseTenPercent(maxTokens int) int {
 }
 
 func getBudget(maxTokens int) int {
-	if maxTokens == 0 {
+	if maxTokens <= 0 {
 		return DefaultMaxTokens
 	}
 	return maxTokens

--- a/pkg/openai/count.go
+++ b/pkg/openai/count.go
@@ -1,7 +1,10 @@
 package openai
 
 import (
+	"encoding/json"
+
 	openai "github.com/gptscript-ai/chat-completion-client"
+	"github.com/gptscript-ai/gptscript/pkg/types"
 )
 
 const DefaultMaxTokens = 128_000
@@ -72,4 +75,30 @@ func countMessage(msg openai.ChatCompletionMessage) (count int) {
 	}
 	count += len(msg.ToolCallID)
 	return count / 3
+}
+
+func countChatCompletionTools(tools []types.ChatCompletionTool) (count int, err error) {
+	for _, t := range tools {
+		count += len(t.Function.Name)
+		count += len(t.Function.Description)
+		paramsJSON, err := json.Marshal(t.Function.Parameters)
+		if err != nil {
+			return 0, err
+		}
+		count += len(paramsJSON)
+	}
+	return count / 3, nil
+}
+
+func countOpenAITools(tools []openai.Tool) (count int, err error) {
+	for _, t := range tools {
+		count += len(t.Function.Name)
+		count += len(t.Function.Description)
+		paramsJSON, err := json.Marshal(t.Function.Parameters)
+		if err != nil {
+			return 0, err
+		}
+		count += len(paramsJSON)
+	}
+	return count / 3, nil
 }


### PR DESCRIPTION
The tokens used for tool definitions are counted as part of the context window, but we were failing to count them here when trying to stay beneath the limit. This introduces a fix so that we account for it.

Our token estimation still isn't great. For example, a message consisting of `1\n` repeated 30000 times is counted as 20000 tokens in our method (since we just divide the character count by 3), but in OpenAI's tokenizer, it is 60000 tokens, meaning we grossly underestimate. I think we should consider calling out to Python to use the `tiktoken` library to count tokens for us, as that will be far more reliable. However, in practice, this rarely seems to cause us any trouble, so maybe we are fine sticking with our current approach of just dividing by 3.