### PR TITLE
fix: distinguish between nil and non-nil allowed tools

### DIFF
--- a/pkg/mcp/loader.go
+++ b/pkg/mcp/loader.go
@@ -181,7 +181,7 @@ func (l *Local) Close() error {
 }
 
 func (l *Local) sessionToTools(ctx context.Context, session *Session, toolName string, allowedTools []string) ([]types.Tool, error) {
-	allToolsAllowed := len(allowedTools) == 0 || slices.Contains(allowedTools, "*")
+	allToolsAllowed := allowedTools == nil || slices.Contains(allowedTools, "*")
 
 	tools, err := session.Client.ListTools(ctx, mcp.ListToolsRequest{})
 	if err != nil {


### PR DESCRIPTION
If allowedTools is nil, then all tools are allowed. If allowed tools is non-nil and has length zero, then no tools are allowed.