### PR TITLE
enhance: provide contexts to credential helpers when listing credentials

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ init-docs:
 
 # Ensure docs build without errors. Makes sure generated docs are in-sync with CLI.
 validate-docs: gen-docs
-	docker run --rm --workdir=/docs -v $${PWD}/docs:/docs node:18-buster yarn build
+	docker run --rm --workdir=/docs -v $${PWD}/docs:/docs node:18-buster npm run build
 	if [ -n "$$(git status --porcelain --untracked-files=no)" ]; then \
 		git status --porcelain --untracked-files=no; \
 		echo "Encountered dirty repo!"; \

--- a/pkg/credentials/store.go
+++ b/pkg/credentials/store.go
@@ -269,8 +269,9 @@ func (s *Store) recreateCredential(store credentials.Store, serverAddress string
 func (s *Store) getStore() (credentials.Store, error) {
 	if s.program != nil {
 		return &toolCredentialStore{
-			file:    credentials.NewFileStore(s.cfg),
-			program: s.program,
+			file:     credentials.NewFileStore(s.cfg),
+			program:  s.program,
+			contexts: s.credCtxs,
 		}, nil
 	}
 	return credentials.NewFileStore(s.cfg), nil

--- a/pkg/credentials/toolstore.go
+++ b/pkg/credentials/toolstore.go
@@ -46,6 +46,10 @@ func (h *toolCredentialStore) Get(serverAddress string) (types.AuthConfig, error
 	}, nil
 }
 
+// GetAll will list all credentials in the credential store.
+// It MAY (but is not required to) filter the credentials based on the contexts provided.
+// This is only supported by some credential stores, while others will ignore it and return all credentials.
+// The caller of this function is still required to filter the output to only include the contexts requested.
 func (h *toolCredentialStore) GetAll() (map[string]types.AuthConfig, error) {
 	var (
 		serverAddresses map[string]string

--- a/pkg/credentials/toolstore_test.go
+++ b/pkg/credentials/toolstore_test.go
@@ -55,7 +55,8 @@ func (m *mockProgram) Output() ([]byte, error) {
 	return nil, nil
 }
 
-func NewMockProgram(t *testing.T, mode string) client.ProgramFunc {
+func newMockProgram(t *testing.T, mode string) client.ProgramFunc {
+	t.Helper()
 	return func(args ...string) client.Program {
 		p := &mockProgram{
 			mode: mode,
@@ -68,8 +69,8 @@ func NewMockProgram(t *testing.T, mode string) client.ProgramFunc {
 }
 
 func TestGetAll(t *testing.T) {
-	dbProgram := NewMockProgram(t, "db")
-	normalProgram := NewMockProgram(t, "normal")
+	dbProgram := newMockProgram(t, "db")
+	normalProgram := newMockProgram(t, "normal")
 
 	tests := []struct {
 		name     string

--- a/pkg/credentials/toolstore_test.go
+++ b/pkg/credentials/toolstore_test.go
@@ -1,0 +1,129 @@
+package credentials
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/docker/cli/cli/config/types"
+	"github.com/docker/docker-credential-helpers/client"
+	"github.com/docker/docker-credential-helpers/credentials"
+)
+
+type mockProgram struct {
+	// mode is either "db" or "normal"
+	// db mode will honor contexts, normal mode will not
+	mode     string
+	action   string
+	contexts []string
+}
+
+func (m *mockProgram) Input(in io.Reader) {
+	switch m.action {
+	case credentials.ActionList:
+		var contexts []string
+		if err := json.NewDecoder(in).Decode(&contexts); err == nil && len(contexts) > 0 {
+			m.contexts = contexts
+		}
+	}
+	// TODO: add other cases here as needed
+}
+
+func (m *mockProgram) Output() ([]byte, error) {
+	switch m.action {
+	case credentials.ActionList:
+		switch m.mode {
+		case "db":
+			// Return only credentials that are in the list of contexts.
+			creds := make(map[string]string)
+			for _, context := range m.contexts {
+				creds[fmt.Sprintf("https://example///%s", context)] = "username"
+			}
+			return json.Marshal(creds)
+		case "normal":
+			// Return credentials in the list of contexts, plus some made up extras.
+			creds := make(map[string]string)
+			for _, context := range m.contexts {
+				creds[fmt.Sprintf("https://example///%s", context)] = "username"
+			}
+			creds[fmt.Sprintf("https://example///%s", "otherContext1")] = "username"
+			creds[fmt.Sprintf("https://example///%s", "otherContext2")] = "username"
+			return json.Marshal(creds)
+		}
+	}
+	return nil, nil
+}
+
+func NewMockProgram(t *testing.T, mode string) client.ProgramFunc {
+	return func(args ...string) client.Program {
+		p := &mockProgram{
+			mode: mode,
+		}
+		if len(args) > 0 {
+			p.action = args[0]
+		}
+		return p
+	}
+}
+
+func TestGetAll(t *testing.T) {
+	dbProgram := NewMockProgram(t, "db")
+	normalProgram := NewMockProgram(t, "normal")
+
+	tests := []struct {
+		name     string
+		program  client.ProgramFunc
+		wantErr  bool
+		contexts []string
+		expected map[string]types.AuthConfig
+	}{
+		{name: "db", program: dbProgram, wantErr: false, contexts: []string{"credctx"}, expected: map[string]types.AuthConfig{
+			"https://example///credctx": {
+				Username:      "username",
+				ServerAddress: "https://example///credctx",
+			},
+		}},
+		{name: "normal", program: normalProgram, wantErr: false, contexts: []string{"credctx"}, expected: map[string]types.AuthConfig{
+			"https://example///credctx": {
+				Username:      "username",
+				ServerAddress: "https://example///credctx",
+			},
+			"https://example///otherContext1": {
+				Username:      "username",
+				ServerAddress: "https://example///otherContext1",
+			},
+			"https://example///otherContext2": {
+				Username:      "username",
+				ServerAddress: "https://example///otherContext2",
+			},
+		}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			store := &toolCredentialStore{
+				program:  test.program,
+				contexts: test.contexts,
+			}
+			got, err := store.GetAll()
+			if (err != nil) != test.wantErr {
+				t.Errorf("GetAll() error = %v, wantErr %v", err, test.wantErr)
+			}
+			if len(got) != len(test.expected) {
+				t.Errorf("GetAll() got %d credentials, want %d", len(got), len(test.expected))
+			}
+			for name, cred := range got {
+				if _, ok := test.expected[name]; !ok {
+					t.Errorf("GetAll() got unexpected credential: %s", name)
+				}
+				if got[name].Username != test.expected[name].Username {
+					t.Errorf("GetAll() got unexpected username for %s", cred.ServerAddress)
+				}
+				if got[name].Username != test.expected[name].Username {
+					t.Errorf("GetAll() got unexpected username for %s", name)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
for https://github.com/obot-platform/obot/issues/3180

This PR changes the way we request a list of credentials by also including the contexts as input. The contexts are ignored by all non-database credential helpers (like Wincred and macOS Keychain), so we still filter by context after we call `GetAll`, but this allows the database credential helpers to be more efficient and only return to us the credentials that we actually need.

Once this PR is merged, I will have a PR for Obot to bump the GPTScript dependency. We might have to temporarily (or permanently, as I don't think it will do any harm) enable schema migration for the credentials table, which is currently disabled with an environment variable.

Related PR to change the credential helpers: https://github.com/obot-platform/tools/pull/692