### PR TITLE
chore: stop using default mux in SDK server

### DIFF
--- a/pkg/sdkserver/server.go
+++ b/pkg/sdkserver/server.go
@@ -126,10 +126,11 @@ func run(ctx context.Context, listener net.Listener, opts Options) error {
 	}
 	defer s.close()
 
-	s.addRoutes(http.DefaultServeMux)
+	mux := http.NewServeMux()
+	s.addRoutes(mux)
 
 	httpServer := &http.Server{
-		Handler: apply(http.DefaultServeMux,
+		Handler: apply(mux,
 			contentType("application/json"),
 			addRequestID,
 			addLogger,


### PR DESCRIPTION
This is essentially a hack. We need to be able to run the SDK server twice in Obot to fix some short-term dependency cycles. We are unable to do this if both use the default server mux. This change will use a separate mux for each.